### PR TITLE
Native report - include NDK main thread id

### DIFF
--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -31,6 +31,7 @@ static crashpad::CrashpadClient *client;
 // check if crashpad client is already initialized
 static std::atomic_bool initialized;
 static std::mutex attribute_synchronization;
+static std::string thread_id;
 
 JNIEXPORT jint JNI_OnLoad(JavaVM *jvm, void *reserved) {
     JNIEnv *env;
@@ -41,7 +42,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *jvm, void *reserved) {
         return JNI_ERR;
     }
     javaVm = jvm;
-
+    thread_id = std::to_string(gettid());
     return JNI_VERSION_1_4;
 }
 
@@ -98,7 +99,9 @@ namespace /* anonymous */
         std::map<std::string, std::string> attributes;
         attributes["format"] = "minidump";
         // save native main thread id
-        attributes["thread.main"] = std::to_string(gettid());
+        if(!thread_id.empty()) {
+            attributes["thread.main"] = thread_id;
+        }
 
         jint keyLength = env->GetArrayLength(attributeKeys);
         jint valueLength = env->GetArrayLength(attributeValues);

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -97,6 +97,8 @@ namespace /* anonymous */
 
         std::map<std::string, std::string> attributes;
         attributes["format"] = "minidump";
+        // save native main thread id
+        attributes["thread.main"] = std::to_string(gettid());
 
         jint keyLength = env->GetArrayLength(attributeKeys);
         jint valueLength = env->GetArrayLength(attributeValues);


### PR DESCRIPTION
**Why**

When the user creates a native report in a background thread, it's super useful for the user to also know what is the main thread id. 

**User story**
* as a Unity user when ANR occurs I would like to know what is main thread id to see what my main thread did when ANR occurred,
* as a Backtrace-Android user when I'm reporting application state from background thread I would like to know the main thread id,

This diff shows how to include the main thread id in default attributes in the initialization method.