### PR TITLE
NDK - safe background thread operations

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -202,7 +202,7 @@ public class BacktraceBase implements Client {
         crash();
     }
 
-    public native void dumpWithoutCrash();
+    public native void dumpWithoutCrash(String message);
 
     /**
      * Sending an exception to Backtrace API


### PR DESCRIPTION
Previously, Backtrace-android cached JNIEnv pointer on environment startup. While there is a small chance to initialize Backtrace-native integration in the background thread, there is a chance that someone would like to add an attribute or dump process from the background thread - for example when ANR/OOM occurred. 
 
Cached JNIEnv won't be available when we will call native code from managed background thread - which caused an exception. 

This diff allows to:
* Fetch dynamically JNIEnv when we will need to use it,
* format native code (was unformatted),
* extends `DumpWithoutCrash` method to include `error.message` that users define.