### PR TITLE
Expose DumpWithoutCrash to managed layer

### DIFF
--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -120,6 +120,12 @@ extern "C" {
         *(volatile int *) 0 = 0;
     }
 
+    void DumpWithoutCrash() {
+        crashpad::NativeCPUContext context;
+        crashpad::CaptureContext(&context);
+        client->DumpWithoutCrash(&context);
+    }
+
     JNIEXPORT void JNICALL Java_backtraceio_library_base_BacktraceBase_crash(
             JNIEnv *env,
             jobject /* this */) {
@@ -180,5 +186,10 @@ extern "C" {
     Java_backtraceio_library_BacktraceDatabase_addAttribute(JNIEnv *env, jobject thiz,
                                                             jstring name, jstring value) {
         AddAttribute(name, value);
+    }
+
+    JNIEXPORT void JNICALL
+    Java_backtraceio_library_base_BacktraceBase_dumpWithoutCrash(JNIEnv *env, jobject thiz) {
+        DumpWithoutCrash();
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -202,6 +202,8 @@ public class BacktraceBase implements Client {
         crash();
     }
 
+    public native void dumpWithoutCrash();
+
     /**
      * Sending an exception to Backtrace API
      *


### PR DESCRIPTION
This commit exposes the crashpad function DumpWithoutCrash to the managed layer. This is useful if we want to debug something in the managed layer but at the same time we want to see the state of the native layer.

We don't need a unit test here since we are just exposing the crashpad function DumpWithoutCrash. I confirmed the behavior with manual testing. 