### PR TITLE
NDK support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,7 @@ hs_err_pid*
 /captures
 **/*.iml
 *.class
+
+#NDK
+obj/
+.externalNativeBuild

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backtrace-library/src/main/cpp/crashpad-builds"]
+	path = backtrace-library/src/main/cpp/crashpad-builds
+	url = https://github.com/backtrace-labs/crashpad-builds.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
   - echo y | sdkmanager 'ndk-bundle'
+  - echo y | sdkmanager "cmake;3.10.2.4988404"
 
 before_script:
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,6 @@ install:
   - echo y | sdkmanager "platforms;android-28"
   - echo y | sdkmanager 'ndk-bundle'
   - echo y | sdkmanager "cmake;3.6.4111459"
-  - echo y | sdkmanager "lldb;3.1"
 before_script:
   - chmod +x gradlew
   - pip install --user codecov #Install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,10 +38,13 @@ cache:
 install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
+  - echo y | sdkmanager 'ndk-bundle'
+  - echo y | sdkmanager 'cmake;3.6.4111459'
+  - echo y | sdkmanager 'lldb;3.0'
 
 before_script:
   - chmod +x gradlew
-  - pip install --user codecov    #Install codecov
+  - pip install --user codecov #Install codecov
   - android list targets
   - echo no | android create avd --force -n test -t android-23 --tag "google_apis"
   - emulator -avd test -no-window &
@@ -49,7 +52,7 @@ before_script:
   - adb shell input keyevent 82 &
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)                      #Run codecov
+  - bash <(curl -s https://codecov.io/bash) #Run codecov
 
 script:
   - ./gradlew assembleDebug

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
   - echo y | sdkmanager 'ndk-bundle'
-  - echo y | sdkmanager "cmake;3.6.4111459"
+  - echo y | sdkmanager "cmake;3.10.2.4988404"
 before_script:
   - chmod +x gradlew
   - pip install --user codecov #Install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_script:
   - emulator -avd test -no-window &
   - android-wait-for-emulator
   - adb shell input keyevent 82 &
+  - export PATH="$ANDROID_HOME/cmake/3.10.2.4988404/bin:$PATH"
 
 after_success:
   - bash <(curl -s https://codecov.io/bash) #Run codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ cache:
 install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
-  - echo y | sdkmanager --channel=3 --channel=1 "cmake;3.10.2.4988404"
-  - echo y | sdkmanager "lldb;3.1"
   - echo y | sdkmanager 'ndk-bundle'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,7 @@ install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
   - echo y | sdkmanager 'ndk-bundle'
-  - echo y | sdkmanager 'cmake;3.6.4111459'
-  - echo y | sdkmanager 'lldb;3.0'
+  - echo y | sdkmanager 'cmake;3.10.2.4988404'
 
 before_script:
   - chmod +x gradlew

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,8 +39,8 @@ install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
   - echo y | sdkmanager 'ndk-bundle'
-  - echo y | sdkmanager "cmake;3.10.2.4988404"
-
+  - echo y | sdkmanager "cmake;3.6.4111459"
+  - echo y | sdkmanager "lldb;3.1"
 before_script:
   - chmod +x gradlew
   - pip install --user codecov #Install codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,9 @@ cache:
 install:
   # - echo y | sdkmanager "platforms;android-23"
   - echo y | sdkmanager "platforms;android-28"
+  - echo y | sdkmanager --channel=3 --channel=1 "cmake;3.10.2.4988404"
+  - echo y | sdkmanager "lldb;3.1"
   - echo y | sdkmanager 'ndk-bundle'
-  - echo y | sdkmanager 'cmake;3.10.2.4988404'
 
 before_script:
   - chmod +x gradlew

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Backtrace Android Release Notes
+## Version 3.1.0 - 29.09.2020
+- Backtrace Android allows to capture native crashes from Android NDK code. To enable NDK crashes exception handler use `setupNativeIntegration` method and pass backtraceClient with credentials.
+
+```java
+        database.setupNativeIntegration(backtraceClient, credentials);
+```
 
 ## Version 3.0.2 - 23.01.2020
 - Fixed checking internal path during filtering attachments 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ catch (e: Exception) {
 * Supports monitoring the blocking of manually created threads by providing watchdog.
 
 # Supported SDKs <a name="supported-sdks"></a>
-* Minimal SDK version 19 (Android 4.4)
+* Minimal SDK version 21 (Android 5.0)
 * Target SDK version 28 (Android 9.0)
 
 # Differences and limitations of the SDKs version <a name="limitations"></a>

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ settings.setRetryOrder(RetryOrder.Queue);
 
 BacktraceDatabase database = new BacktraceDatabase(context, settings);
 BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database);
+// start capturing NDK crashes
+database.setupNativeIntegration(backtraceClient, credentials);
 ```
 
 ## Sending an error report <a name="using-backtrace-sending-report"></a>
@@ -347,6 +349,12 @@ You can add custom map of attributes to `BacktraceExceptionHandler` which will b
 
 ```java
 BacktraceExceptionHandler.setCustomAttributes(customAttributes);
+```
+
+If you would like to capture NDK Crashes you can use `BacktraceDatabase` `setupNativeIntegration` method.
+
+```java
+        database.setupNativeIntegration(backtraceClient, credentials);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -390,6 +390,9 @@ watchdog.checkIsAnyThreadIsBlocked(); // check if any thread has exceeded the ti
 watchdog.tick(this); // In your custom thread class make incrementation to inform that the thread is not blocked
 ```
 
+## Uploading symbols to Backtrace
+If you're developing a NDK application, to have better debugging experience in Backtrace, we recommend to upload application symbols to Backtrace. You can find application symbols in the "%application_dir%/build/intermediates/symbols/%release_type%/". To learn more about symbolification please check the article: https://help.backtrace.io/product-guide/symbolification
+
 # Documentation  <a name="documentation"></a>
 
 ## BacktraceReport  <a name="documentation-BacktraceReport"></a>

--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ catch (e: Exception) {
 * Gradle
 ```
 dependencies {
-    implementation 'com.github.backtrace-labs.backtrace-android:backtrace-library:3.0.2'
+    implementation 'com.github.backtrace-labs.backtrace-android:backtrace-library:3.1.0'
 }
 ```
 
@@ -84,13 +84,13 @@ dependencies {
 <dependency>
   <groupId>com.github.backtrace-labs.backtrace-android</groupId>
   <artifactId>backtrace-library</artifactId>
-  <version>3.0.2</version>
+  <version>3.1.0</version>
   <type>aar</type>
 </dependency>
 ```
 
 <!-- ## Installation pre-release version <a name="prerelease-version"></a>
-### Pre-release version of `v.3.0.2` is available in the following repository: https://oss.sonatype.org/content/repositories/comgithubbacktrace-labs-1018/
+### Pre-release version of `v.3.1.0` is available in the following repository: https://oss.sonatype.org/content/repositories/comgithubbacktrace-labs-1018/
 Add the above url in `build.gradle` file to `repositories` section as below to allow downloading the library from our staging repository:
 ```
 maven {
@@ -100,7 +100,7 @@ maven {
 Then you can download this library by adding to the dependencies in `build.gradle` file to `dependencies` section:
 
 ```
-implementation 'com.github.backtrace-labs.backtrace-android:backtrace-library:3.0.2'
+implementation 'com.github.backtrace-labs.backtrace-android:backtrace-library:3.1.0'
 ```-->
 
 ## Permissions

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -5,11 +5,18 @@ android {
     compileSdkVersion 28
 
     defaultConfig {
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 302
         versionName "3.0.2"
+
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+
+        externalNativeBuild {
+            cmake {
+                cppFlags ""
+            }
+        }
     }
 
     buildTypes {
@@ -24,6 +31,18 @@ android {
         }
     }
 
+    externalNativeBuild {
+    cmake {
+        path file('src/main/cpp/CMakeLists.txt')
+        version "3.10.2"
+    }
+    }
+    sourceSets {
+        main {
+            jniLibs.srcDirs = ['src/main/cpp/crashpad-builds']
+            jniLibs.includes = ['src/main/cpp/crashpad-builds/crashpad_handler']
+        }
+    }
 }
 
 dependencies {

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -7,7 +7,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 302
+        versionCode 310
         versionName "3.1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 21
         targetSdkVersion 28
         versionCode 302
-        versionName "3.0.2"
+        versionName "3.1.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -32,10 +32,10 @@ android {
     }
 
     externalNativeBuild {
-    cmake {
-        path file('src/main/cpp/CMakeLists.txt')
-        version "3.10.2"
-    }
+        cmake {
+            path file('src/main/cpp/CMakeLists.txt')
+            version "3.10.2"
+        }
     }
     sourceSets {
         main {

--- a/backtrace-library/publish.gradle
+++ b/backtrace-library/publish.gradle
@@ -83,6 +83,10 @@ afterEvaluate { project ->
                             id POM_DEVELOPER_ID
                             name POM_DEVELOPER_NAME
                         }
+                        developer {
+                            id POM_DEVELOPER_ID2
+                            name POM_DEVELOPER_NAME2
+                        }
                     }
                 }
             }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceUrlTests.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceUrlTests.java
@@ -1,34 +1,11 @@
 package backtraceio.library;
 
-import android.content.Context;
 import android.net.Uri;
-import android.support.test.InstrumentationRegistry;
 import android.support.test.runner.AndroidJUnit4;
 
-import net.jodah.concurrentunit.Waiter;
-
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeUnit;
-
-import backtraceio.library.events.OnServerResponseEventListener;
-import backtraceio.library.events.RequestHandler;
-import backtraceio.library.models.BacktraceData;
-import backtraceio.library.models.BacktraceExceptionHandler;
-import backtraceio.library.models.BacktraceResult;
-import backtraceio.library.models.database.BacktraceDatabaseSettings;
-import backtraceio.library.models.types.BacktraceResultStatus;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
 
 @RunWith(AndroidJUnit4.class)
 public class BacktraceUrlTests {
@@ -46,10 +23,10 @@ public class BacktraceUrlTests {
 
     @Test
     public void createMinidumpSubmissionUrlWithSubmitBacktraceUrl() {
-        String backtraceLegacyUrl = "https://submit.backtrace.io/universe/1234token/json";
+        String backtraceUrl = "https://submit.backtrace.io/universe/1234token/json";
         String expectedMinidumpUrl = "https://submit.backtrace.io/universe/1234token/minidump";
 
-        BacktraceCredentials credentials = new BacktraceCredentials(backtraceLegacyUrl);
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceUrl);
         Uri actualSubmissionUrl = credentials.getMinidumpSubmissionUrl();
 
         Assert.assertNotNull(actualSubmissionUrl);
@@ -58,11 +35,48 @@ public class BacktraceUrlTests {
 
     @Test
     public void createMinidumpSubmissionUrlForInvalidBacktraceUrl() {
-        String backtraceLegacyUrl = "https://submit.backtrace.io/definetly/invalid/url";
+        String backtraceUrl = "https://submit.backtrace.io/definetly/invalid/url";
 
-        BacktraceCredentials credentials = new BacktraceCredentials(backtraceLegacyUrl);
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceUrl);
         Uri actualSubmissionUrl = credentials.getMinidumpSubmissionUrl();
 
         Assert.assertNull(actualSubmissionUrl);
+    }
+
+    @Test
+    public void createCorrectSubmissionUrl() {
+        String backtraceUrl = "https://submit.backtrace.io/universe/1234token/json";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceUrl);
+        Uri actualSubmissionUrl = credentials.getSubmissionUrl();
+
+        Assert.assertNotNull(actualSubmissionUrl);
+        Assert.assertEquals(backtraceUrl, actualSubmissionUrl.toString());
+    }
+
+    @Test
+    public void createCorrectSubmissionUrlForLegacyUrlWithMissingServerSlash() {
+        String backtraceServerUrl = "https://universe.sp.backtrace.io:6098";
+        String token = "1234token";
+        String expectedBacktraceUrl = "https://universe.sp.backtrace.io:6098/post?format=json&token=1234token";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceServerUrl, token);
+        Uri actualSubmissionUrl = credentials.getSubmissionUrl();
+
+        Assert.assertNotNull(actualSubmissionUrl);
+        Assert.assertEquals(expectedBacktraceUrl, actualSubmissionUrl.toString());
+    }
+
+    @Test
+    public void createCorrectSubmissionUrlForLegacyUrl() {
+        String backtraceServerUrl = "https://universe.sp.backtrace.io:6098/";
+        String token = "1234token";
+        String expectedBacktraceUrl = "https://universe.sp.backtrace.io:6098/post?format=json&token=1234token";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceServerUrl, token);
+        Uri actualSubmissionUrl = credentials.getSubmissionUrl();
+
+        Assert.assertNotNull(actualSubmissionUrl);
+        Assert.assertEquals(expectedBacktraceUrl, actualSubmissionUrl.toString());
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceUrlTests.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceUrlTests.java
@@ -1,0 +1,68 @@
+package backtraceio.library;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.test.InstrumentationRegistry;
+import android.support.test.runner.AndroidJUnit4;
+
+import net.jodah.concurrentunit.Waiter;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import backtraceio.library.events.OnServerResponseEventListener;
+import backtraceio.library.events.RequestHandler;
+import backtraceio.library.models.BacktraceData;
+import backtraceio.library.models.BacktraceExceptionHandler;
+import backtraceio.library.models.BacktraceResult;
+import backtraceio.library.models.database.BacktraceDatabaseSettings;
+import backtraceio.library.models.types.BacktraceResultStatus;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+
+@RunWith(AndroidJUnit4.class)
+public class BacktraceUrlTests {
+    @Test
+    public void createMinidumpSubmissionUrlWithLegacyBacktraceUrl() {
+        String backtraceLegacyUrl = "https://universe.sp.backtrace.io:6098/post?format=json&token=1234token";
+        String expectedMinidumpUrl = "https://universe.sp.backtrace.io:6098/post?format=minidump&token=1234token";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceLegacyUrl);
+        Uri actualSubmissionUrl = credentials.getMinidumpSubmissionUrl();
+
+        Assert.assertNotNull(actualSubmissionUrl);
+        Assert.assertEquals(actualSubmissionUrl.toString(), expectedMinidumpUrl);
+    }
+
+    @Test
+    public void createMinidumpSubmissionUrlWithSubmitBacktraceUrl() {
+        String backtraceLegacyUrl = "https://submit.backtrace.io/universe/1234token/json";
+        String expectedMinidumpUrl = "https://submit.backtrace.io/universe/1234token/minidump";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceLegacyUrl);
+        Uri actualSubmissionUrl = credentials.getMinidumpSubmissionUrl();
+
+        Assert.assertNotNull(actualSubmissionUrl);
+        Assert.assertEquals(actualSubmissionUrl.toString(), expectedMinidumpUrl);
+    }
+
+    @Test
+    public void createMinidumpSubmissionUrlForInvalidBacktraceUrl() {
+        String backtraceLegacyUrl = "https://submit.backtrace.io/definetly/invalid/url";
+
+        BacktraceCredentials credentials = new BacktraceCredentials(backtraceLegacyUrl);
+        Uri actualSubmissionUrl = credentials.getMinidumpSubmissionUrl();
+
+        Assert.assertNull(actualSubmissionUrl);
+    }
+}

--- a/backtrace-library/src/main/cpp/CMakeLists.txt
+++ b/backtrace-library/src/main/cpp/CMakeLists.txt
@@ -11,13 +11,13 @@ cmake_minimum_required(VERSION 3.4.1)
 # Gradle automatically packages shared libraries with your APK.
 
 add_library( # Sets the name of the library.
-             backtrace-crashpad
+             backtrace-native
 
              # Sets the library as a shared library.
              SHARED
 
              # Provides a relative path to your source file(s).
-            backtrace-crashpad.cpp )
+        backtrace-native.cpp)
 
 # Crashpad Libraries
 add_library(crashpad_client STATIC IMPORTED)
@@ -53,7 +53,7 @@ find_library( # Sets the name of the path variable.
 # build script, prebuilt third-party libraries, or system libraries.
 
 target_link_libraries( # Specifies the target library.
-                        backtrace-crashpad
+                        backtrace-native
                        # Links the target library to the log library
                        # included in the NDK.
                        ${log-lib}

--- a/backtrace-library/src/main/cpp/CMakeLists.txt
+++ b/backtrace-library/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,63 @@
+# For more information about using CMake with Android Studio, read the
+# documentation: https://d.android.com/studio/projects/add-native-code.html
+
+# Sets the minimum version of CMake required to build the native library.
+
+cmake_minimum_required(VERSION 3.4.1)
+
+# Creates and names a library, sets it as either STATIC
+# or SHARED, and provides the relative paths to its source code.
+# You can define multiple libraries, and CMake builds them for you.
+# Gradle automatically packages shared libraries with your APK.
+
+add_library( # Sets the name of the library.
+             backtrace-crashpad
+
+             # Sets the library as a shared library.
+             SHARED
+
+             # Provides a relative path to your source file(s).
+            backtrace-crashpad.cpp )
+
+# Crashpad Libraries
+add_library(crashpad_client STATIC IMPORTED)
+set_property(TARGET crashpad_client PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/crashpad-builds/${ANDROID_ABI}/client/libcrashpad_client.a)
+
+add_library(crashpad_util STATIC IMPORTED)
+set_property(TARGET crashpad_util PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/crashpad-builds/${ANDROID_ABI}/util/libcrashpad_util.a)
+
+add_library(base STATIC IMPORTED)
+set_property(TARGET base PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/crashpad-builds/${ANDROID_ABI}/third_party/mini_chromium/mini_chromium/base/libbase.a)
+
+# Crashpad Headers
+include_directories(${PROJECT_SOURCE_DIR}/crashpad-builds/headers/ ${PROJECT_SOURCE_DIR}/crashpad-builds/headers/third_party/mini_chromium/mini_chromium/)
+
+# Searches for a specified prebuilt library and stores the path as a
+# variable. Because CMake includes system libraries in the search path by
+# default, you only need to specify the name of the public NDK library
+# you want to add. CMake verifies that the library exists before
+# completing its build.
+
+find_library( # Sets the name of the path variable.
+              log-lib
+
+              # Specifies the name of the NDK library that
+              # you want CMake to locate.
+              log
+            )
+
+
+
+# Specifies libraries CMake should link to your target library. You
+# can link multiple libraries, such as libraries you define in this
+# build script, prebuilt third-party libraries, or system libraries.
+
+target_link_libraries( # Specifies the target library.
+                        backtrace-crashpad
+                       # Links the target library to the log library
+                       # included in the NDK.
+                       ${log-lib}
+                        crashpad_client
+                        crashpad_util
+                        base
+        )

--- a/backtrace-library/src/main/cpp/backtrace-crashpad.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-crashpad.cpp
@@ -1,0 +1,154 @@
+#include <jni.h>
+#include <string>
+#include <android/log.h>
+
+#include "client/crashpad_client.h"
+#include "client/crash_report_database.h"
+#include "client/settings.h"
+#include "client/crashpad_info.h"
+#include "base/logging.h"
+#include <android/log.h>
+#include <unistd.h>
+#include <vector>
+#include <map>
+
+using namespace base;
+
+static jint JNI_VERSION = JNI_VERSION_1_6;
+
+JNIEnv *env;
+
+crashpad::CrashpadClient *client;
+
+bool initialized = false;
+JNIEXPORT jint JNI_OnLoad(JavaVM* jvm, void* reserved)
+{
+    if (jvm->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION) != JNI_OK) {
+
+        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "%s",
+                            "Cannot load JNI env");
+        return JNI_ERR;
+    }
+    return JNI_VERSION_1_4;
+}
+
+
+extern "C" {
+    void Crash() {
+        *(volatile int *) 0 = 0;
+    }
+
+    JNIEXPORT void JNICALL Java_backtraceio_library_base_BacktraceBase_Crash(
+            JNIEnv *env,
+            jobject /* this */) {
+        Crash();
+    }
+
+    bool InitializeCrashpad(jstring url,
+                            jstring crashpad_database_path,
+                            jstring crashpad_handler_path,
+                            jobjectArray attributeKeys,
+                            jobjectArray attributeValues) {
+        using namespace crashpad;
+        // avoid multi initialization
+        if(initialized) {
+            return true;
+        }
+        std::map<std::string, std::string> attributes;
+        attributes["format"] = "minidump";
+
+        jint keyLength = env->GetArrayLength(attributeKeys);
+        jint valueLength = env->GetArrayLength(attributeValues);
+        if(keyLength == valueLength) {
+            for (int attributeIndex = 0; attributeIndex < keyLength; ++attributeIndex) {
+                jstring jstringKey = (jstring) env->GetObjectArrayElement(attributeKeys,
+                                                                          attributeIndex);
+                jboolean isCopy;
+                const char *convertedKey = (env)->GetStringUTFChars(jstringKey, &isCopy);
+
+                jstring stringValue = (jstring) env->GetObjectArrayElement(attributeValues,
+                                                                           attributeIndex);
+                const char *convertedValue = (env)->GetStringUTFChars(stringValue, &isCopy);
+                attributes[convertedKey] = convertedValue;
+
+                env->ReleaseStringUTFChars(jstringKey, convertedKey);
+                env->ReleaseStringUTFChars(stringValue, convertedValue);
+            }
+        } else {
+            __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Attribute array length doesn't match. Attributes won't be available in the Crashpad integration");
+        }
+
+        std::vector<std::string> arguments;
+        arguments.push_back("--no-rate-limit");
+
+        // Backtrace url
+        const char *backtraceUrl = env->GetStringUTFChars(url, 0);
+
+        // path to crash handler executable
+        const char *handlerPath  = env->GetStringUTFChars(crashpad_handler_path, 0);
+        FilePath handler(handlerPath);
+
+        // path to crashpad database
+        const char *filePath = env->GetStringUTFChars(crashpad_database_path, 0);
+        FilePath db(filePath);
+
+        std::unique_ptr<CrashReportDatabase> database = CrashReportDatabase::Initialize(db);
+        if (database == nullptr || database->GetSettings() == NULL) {
+            return false;
+        }
+
+        /* Enable automated uploads. */
+        database->GetSettings()->SetUploadsEnabled(true);
+
+        // Start crash handler
+        client = new CrashpadClient();
+
+        initialized = client->StartHandlerAtCrash(handler, db, db, backtraceUrl, attributes, arguments);
+
+        env->ReleaseStringUTFChars(url, backtraceUrl);
+        env->ReleaseStringUTFChars(crashpad_handler_path, handlerPath);
+        env->ReleaseStringUTFChars(crashpad_database_path, filePath);
+        return initialized;
+    }
+
+
+    JNIEXPORT jboolean JNICALL
+    Java_backtraceio_library_BacktraceDatabase_InitializeCrashpad(JNIEnv *env,
+            jobject thiz,
+            jstring url,
+            jstring crashpad_database_path,
+            jstring crashpad_handler_path,
+            jobjectArray attributeKeys,
+            jobjectArray attributeValues) {
+        return InitializeCrashpad(url, crashpad_database_path, crashpad_handler_path, attributeKeys, attributeValues);
+    }
+
+
+    void AddCrashpadAttribute(jstring key, jstring value) {
+        if(initialized == false) {
+            __android_log_print(ANDROID_LOG_WARN, "Backtrace-Android", "Crashpad integration isn't available. Please initialize Crashpad integration first.");
+            return;
+        }
+        crashpad::CrashpadInfo* info = crashpad::CrashpadInfo::GetCrashpadInfo();
+        crashpad::SimpleStringDictionary* annotations = info->simple_annotations();
+        if (!annotations)
+        {
+            annotations = new crashpad::SimpleStringDictionary();
+            info->set_simple_annotations(annotations);
+        }
+        jboolean isCopy;
+        const char* crashpadKey = env->GetStringUTFChars(key, &isCopy);
+        const char* crashpadValue = env->GetStringUTFChars(value, &isCopy);
+        annotations->SetKeyValue(crashpadKey, crashpadValue);
+
+        env->ReleaseStringUTFChars(key, crashpadKey);
+        env->ReleaseStringUTFChars(value, crashpadValue);
+    }
+
+    JNIEXPORT void JNICALL
+    Java_backtraceio_library_BacktraceDatabase_AddCrashpadAttribute(JNIEnv *env, jobject thiz,
+                                                                     jstring name, jstring value) {
+        AddCrashpadAttribute(name, value);
+    }
+
+}

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -120,7 +120,7 @@ extern "C" {
         *(volatile int *) 0 = 0;
     }
 
-    JNIEXPORT void JNICALL Java_backtraceio_library_base_BacktraceBase_Crash(
+    JNIEXPORT void JNICALL Java_backtraceio_library_base_BacktraceBase_crash(
             JNIEnv *env,
             jobject /* this */) {
         Crash();
@@ -142,7 +142,7 @@ extern "C" {
     }
 
     JNIEXPORT jboolean JNICALL
-    Java_backtraceio_library_BacktraceDatabase_Initialize(JNIEnv *env,
+    Java_backtraceio_library_BacktraceDatabase_initialize(JNIEnv *env,
                                                           jobject thiz,
                                                           jstring url,
                                                           jstring database_path,
@@ -177,8 +177,8 @@ extern "C" {
     }
 
     JNIEXPORT void JNICALL
-    Java_backtraceio_library_BacktraceDatabase_AddAttribute(JNIEnv *env, jobject thiz,
-                                                                     jstring name, jstring value) {
+    Java_backtraceio_library_BacktraceDatabase_addAttribute(JNIEnv *env, jobject thiz,
+                                                            jstring name, jstring value) {
         AddAttribute(name, value);
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceClient.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceClient.java
@@ -32,7 +32,7 @@ public class BacktraceClient extends BacktraceBase {
      * @param credentials credentials to Backtrace API server
      */
     public BacktraceClient(Context context, BacktraceCredentials credentials) {
-        this(context, credentials, (BacktraceDatabase)null, null);
+        this(context, credentials, (BacktraceDatabase) null, null);
     }
 
     /**
@@ -42,7 +42,7 @@ public class BacktraceClient extends BacktraceBase {
      * @param credentials credentials to Backtrace API server
      */
     public BacktraceClient(Context context, BacktraceCredentials credentials, Map<String, Object> attributes) {
-        this(context, credentials, (BacktraceDatabase)null, attributes);
+        this(context, credentials, (BacktraceDatabase) null, attributes);
     }
 
     /**
@@ -54,7 +54,7 @@ public class BacktraceClient extends BacktraceBase {
      */
     public BacktraceClient(Context context, BacktraceCredentials credentials,
                            BacktraceDatabaseSettings databaseSettings) {
-        this(context, credentials,  new BacktraceDatabase(context, databaseSettings));
+        this(context, credentials, new BacktraceDatabase(context, databaseSettings));
     }
 
     /**
@@ -66,7 +66,7 @@ public class BacktraceClient extends BacktraceBase {
      */
     public BacktraceClient(Context context, BacktraceCredentials credentials,
                            BacktraceDatabaseSettings databaseSettings, Map<String, Object> attributes) {
-        this(context, credentials,  new BacktraceDatabase(context, databaseSettings), attributes);
+        this(context, credentials, new BacktraceDatabase(context, databaseSettings), attributes);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceClient.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceClient.java
@@ -20,7 +20,7 @@ import backtraceio.library.models.json.BacktraceReport;
 public class BacktraceClient extends BacktraceBase {
 
     /**
-     *
+     * Backtrace ANR watchdog instance
      */
     private BacktraceANRWatchdog anrWatchdog;
 

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -76,4 +76,15 @@ public class BacktraceCredentials {
         }
         return getServerUrl();
     }
+
+    public Uri getMinidumpSubmissionUrl() {
+        Uri backtraceJsonUri = getSubmissionUrl();
+        String jsonUrl = backtraceJsonUri.toString();
+        if(jsonUrl.contains("format=json")) {
+            jsonUrl = jsonUrl.replace("format=json", "format=minidump");
+        } else if (jsonUrl.contains(("/json"))) {
+            jsonUrl = jsonUrl.replace("/json", "/minidump");
+        }
+        return Uri.parse(jsonUrl);
+    }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -85,6 +85,8 @@ public class BacktraceCredentials {
             jsonUrl = jsonUrl.replace("format=json", "format=minidump");
         } else if (jsonUrl.contains(("/json"))) {
             jsonUrl = jsonUrl.replace("/json", "/minidump");
+        } else {
+            return null;
         }
         return Uri.parse(jsonUrl);
     }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -21,7 +21,7 @@ public class BacktraceCredentials {
     /**
      * Initialize Backtrace credentials
      *
-     * @param endpointUrl endpoint url address
+     * @param endpointUrl     endpoint url address
      * @param submissionToken server access token
      */
     public BacktraceCredentials(String endpointUrl, String submissionToken) {
@@ -29,11 +29,11 @@ public class BacktraceCredentials {
         this.submissionToken = submissionToken;
     }
 
-    public BacktraceCredentials(String backtraceHostUri){
+    public BacktraceCredentials(String backtraceHostUri) {
         this(Uri.parse(backtraceHostUri));
     }
 
-    public BacktraceCredentials(Uri backtraceHostUri){
+    public BacktraceCredentials(Uri backtraceHostUri) {
         this.backtraceHostUri = backtraceHostUri;
     }
 
@@ -59,7 +59,7 @@ public class BacktraceCredentials {
         return backtraceHostUri;
     }
 
-    private Uri getServerUrl(){
+    private Uri getServerUrl() {
         String url = String.format("%spost?format=%s&token=%s", this.getEndpointUrl(),
                 this.format, this.getSubmissionToken());
         return Uri.parse(url);
@@ -67,11 +67,12 @@ public class BacktraceCredentials {
 
     /**
      * Get submission URL to Backtrace API
+     *
      * @return URL to Backtrace API
      */
-    public Uri getSubmissionUrl(){
+    public Uri getSubmissionUrl() {
         Uri backtraceUri = getBacktraceHostUri();
-        if (backtraceUri != null){
+        if (backtraceUri != null) {
             return backtraceUri;
         }
         return getServerUrl();
@@ -80,7 +81,7 @@ public class BacktraceCredentials {
     public Uri getMinidumpSubmissionUrl() {
         Uri backtraceJsonUri = getSubmissionUrl();
         String jsonUrl = backtraceJsonUri.toString();
-        if(jsonUrl.contains("format=json")) {
+        if (jsonUrl.contains("format=json")) {
             jsonUrl = jsonUrl.replace("format=json", "format=minidump");
         } else if (jsonUrl.contains(("/json"))) {
             jsonUrl = jsonUrl.replace("/json", "/minidump");

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -60,7 +60,9 @@ public class BacktraceCredentials {
     }
 
     private Uri getServerUrl() {
-        String url = String.format("%spost?format=%s&token=%s", this.getEndpointUrl(),
+        String serverUrl = this.getEndpointUrl();
+        String prefix = serverUrl.endsWith("/") ? "" : "/";
+        String url = String.format("%s%spost?format=%s&token=%s", serverUrl, prefix,
                 this.format, this.getSubmissionToken());
         return Uri.parse(url);
     }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -126,27 +126,30 @@ public class BacktraceDatabase implements Database {
      * @param client      Backtrace client
      * @param credentials Backtrace credentials
      */
-    public void setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials) {
+    public Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials) {
         // avoid initialization when database doesn't exist
         if (getSettings() == null) {
-            return;
+            return false;
         }
         String minidumpSubmissionUrl = credentials.getMinidumpSubmissionUrl().toString();
         if (minidumpSubmissionUrl == null) {
-            return;
+            return false;
         }
         // path to crashpad native handler
         String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + _crashpadHandlerName;
 
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, null, client.attributes);
-        List<String> result = new ArrayList(crashpadAttributes.attributes.keySet());
-        List<String> values = new ArrayList(crashpadAttributes.attributes.values());
-        initialize(
+        String[] keys = crashpadAttributes.attributes.keySet().toArray(new String[0]);
+        String[] values = crashpadAttributes.attributes.values().toArray(new String[0]);
+        String databasePath = getSettings().getDatabasePath() + _crashpadDatabasePathPrefix;
+        Boolean initialized = initialize(
                 minidumpSubmissionUrl,
-                getSettings().getDatabasePath() + _crashpadDatabasePathPrefix,
+                databasePath,
                 handlerPath,
-                result.toArray(new String[0]),
-                values.toArray(new String[0]));
+                keys,
+                values
+        );
+        return initialized;
     }
 
     public void start() {

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -1,7 +1,6 @@
 package backtraceio.library;
 
 import android.content.Context;
-import android.util.Log;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -17,7 +16,6 @@ import backtraceio.library.common.FileHelper;
 import backtraceio.library.enums.database.RetryBehavior;
 import backtraceio.library.events.OnServerResponseEventListener;
 import backtraceio.library.interfaces.Api;
-import backtraceio.library.interfaces.Client;
 import backtraceio.library.interfaces.Database;
 import backtraceio.library.interfaces.DatabaseContext;
 import backtraceio.library.interfaces.DatabaseFileContext;
@@ -49,21 +47,23 @@ public class BacktraceDatabase implements Database {
 
     /**
      * Add attributes to native reports
-     * @param name attribute name
+     *
+     * @param name  attribute name
      * @param value attribute value
      */
-    public native void AddAttribute(String name, String value);
+    public native void addAttribute(String name, String value);
 
     /**
      * Initialize Backtrace-native integration
-     * @param url url to Backtrace
-     * @param databasePath path to Backtrace-native database
-     * @param handlerPath path to error handler
-     * @param attributeKeys array of attribute keys
+     *
+     * @param url             url to Backtrace
+     * @param databasePath    path to Backtrace-native database
+     * @param handlerPath     path to error handler
+     * @param attributeKeys   array of attribute keys
      * @param attributeValues array of attribute values
      * @return true - if backtrace-native was able to initialize correctly, otherwise false.
      */
-    private native boolean Initialize(String url,  String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues);
+    private native boolean initialize(String url, String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues);
 
 
     /**
@@ -119,12 +119,13 @@ public class BacktraceDatabase implements Database {
 
     /**
      * Setup native crash handler
-     * @param client  Backtrace client
+     *
+     * @param client      Backtrace client
      * @param credentials Backtrace credentials
      */
     public void setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials) {
         // avoid initialization when database doesn't exist
-        if(getSettings() == null) {
+        if (getSettings() == null) {
             return;
         }
         // path to crashpad native handler
@@ -133,7 +134,7 @@ public class BacktraceDatabase implements Database {
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, null, client.attributes);
         List<String> result = new ArrayList(crashpadAttributes.attributes.keySet());
         List<String> values = new ArrayList(crashpadAttributes.attributes.values());
-        Initialize(
+        initialize(
                 credentials.getMinidumpSubmissionUrl().toString(),
                 getSettings().getDatabasePath() + "/crashpad",
                 handlerPath,

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -48,20 +48,20 @@ public class BacktraceDatabase implements Database {
     private boolean _enable = false;
 
     /**
-     * Add Crashpad attribute to Crashpad native reports
+     * Add attributes to native reports
      * @param name attribute name
      * @param value attribute value
      */
     public native void AddAttribute(String name, String value);
 
     /**
-     * Initialize Backtrace Crashpad integration
+     * Initialize Backtrace-native integration
      * @param url url to Backtrace
-     * @param databasePath path to Crashpad database
-     * @param handlerPath path to crashpad error handler
+     * @param databasePath path to Backtrace-native database
+     * @param handlerPath path to error handler
      * @param attributeKeys array of attribute keys
      * @param attributeValues array of attribute values
-     * @return true - if Crashpad was able to initialize correctly, otherwise false.
+     * @return true - if backtrace-native was able to initialize correctly, otherwise false.
      */
     private native boolean Initialize(String url,  String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues);
 

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -35,6 +35,9 @@ import backtraceio.library.services.BacktraceDatabaseFileContext;
  */
 public class BacktraceDatabase implements Database {
 
+    private final String _crashpadHandlerName = "/libcrashpad_handler.so";
+    private final String _crashpadDatabasePathPrefix = "/crashpad";
+
     private static boolean _timerBackgroundWork = false;
     private static Timer _timer;
     private transient final String LOG_TAG = BacktraceDatabase.class.getSimpleName();
@@ -128,15 +131,19 @@ public class BacktraceDatabase implements Database {
         if (getSettings() == null) {
             return;
         }
+        String minidumpSubmissionUrl = credentials.getMinidumpSubmissionUrl().toString();
+        if (minidumpSubmissionUrl == null) {
+            return;
+        }
         // path to crashpad native handler
-        String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + "/libcrashpad_handler.so";
+        String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + _crashpadHandlerName;
 
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, null, client.attributes);
         List<String> result = new ArrayList(crashpadAttributes.attributes.keySet());
         List<String> values = new ArrayList(crashpadAttributes.attributes.values());
         initialize(
-                credentials.getMinidumpSubmissionUrl().toString(),
-                getSettings().getDatabasePath() + "/crashpad",
+                minidumpSubmissionUrl,
+                getSettings().getDatabasePath() + _crashpadDatabasePathPrefix,
                 handlerPath,
                 result.toArray(new String[0]),
                 values.toArray(new String[0]));

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -52,7 +52,7 @@ public class BacktraceDatabase implements Database {
      * @param name attribute name
      * @param value attribute value
      */
-    public native void AddCrashpadAttribute(String name, String value);
+    public native void AddAttribute(String name, String value);
 
     /**
      * Initialize Backtrace Crashpad integration
@@ -63,7 +63,7 @@ public class BacktraceDatabase implements Database {
      * @param attributeValues array of attribute values
      * @return true - if Crashpad was able to initialize correctly, otherwise false.
      */
-    private native boolean InitializeCrashpad(String url,  String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues);
+    private native boolean Initialize(String url,  String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues);
 
 
     /**
@@ -133,8 +133,8 @@ public class BacktraceDatabase implements Database {
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, null, client.attributes);
         List<String> result = new ArrayList(crashpadAttributes.attributes.keySet());
         List<String> values = new ArrayList(crashpadAttributes.attributes.values());
-        InitializeCrashpad(
-                credentials.getSubmissionUrl().toString(),
+        Initialize(
+                credentials.getMinidumpSubmissionUrl().toString(),
                 getSettings().getDatabasePath() + "/crashpad",
                 handlerPath,
                 result.toArray(new String[0]),

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -38,7 +38,7 @@ import backtraceio.library.services.BacktraceApi;
 public class BacktraceBase implements Client {
 
     static {
-        System.loadLibrary("backtrace-crashpad");
+        System.loadLibrary("backtrace-native");
     }
 
     private static transient String LOG_TAG = BacktraceBase.class.getSimpleName();

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -1,16 +1,8 @@
 package backtraceio.library.base;
 
 import android.content.Context;
-import android.provider.ContactsContract;
-import android.system.Os;
-import android.util.Log;
 
-import java.io.File;
-import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import backtraceio.library.BacktraceCredentials;
@@ -27,7 +19,6 @@ import backtraceio.library.models.BacktraceData;
 import backtraceio.library.models.BacktraceResult;
 import backtraceio.library.models.database.BacktraceDatabaseRecord;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
-import backtraceio.library.models.json.BacktraceAttributes;
 import backtraceio.library.models.json.BacktraceReport;
 import backtraceio.library.models.types.BacktraceResultStatus;
 import backtraceio.library.services.BacktraceApi;
@@ -44,7 +35,8 @@ public class BacktraceBase implements Client {
     private static transient String LOG_TAG = BacktraceBase.class.getSimpleName();
 
 
-    public native void Crash();
+    public native void crash();
+
     /**
      * Instance of BacktraceApi that allows to send data to Backtrace API
      */
@@ -159,6 +151,7 @@ public class BacktraceBase implements Client {
 
     /**
      * Get custom attributes
+     *
      * @return map with custom attributes
      */
     public Map<String, Object> getAttributes() {
@@ -193,8 +186,8 @@ public class BacktraceBase implements Client {
         this.backtraceApi.setRequestHandler(requestHandler);
     }
 
-    public void nativeCrash(){
-        Crash();
+    public void nativeCrash() {
+        crash();
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -44,7 +44,7 @@ public class BacktraceBase implements Client {
     private static transient String LOG_TAG = BacktraceBase.class.getSimpleName();
 
 
-    private native void Crash();
+    public native void Crash();
     /**
      * Instance of BacktraceApi that allows to send data to Backtrace API
      */
@@ -57,6 +57,7 @@ public class BacktraceBase implements Client {
         }
     }
 
+    private final BacktraceCredentials credentials;
     /**
      * Application context
      */
@@ -142,11 +143,18 @@ public class BacktraceBase implements Client {
      */
     public BacktraceBase(Context context, BacktraceCredentials credentials, Database database, Map<String, Object> attributes) {
         this.context = context;
+        this.credentials = credentials;
         this.attributes = attributes != null ? attributes : new HashMap<String, Object>();
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
-        this.database.setupNativeIntegration(this, credentials);
+    }
+
+    /**
+     * Capture unhandled native exceptions (Backtrace database integration is required to enable this feature).
+     */
+    public void enableNativeIntegration() {
+        this.database.setupNativeIntegration(this, this.credentials);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -1,8 +1,16 @@
 package backtraceio.library.base;
 
 import android.content.Context;
+import android.provider.ContactsContract;
+import android.system.Os;
+import android.util.Log;
 
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import backtraceio.library.BacktraceCredentials;
@@ -14,10 +22,12 @@ import backtraceio.library.events.RequestHandler;
 import backtraceio.library.interfaces.Api;
 import backtraceio.library.interfaces.Client;
 import backtraceio.library.interfaces.Database;
+import backtraceio.library.logger.BacktraceLogger;
 import backtraceio.library.models.BacktraceData;
 import backtraceio.library.models.BacktraceResult;
 import backtraceio.library.models.database.BacktraceDatabaseRecord;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
+import backtraceio.library.models.json.BacktraceAttributes;
 import backtraceio.library.models.json.BacktraceReport;
 import backtraceio.library.models.types.BacktraceResultStatus;
 import backtraceio.library.services.BacktraceApi;
@@ -27,8 +37,14 @@ import backtraceio.library.services.BacktraceApi;
  */
 public class BacktraceBase implements Client {
 
+    static {
+        System.loadLibrary("backtrace-crashpad");
+    }
+
     private static transient String LOG_TAG = BacktraceBase.class.getSimpleName();
 
+
+    private native void Crash();
     /**
      * Instance of BacktraceApi that allows to send data to Backtrace API
      */
@@ -130,6 +146,7 @@ public class BacktraceBase implements Client {
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
+        this.database.setupNativeIntegration(this, credentials);
     }
 
     /**
@@ -166,6 +183,10 @@ public class BacktraceBase implements Client {
      */
     public void setOnRequestHandler(RequestHandler requestHandler) {
         this.backtraceApi.setRequestHandler(requestHandler);
+    }
+
+    public void nativeCrash(){
+        Crash();
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
@@ -44,26 +44,26 @@ public class DeviceAttributesHelper {
      *
      * @return device attributes
      */
-    public HashMap<String, Object> getDeviceAttributes() {
-        HashMap<String, Object> result = new HashMap<>();
+    public HashMap<String, String> getDeviceAttributes() {
+        HashMap<String, String> result = new HashMap<>();
         result.put("guid", this.generateDeviceId());
         result.put("uname.sysname", "Android");
         result.put("uname.machine", System.getProperty("os.arch"));
-        result.put("cpu.boottime", java.lang.System.currentTimeMillis() - android.os.SystemClock
-                .elapsedRealtime());
-        result.put("device.airplane_mode", isAirplaneModeOn());
+        result.put("cpu.boottime", String.valueOf(java.lang.System.currentTimeMillis() - android.os.SystemClock
+                .elapsedRealtime()));
+        result.put("device.airplane_mode", String.valueOf(isAirplaneModeOn()));
         result.put("device.location", getLocationServiceStatus().toString());
         result.put("device.nfc.status", getNfcStatus().toString());
         result.put("device.gps.enabled", getGpsStatus().toString());
         result.put("device.bluetooth_status", isBluetoothEnabled().toString());
-        result.put("device.cpu.temperature", getCpuTemperature());
-        result.put("device.is_power_saving_mode", isPowerSavingMode());
+        result.put("device.cpu.temperature", String.valueOf(getCpuTemperature()));
+        result.put("device.is_power_saving_mode", String.valueOf(isPowerSavingMode()));
         result.put("device.wifi.status", getWifiStatus().toString());
         result.put("system.memory.total", getMaxRamSize());
         result.put("system.memory.free", getDeviceFreeRam());
         result.put("system.memory.active", getDeviceActiveRam());
         result.put("app.storage_used", getAppUsedStorageSize());
-        result.put("battery.level", getBatteryLevel());
+        result.put("battery.level", String.valueOf(getBatteryLevel()));
         result.put("battery.state", getBatteryState().toString());
         return result;
     }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Client.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Client.java
@@ -12,4 +12,9 @@ public interface Client {
      * @param report data which should be send to Backtrace API
      */
     void send(BacktraceReport report);
+
+    /**
+     * Capture unhandled native exceptions (Backtrace database integration is required to enable this feature).
+     */
+    void enableNativeIntegration();
 }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -76,5 +76,5 @@ public interface Database {
      * @param client      Backtrace client
      * @param credentials Backtrace credentials
      */
-    void setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials);
+    Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -72,7 +72,8 @@ public interface Database {
 
     /**
      * Setup database NDK integration
-     * @param client Backtrace client
+     *
+     * @param client      Backtrace client
      * @param credentials Backtrace credentials
      */
     void setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials);

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -2,6 +2,9 @@ package backtraceio.library.interfaces;
 
 import java.util.Map;
 
+import backtraceio.library.BacktraceClient;
+import backtraceio.library.BacktraceCredentials;
+import backtraceio.library.base.BacktraceBase;
 import backtraceio.library.models.database.BacktraceDatabaseRecord;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
 import backtraceio.library.models.json.BacktraceReport;
@@ -66,4 +69,11 @@ public interface Database {
      * @return
      */
     long getDatabaseSize();
+
+    /**
+     * Setup database NDK integration
+     * @param client Backtrace client
+     * @param credentials Backtrace credentials
+     */
+    void setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -67,7 +67,7 @@ public class BacktraceData {
      * Get built-in attributes
      */
     @SerializedName("attributes")
-    public Map<String, Object> attributes;
+    public Map<String, String> attributes;
 
     /**
      * Application thread details

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -24,7 +24,7 @@ public class BacktraceAttributes {
     /**
      * Get built-in primitive attributes
      */
-    public Map<String, Object> attributes = new HashMap<>();
+    public Map<String, String> attributes = new HashMap<>();
 
     /**
      * Get built-in complex attributes
@@ -69,7 +69,7 @@ public class BacktraceAttributes {
         this.attributes.put("device.model", Build.MODEL);
         this.attributes.put("device.brand", Build.BRAND);
         this.attributes.put("device.product", Build.PRODUCT);
-        this.attributes.put("device.sdk", Build.VERSION.SDK_INT);
+        this.attributes.put("device.sdk", String.valueOf(Build.VERSION.SDK_INT));
         this.attributes.put("device.manufacturer", Build.MANUFACTURER);
 
         this.attributes.put("device.os_version", System.getProperty("os.version"));
@@ -80,7 +80,7 @@ public class BacktraceAttributes {
                 .getPackageName());
 
         this.attributes.put("application", this.context.getApplicationInfo().loadLabel(this.context
-                .getPackageManager()));
+                .getPackageManager()).toString());
 
         try {
             this.attributes.put("version", this.context.getPackageManager()
@@ -98,11 +98,11 @@ public class BacktraceAttributes {
         Display display = wm.getDefaultDisplay();
         DisplayMetrics metrics = new DisplayMetrics();
         display.getMetrics(metrics);
-        this.attributes.put("screen.width", metrics.widthPixels);
-        this.attributes.put("screen.height", metrics.heightPixels);
-        this.attributes.put("screen.dpi", metrics.densityDpi);
+        this.attributes.put("screen.width", String.valueOf(metrics.widthPixels));
+        this.attributes.put("screen.height", String.valueOf(metrics.heightPixels));
+        this.attributes.put("screen.dpi", String.valueOf(metrics.densityDpi));
         this.attributes.put("screen.orientation", getScreenOrientation().toString());
-        this.attributes.put("screen.brightness", getScreenBrightness());
+        this.attributes.put("screen.brightness", String.valueOf(getScreenBrightness()));
     }
 
     /**
@@ -160,9 +160,12 @@ public class BacktraceAttributes {
         Map<String, Object> attributes = BacktraceReport.concatAttributes(report, clientAttributes);
         for (Map.Entry<String, Object> entry : attributes.entrySet()) {
             Object value = entry.getValue();
+            if(value == null) {
+                continue;
+            }
             Class type = value.getClass();
             if (type.isPrimitive() || value instanceof String || type.isEnum()) {
-                this.attributes.put(entry.getKey(), value);
+                this.attributes.put(entry.getKey(), value.toString());
             } else {
                 this.complexAttributes.put(entry.getKey(), value);
             }

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -160,7 +160,7 @@ public class BacktraceAttributes {
         Map<String, Object> attributes = BacktraceReport.concatAttributes(report, clientAttributes);
         for (Map.Entry<String, Object> entry : attributes.entrySet()) {
             Object value = entry.getValue();
-            if(value == null) {
+            if (value == null) {
                 continue;
             }
             Class type = value.getClass();

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceApi.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceApi.java
@@ -23,7 +23,6 @@ public class BacktraceApi implements Api {
     private String serverUrl;
 
 
-
     /**
      * Event triggered when server respond with error
      */

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
@@ -22,6 +22,7 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
     private final int _maxRecordNumber;
     private final File _databaseDirectory;
     private final String recordFilterRegex = ".*-record.json";
+    private final String _crashpadDatabasePathPrefix = "crashpad";
 
     public BacktraceDatabaseFileContext(String databasePath, long maxDatabaseSize, int maxRecordNumber) {
         _databasePath = databasePath;
@@ -107,6 +108,9 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
 
         Iterable<File> files = this.getAll();
         for (File file : files) {
+            if(file.isDirectory() && file.getName().endsWith(this._crashpadDatabasePathPrefix)) {
+                continue;
+            }
             String extension = FileHelper.getFileExtension(file);
             if (!extension.equals("json")) {
                 BacktraceLogger.d(LOG_TAG, "Deleting file - it is not a JSON file");

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
@@ -38,7 +38,7 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
      */
     public Iterable<File> getAll() {
         File[] files = this._databaseDirectory.listFiles();
-        if(files == null)  {
+        if (files == null) {
             return Collections.emptyList();
         }
         return Arrays.asList(files);
@@ -58,7 +58,7 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
                 return p.matcher(f.getName()).matches();
             }
         });
-        if(pagesTemplates == null)  {
+        if (pagesTemplates == null) {
             return Collections.emptyList();
         }
         return Arrays.asList(pagesTemplates);
@@ -108,7 +108,7 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
 
         Iterable<File> files = this.getAll();
         for (File file : files) {
-            if(file.isDirectory() && file.getName().endsWith(this._crashpadDatabasePathPrefix)) {
+            if (file.isDirectory() && file.getName().endsWith(this._crashpadDatabasePathPrefix)) {
                 continue;
             }
             String extension = FileHelper.getFileExtension(file);

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseFileContext.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileFilter;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.regex.Pattern;
 
@@ -35,7 +36,11 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
      * @return all existing physical files
      */
     public Iterable<File> getAll() {
-        return Arrays.asList(this._databaseDirectory.listFiles());
+        File[] files = this._databaseDirectory.listFiles();
+        if(files == null)  {
+            return Collections.emptyList();
+        }
+        return Arrays.asList(files);
     }
 
     /**
@@ -52,6 +57,9 @@ public class BacktraceDatabaseFileContext implements DatabaseFileContext {
                 return p.matcher(f.getName()).matches();
             }
         });
+        if(pagesTemplates == null)  {
+            return Collections.emptyList();
+        }
         return Arrays.asList(pagesTemplates);
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,14 +1,14 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 buildscript {
-    
+
     repositories {
         google()
         jcenter()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        
+
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -4,7 +4,7 @@ android {
     compileSdkVersion 28
     defaultConfig {
         applicationId "backtraceio.backtraceio"
-        minSdkVersion 19
+        minSdkVersion 21
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
@@ -17,6 +17,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+
     buildToolsVersion '28.0.3'
 }
 

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -24,7 +24,7 @@ android {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'com.android.support:appcompat-v7:28.0.0'
-    implementation 'com.android.support.constraint:constraint-layout:1.1.3'
+    implementation 'com.android.support.constraint:constraint-layout:2.0.1'
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -3,6 +3,8 @@ package backtraceio.backtraceio;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.widget.Button;
 
 import backtraceio.library.BacktraceClient;
 import backtraceio.library.BacktraceCredentials;
@@ -13,14 +15,16 @@ import backtraceio.library.models.BacktraceExceptionHandler;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
 
 public class MainActivity extends AppCompatActivity {
-
+    BacktraceClient backtraceClient;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        BacktraceCredentials credentials =
-                new BacktraceCredentials("<endpoint-url>", "<token>");
+        BacktraceCredentials credentials = new BacktraceCredentials(
+                "https://yolo.sp.backtrace.io:6098",
+                "533c6e267998b8562e4b878c891bf7fc509beec7839f991bdaa1d43220d0f497"
+        );
 
         Context context = getApplicationContext();
         String dbPath = context.getFilesDir().getAbsolutePath();
@@ -33,9 +37,21 @@ public class MainActivity extends AppCompatActivity {
         settings.setRetryOrder(RetryOrder.Queue);
 
         BacktraceDatabase database = new BacktraceDatabase(context, settings);
-        BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database);
+        backtraceClient = new BacktraceClient(context, credentials, database);
+        database.setupNativeIntegration(backtraceClient, credentials);
 
         BacktraceExceptionHandler.enable(backtraceClient);
         backtraceClient.send("test");
+
+
+        Button button = (Button) findViewById(R.id.button1);
+
+        button.setOnClickListener(new View.OnClickListener() {
+
+            @Override
+            public void onClick(View arg0) {
+                backtraceClient.nativeCrash();
+            }
+        });
     }
 }

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -3,8 +3,6 @@ package backtraceio.backtraceio;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
-import android.view.View;
-import android.widget.Button;
 
 import backtraceio.library.BacktraceClient;
 import backtraceio.library.BacktraceCredentials;
@@ -15,16 +13,14 @@ import backtraceio.library.models.BacktraceExceptionHandler;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
 
 public class MainActivity extends AppCompatActivity {
-    BacktraceClient backtraceClient;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_main);
 
-        BacktraceCredentials credentials = new BacktraceCredentials(
-                "https://yolo.sp.backtrace.io:6098",
-                "533c6e267998b8562e4b878c891bf7fc509beec7839f991bdaa1d43220d0f497"
-        );
+        BacktraceCredentials credentials =
+                new BacktraceCredentials("<endpoint-url>", "<token>");
 
         Context context = getApplicationContext();
         String dbPath = context.getFilesDir().getAbsolutePath();
@@ -37,21 +33,9 @@ public class MainActivity extends AppCompatActivity {
         settings.setRetryOrder(RetryOrder.Queue);
 
         BacktraceDatabase database = new BacktraceDatabase(context, settings);
-        backtraceClient = new BacktraceClient(context, credentials, database);
-        database.setupNativeIntegration(backtraceClient, credentials);
+        BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database);
 
         BacktraceExceptionHandler.enable(backtraceClient);
         backtraceClient.send("test");
-
-
-        Button button = (Button) findViewById(R.id.button1);
-
-        button.setOnClickListener(new View.OnClickListener() {
-
-            @Override
-            public void onClick(View arg0) {
-                backtraceClient.nativeCrash();
-            }
-        });
     }
 }

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -15,13 +15,4 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
-
-    <Button
-        android:id="@+id/button1"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="Crash Application"
-        tools:layout_editor_absoluteX="124dp"
-        tools:layout_editor_absoluteY="279dp" />
-
 </android.support.constraint.ConstraintLayout>

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -15,4 +15,13 @@
         app:layout_constraintRight_toRightOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+
+    <Button
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Crash Application"
+        tools:layout_editor_absoluteX="124dp"
+        tools:layout_editor_absoluteY="279dp" />
+
 </android.support.constraint.ConstraintLayout>

--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,5 @@ POM_LICENCE_URL=http://www.apache.org/licenses/LICENSE-2.0.txt
 POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=BartoszLitwiniuk
 POM_DEVELOPER_NAME=Bartosz Litwiniuk
+POM_DEVELOPER_ID2=KonradDysput
+POM_DEVELOPER_NAME2=Konrad Dysput

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ org.gradle.jvmargs=-Xmx1024m
 # org.gradle.parallel=true
 
 
-VERSION_NAME=3.0.2
-VERSION_CODE=302
+VERSION_NAME=3.1.0
+VERSION_CODE=310
 GROUP=com.github.backtrace-labs.backtrace-android
 
 POM_DESCRIPTION=Backtrace's integration with Android applications written in Java allows customers to capture and report handled and unhandled java exceptions.


### PR DESCRIPTION
This diff allows Backtrace-android to start a native exception handler process and capture all unhandled native crashes. The current implementation uses the Crashpad library to generate minidump when a crash occurred. 