### PR TITLE
Extended primitive type comparision

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/common/TypeHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/TypeHelper.java
@@ -1,0 +1,18 @@
+package backtraceio.library.common;
+
+/**
+ * Backtrace TypeHelper helps with common type comparision.
+ */
+public class TypeHelper {
+    /**
+     * Check if object type is primitive - for example: int or long.
+     * @param type object to check
+     * @return true, if an object is primitive. Otherwise false.
+     */
+    public static boolean isPrimitiveOrPrimitiveWrapperOrString(Class type) {
+        return (type.isPrimitive() && type != void.class) ||
+                type == Double.class || type == Float.class || type == Long.class ||
+                type == Integer.class || type == Short.class || type == Character.class ||
+                type == Byte.class || type == Boolean.class || type == String.class;
+    }
+}

--- a/backtrace-library/src/main/java/backtraceio/library/common/TypeHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/TypeHelper.java
@@ -13,6 +13,6 @@ public class TypeHelper {
         return (type.isPrimitive() && type != void.class) ||
                 type == Double.class || type == Float.class || type == Long.class ||
                 type == Integer.class || type == Short.class || type == Character.class ||
-                type == Byte.class || type == Boolean.class || type == String.class;
+                type == Byte.class || type == Boolean.class || type == String.class || type.isEnum();
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import backtraceio.library.BuildConfig;
+import backtraceio.library.common.TypeHelper;
 import backtraceio.library.enums.ScreenOrientation;
 
 /**
@@ -164,7 +165,7 @@ public class BacktraceAttributes {
                 continue;
             }
             Class type = value.getClass();
-            if (type.isPrimitive() || value instanceof String || type.isEnum()) {
+            if (TypeHelper.isPrimitiveOrPrimitiveWrapperOrString(type) || value instanceof String || type.isEnum()) {
                 this.attributes.put(entry.getKey(), value.toString());
             } else {
                 this.complexAttributes.put(entry.getKey(), value);

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -165,7 +165,7 @@ public class BacktraceAttributes {
                 continue;
             }
             Class type = value.getClass();
-            if (TypeHelper.isPrimitiveOrPrimitiveWrapperOrString(type) || value instanceof String || type.isEnum()) {
+            if (TypeHelper.isPrimitiveOrPrimitiveWrapperOrString(type)) {
                 this.attributes.put(entry.getKey(), value.toString());
             } else {
                 this.complexAttributes.put(entry.getKey(), value);


### PR DESCRIPTION
Previously we used `.isPrimitiveType` method available in the `Object` class. This method doesn't return true, when a user pass - for example, primitive value 123. Type of value 123 is an Integer - not int. Because of that, we added this value to annotations, instead of to attributes.


This diff extends if statement and treat primitive object types like Integer, Long, Double like primitives.