### PR TITLE
Feature/client side unwinding

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "backtrace-library/src/main/cpp/crashpad-builds"]
 	path = backtrace-library/src/main/cpp/crashpad-builds
 	url = https://github.com/backtrace-labs/crashpad-builds.git
+[submodule "backtrace-library/src/main/cpp/libbun"]
+	path = backtrace-library/src/main/cpp/libbun
+	url = git@github.com:backtrace-labs/libbun.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Backtrace Android Release Notes
 
+
+## Version 3.3.0 - 15.07.2021
+- Added support for client side unwinding of native crashes
+
 ## Version 3.2.2 - 10.03.2021
 - Hotfix for crash when user enables native integration without file attachments
 

--- a/README.md
+++ b/README.md
@@ -485,7 +485,7 @@ More details about [extractNativeLibs](https://developer.android.com/guide/topic
 For an NDK application, debugging symbols are not available to Backtrace by default. You will need to upload the application symbols for your native code to Backtrace. You can do this by uploading the native libraries themselves, which are usually found in the .apk bundle. [Click here to learn more about symbolification](https://support.backtrace.io/hc/en-us/articles/360040517071-Symbolication-Overview)
 
 ## Client side unwinding
-For an NDK application, debugging symbols for system functions (for instance in `libc.so`) and other opaque libraries can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client).
+For an NDK application, debugging symbols for system functions (for instance in `libc.so`) and other opaque libraries can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client). This may not provide the same callstack quality as with debugging symbols, but will give you debugging information you would otherwise not have if you don't have debugging symbols available.
 
 To enable client side unwinding, you can call the `setupNativeIntegration` method with an additional boolean value.
 ```java
@@ -503,8 +503,9 @@ NOTE: Client side unwinding is only available in API level 23+ (Android 6.0)+
 
 - **LOCAL** - Unwinding is done within the same process that has the crash. This is less robust than remote unwinding, but avoids the complexity of creating a child process and IPC. Local unwinding is executed from a signal handler and needs to be signal-safe.
 - **REMOTE** - Unwinding is done by a child process. This means that the unwinding is correct even in case of severe malfunctions in the crashing parent process, and signal-safety is not a concern.
-- **DUMPWITHOUTCRASH** - Instead of using the regular Crashpad reporting mechanism, tell Crashpad that we're the ones who are responsible for sending the crash report. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
-- **CONTEXT** - Use `ucontext *` from signal handler to reconstruct the callstack.
+- **LOCAL_DUMPWITHOUTCRASH** - The same as `LOCAL` unwinding, but instead of using the regular Crashpad reporting mechanism, Backtrace's custom reporting mechanism will be used. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
+- **REMOTE_DUMPWITHOUTCRASH** - The same as `REMOTE` unwinding, but instead of using the regular Crashpad reporting mechanism, Backtrace's custom reporting mechanism will be used. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
+- **LOCAL_CONTEXT** -  The same as `LOCAL` unwinding, but use `ucontext_t *` from the signal handler to reconstruct the callstack.
 
 # Working with Proguard <a name="working_with_proguard"></a>
 

--- a/README.md
+++ b/README.md
@@ -492,19 +492,21 @@ To enable client side unwinding, you can call the `setupNativeIntegration` metho
 database.setupNativeIntegration(backtraceClient, credentials, true);
 ```
 
-You can also optionally specify the unwinding mode (`REMOTE_DUMPWITHOUTCRASH` is the default)
+**NOTE:** Client side unwinding is only available in API level 23+ (Android 6.0)+
+
+**NOTE:** When viewing a crash in the Backtrace Debugger, it may still show warning messages that symbols are missing from certain frames after client-side unwinding is performed. This warning is expected if these symbols are not available on the Backtrace server, and should have no impact to the end-user's ability to read the call stack.
+
+### Unwinding Modes and Options
+
+You can optionally specify the unwinding mode (`REMOTE_DUMPWITHOUTCRASH` is the default)
 ```java
 database.setupNativeIntegration(backtraceClient, credentials, true, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
 ```
 
-NOTE: Client side unwinding is only available in API level 23+ (Android 6.0)+
-
-### Unwinding Modes and Options
-
 - **LOCAL** - Unwinding is done within the same process that has the crash. This is less robust than remote unwinding, but avoids the complexity of creating a child process and IPC. Local unwinding is executed from a signal handler and needs to be signal-safe.
 - **REMOTE** - Unwinding is done by a child process. This means that the unwinding is correct even in case of severe malfunctions in the crashing parent process, and signal-safety is not a concern.
-- **LOCAL_DUMPWITHOUTCRASH** - The same as `LOCAL` unwinding, but instead of using the regular Crashpad reporting mechanism, Backtrace's custom reporting mechanism will be used. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
-- **REMOTE_DUMPWITHOUTCRASH** - The same as `REMOTE` unwinding, but instead of using the regular Crashpad reporting mechanism, Backtrace's custom reporting mechanism will be used. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
+- **LOCAL_DUMPWITHOUTCRASH** - The same as `LOCAL` unwinding, but instead of using the regular Crashpad signal hander to call the unwinder and regular Crashpad reporting mechanism, Backtrace's custom signal handler will be used to call the unwinder before we send the report using Crashpad's `DumpWithoutCrash()` method.
+- **REMOTE_DUMPWITHOUTCRASH** - This is the default and recommended option. Same as `LOCAL` unwinding, but instead of using the regular Crashpad signal hander to call the unwinder and regular Crashpad reporting mechanism, Backtrace's custom signal handler will be used to call the unwinder before we send the report using Crashpad's `DumpWithoutCrash()` method.
 - **LOCAL_CONTEXT** -  The same as `LOCAL` unwinding, but use `ucontext_t *` from the signal handler to reconstruct the callstack.
 
 # Working with Proguard <a name="working_with_proguard"></a>

--- a/README.md
+++ b/README.md
@@ -484,6 +484,19 @@ More details about [extractNativeLibs](https://developer.android.com/guide/topic
 ## Uploading symbols to Backtrace
 For an NDK application, debugging symbols are not available to Backtrace by default. You will need to upload the application symbols for your native code to Backtrace. You can do this by uploading the native libraries themselves, which are usually found in the .apk bundle. [Click here to learn more about symbolification](https://support.backtrace.io/hc/en-us/articles/360040517071-Symbolication-Overview)
 
+## Client side unwinding
+For an NDK application, debugging symbols for system functions (for instance in `libc.so`) can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client). To enable client side unwinding, you can use the `BacktraceClient` `enableClientSideUnwinding` method.
+
+```cpp
+backtraceClient.enableClientSideUnwinding(context.getFilesDir().getAbsolutePath());
+
+database.setupNativeIntegration(backtraceClient, credentials);
+```
+
+NOTE: `enableClientSideUnwinding` must be called BEFORE `setupNativeIntegration`
+
+NOTE: Client side unwinding is only available in API level 23 (Android 6.0)+
+
 # Working with Proguard <a name="working_with_proguard"></a>
 
 ##### 1. Add the following to the `proguard_rules.pro` for your app

--- a/README.md
+++ b/README.md
@@ -499,6 +499,13 @@ database.setupNativeIntegration(backtraceClient, credentials, true, UnwindingMod
 
 NOTE: Client side unwinding is only available in API level 23+ (Android 6.0)+
 
+### Unwinding Modes and Options
+
+- **LOCAL** - Unwinding is done within the same process that has the crash. This is less robust than remote unwinding, but avoids the complexity of creating a child process and IPC. Local unwinding is executed from a signal handler and needs to be signal-safe.
+- **REMOTE** - Unwinding is done by a child process. This means that the unwinding is correct even in case of severe malfunctions in the crashing parent process, and signal-safety is not a concern.
+- **DUMPWITHOUTCRASH** - Instead of using the regular Crashpad reporting mechanism, tell Crashpad that we're the ones who are responsible for sending the crash report. Then, we send the report using Crashpad's `DumpWithoutCrash()` method.
+- **CONTEXT** - Use `ucontext *` from signal handler to reconstruct the callstack.
+
 # Working with Proguard <a name="working_with_proguard"></a>
 
 ##### 1. Add the following to the `proguard_rules.pro` for your app

--- a/README.md
+++ b/README.md
@@ -487,7 +487,7 @@ For an NDK application, debugging symbols are not available to Backtrace by defa
 ## Client side unwinding
 For an NDK application, debugging symbols for system functions (for instance in `libc.so`) can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client). To enable client side unwinding, you can use the `BacktraceClient` `enableClientSideUnwinding` method.
 
-```cpp
+```java
 backtraceClient.enableClientSideUnwinding(context.getFilesDir().getAbsolutePath());
 
 database.setupNativeIntegration(backtraceClient, credentials);

--- a/README.md
+++ b/README.md
@@ -496,6 +496,8 @@ database.setupNativeIntegration(backtraceClient, credentials, true);
 
 **NOTE:** When viewing a crash in the Backtrace Debugger, it may still show warning messages that symbols are missing from certain frames after client-side unwinding is performed. This warning is expected if these symbols are not available on the Backtrace server, and should have no impact to the end-user's ability to read the call stack.
 
+**NOTE:** Client side unwinding is only available for fatal crashes. Non-fatal Crashpad dumps you generate via `DumpWithoutCrash` for instance will not use client side unwinding.
+
 ### Unwinding Modes and Options
 
 You can optionally specify the unwinding mode (`REMOTE_DUMPWITHOUTCRASH` is the default)

--- a/README.md
+++ b/README.md
@@ -485,17 +485,19 @@ More details about [extractNativeLibs](https://developer.android.com/guide/topic
 For an NDK application, debugging symbols are not available to Backtrace by default. You will need to upload the application symbols for your native code to Backtrace. You can do this by uploading the native libraries themselves, which are usually found in the .apk bundle. [Click here to learn more about symbolification](https://support.backtrace.io/hc/en-us/articles/360040517071-Symbolication-Overview)
 
 ## Client side unwinding
-For an NDK application, debugging symbols for system functions (for instance in `libc.so`) can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client). To enable client side unwinding, you can use the `BacktraceClient` `enableClientSideUnwinding` method.
+For an NDK application, debugging symbols for system functions (for instance in `libc.so`) and other opaque libraries can be difficult to obtain. In these cases, it is better to unwind the callstack on the crashing application (i.e: the client).
 
+To enable client side unwinding, you can call the `setupNativeIntegration` method with an additional boolean value.
 ```java
-backtraceClient.enableClientSideUnwinding(context.getFilesDir().getAbsolutePath());
-
-database.setupNativeIntegration(backtraceClient, credentials);
+database.setupNativeIntegration(backtraceClient, credentials, true);
 ```
 
-NOTE: `enableClientSideUnwinding` must be called BEFORE `setupNativeIntegration`
+You can also optionally specify the unwinding mode (`REMOTE_DUMPWITHOUTCRASH` is the default)
+```java
+database.setupNativeIntegration(backtraceClient, credentials, true, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+```
 
-NOTE: Client side unwinding is only available in API level 23 (Android 6.0)+
+NOTE: Client side unwinding is only available in API level 23+ (Android 6.0)+
 
 # Working with Proguard <a name="working_with_proguard"></a>
 

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 322
-        versionName "3.2.2"
+        versionCode 330
+        versionName "3.3.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/backtrace-library/src/main/cpp/CMakeLists.txt
+++ b/backtrace-library/src/main/cpp/CMakeLists.txt
@@ -64,5 +64,5 @@ target_link_libraries( # Specifies the target library.
                         crashpad_client
                         crashpad_util
                         base
-			bun
-        )
+                        bun
+                     )

--- a/backtrace-library/src/main/cpp/CMakeLists.txt
+++ b/backtrace-library/src/main/cpp/CMakeLists.txt
@@ -33,6 +33,7 @@ set_property(TARGET base PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/crashp
 include_directories(${PROJECT_SOURCE_DIR}/crashpad-builds/headers/ ${PROJECT_SOURCE_DIR}/crashpad-builds/headers/third_party/mini_chromium/mini_chromium/)
 
 # Bun Libraries
+set(LIBUNWINDSTACK_ENABLED TRUE)
 add_subdirectory(libbun)
 
 # Searches for a specified prebuilt library and stores the path as a

--- a/backtrace-library/src/main/cpp/CMakeLists.txt
+++ b/backtrace-library/src/main/cpp/CMakeLists.txt
@@ -32,6 +32,9 @@ set_property(TARGET base PROPERTY IMPORTED_LOCATION ${PROJECT_SOURCE_DIR}/crashp
 # Crashpad Headers
 include_directories(${PROJECT_SOURCE_DIR}/crashpad-builds/headers/ ${PROJECT_SOURCE_DIR}/crashpad-builds/headers/third_party/mini_chromium/mini_chromium/)
 
+# Bun Libraries
+add_subdirectory(libbun)
+
 # Searches for a specified prebuilt library and stores the path as a
 # variable. Because CMake includes system libraries in the search path by
 # default, you only need to specify the name of the public NDK library
@@ -60,4 +63,5 @@ target_link_libraries( # Specifies the target library.
                         crashpad_client
                         crashpad_util
                         base
+			bun
         )

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -118,8 +118,7 @@ namespace /* anonymous */
         bun_handle handle;
 
         bool bun_initialized = bun_handle_init(&handle, BUN_BACKEND_LIBUNWINDSTACK);
-        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "%s",
-                            "Bun initialized? %d", bun_initialized);
+        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Bun initialized? %d", bun_initialized);
         if (!bun_initialized) {
             return -1;
         }
@@ -127,8 +126,7 @@ namespace /* anonymous */
         bun_buffer buf = { buffer_child, BUFFER_SIZE };
 
         auto written = bun_unwind_remote(&handle, &buf, tid);
-        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "%s",
-                            "Bun bytes written %d", written);
+        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Bun bytes written %d", written);
         (void) written;
 
         return -1;

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -230,16 +230,14 @@ namespace /* anonymous */
 
         thread_local bool flag;
 
-        if (flag == false) {
-            flag = true;
-            bcd_emit(&bcd, "1");
-
-            crashpad::CrashpadClient::DumpWithoutCrash(context);
-
-            return true;
-        } else {
+        if (flag == true) {
             return false;
         }
+
+        flag = true;
+        bcd_emit(&bcd, "1");
+
+        crashpad::CrashpadClient::DumpWithoutCrash(context);
 
         return true;
     }

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -353,7 +353,7 @@ bool EnableClientSideUnwinding() {
     }
     bun_config cfg;
     memset(&cfg, 0, sizeof(cfg));
-    cfg.unwind_backend = BUN_LIBUNWINDSTACK;
+    cfg.unwind_backend = BUN_BACKEND_LIBUNWINDSTACK;
     cfg.buffer_size = 65536;
     cfg.buffer = buf;
     handle = bun_create(&cfg);

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -146,6 +146,7 @@ namespace /* anonymous */
 
         (void) written;
 
+        // We return -1 on purpose to tell bcd to not employ its own ptrace dumping mechanism
         return -1;
     }
 

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -40,7 +40,7 @@ static std::string thread_id;
 
 // bun handle
 bun_t *handle;
-
+// bun buffer
 char buf[65536];
 
 // bun signal handler
@@ -345,9 +345,7 @@ Java_backtraceio_library_base_BacktraceBase_dumpWithoutCrash__Ljava_lang_String_
     DumpWithoutCrash(message, set_main_thread_as_faulting_thread);
 }
 
-extern "C"
-JNIEXPORT jboolean JNICALL
-Java_backtraceio_library_BacktraceDatabase_enableClientSideUnwinding(JNIEnv *env, jobject thiz) {
+bool EnableClientSideUnwinding() {
     if (!initialized) {
         __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
                             "Crashpad needs to be initialized to enable client-side unwinding");
@@ -365,5 +363,11 @@ Java_backtraceio_library_BacktraceDatabase_enableClientSideUnwinding(JNIEnv *env
         return false;
     }
     return true;
+}
+
+extern "C"
+JNIEXPORT jboolean JNICALL
+Java_backtraceio_library_BacktraceDatabase_enableClientSideUnwinding(JNIEnv *env, jobject thiz) {
+    return EnableClientSideUnwinding();
 }
 }

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -366,7 +366,7 @@ namespace /* anonymous */
         return true;
     }
 
-    bool EnableClientSideUnwinding(JNIEnv *env, jstring path, jobject unwindingMode) {
+    bool EnableClientSideUnwinding(JNIEnv *env, jstring path, jint unwindingMode) {
         if (!sdkSupportsClientSideUnwinding()) {
             return false;
         }
@@ -377,14 +377,7 @@ namespace /* anonymous */
             return false;
         }
 
-        jint unwindingModeInt = (int) UnwindingMode::REMOTE_DUMPWITHOUTCRASH;
-        if (unwindingMode != nullptr) {
-            jmethodID unwindingModeGetValueMethod = env->GetMethodID(env->FindClass(
-                    "backtraceio/library/enums/UnwindingMode"), "ordinal", "()I");
-            jint unwindingModeInt = env->CallIntMethod(unwindingMode, unwindingModeGetValueMethod);
-        }
-
-        unwinding_mode = static_cast<UnwindingMode>((int) unwindingModeInt);
+        unwinding_mode = static_cast<UnwindingMode>((int) unwindingMode);
 
         switch (unwinding_mode) {
             case UnwindingMode::LOCAL:
@@ -407,7 +400,7 @@ namespace /* anonymous */
                         jobjectArray attributeValues,
                         jobjectArray attachmentPaths = nullptr,
                         jboolean enableClientSideUnwinding = false,
-                        jobject unwindingMode = nullptr) {
+                        jint unwindingMode = (int) UnwindingMode::REMOTE_DUMPWITHOUTCRASH) {
         using namespace crashpad;
 
         // avoid multi initialization
@@ -642,7 +635,7 @@ bool Initialize(jstring url,
                 jobjectArray attributeValues,
                 jobjectArray attachmentPaths = nullptr,
                 jboolean enableClientSideUnwinding = false,
-                jobject unwindingMode = nullptr) {
+                jint unwindingMode = (int) UnwindingMode::REMOTE_DUMPWITHOUTCRASH) {
     static std::once_flag initialize_flag;
 
     std::call_once(initialize_flag, [&] {
@@ -666,9 +659,16 @@ Java_backtraceio_library_BacktraceDatabase_initialize(JNIEnv *env,
                                                       jobjectArray attachmentPaths = nullptr,
                                                       jboolean enableClientSideUnwinding = false,
                                                       jobject unwindingMode = nullptr) {
+    jint unwindingModeInt = (int) UnwindingMode::REMOTE_DUMPWITHOUTCRASH;
+    if (unwindingMode != nullptr) {
+        jmethodID unwindingModeGetValueMethod = env->GetMethodID(env->FindClass(
+                "backtraceio/library/enums/UnwindingMode"), "ordinal", "()I");
+        unwindingModeInt = env->CallIntMethod(unwindingMode, unwindingModeGetValueMethod);
+    }
+
     return Initialize(url, database_path, handler_path, attributeKeys,
                       attributeValues, attachmentPaths, enableClientSideUnwinding,
-                      unwindingMode);
+                      unwindingModeInt);
 }
 
 

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -67,11 +67,14 @@ public class BacktraceDatabase implements Database {
      * @param attributeKeys             array of attribute keys
      * @param attributeValues           array of attribute values
      * @param attachmentPaths           array of paths to file attachments
+     * @param enableClientSideUnwinding enable client side unwinding
+     * @param unwindingMode             unwinding mode for client side unwinding to use
      * @return true - if backtrace-native was able to initialize correctly, otherwise false.
      */
     private native boolean initialize(String url, String databasePath, String handlerPath,
                                       String[] attributeKeys, String[] attributeValues,
-                                      String[] attachmentPaths);
+                                      String[] attachmentPaths, boolean enableClientSideUnwinding,
+                                      UnwindingMode unwindingMode);
 
     /**
      * Create disabled instance of BacktraceDatabase
@@ -132,6 +135,31 @@ public class BacktraceDatabase implements Database {
      * @param credentials Backtrace credentials
      */
     public Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials) {
+        return setupNativeIntegration(client, credentials, false);
+    }
+
+    /**
+     * Setup native crash handler
+     *
+     * @param client                    Backtrace client
+     * @param credentials               Backtrace credentials
+     * @param enableClientSideUnwinding Enable client side unwinding
+     */
+    public Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials,
+                                          boolean enableClientSideUnwinding) {
+        return setupNativeIntegration(client, credentials, enableClientSideUnwinding, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+    }
+
+    /**
+     * Setup native crash handler
+     *
+     * @param client                    Backtrace client
+     * @param credentials               Backtrace credentials
+     * @param enableClientSideUnwinding Enable client side unwinding
+     * @param unwindingMode             Unwinding mode to use for client side unwinding
+     */
+    public Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials,
+                                          boolean enableClientSideUnwinding, UnwindingMode unwindingMode) {
         // avoid initialization when database doesn't exist
         if (getSettings() == null) {
             return false;
@@ -165,7 +193,9 @@ public class BacktraceDatabase implements Database {
                 handlerPath,
                 keys,
                 values,
-                attachmentPaths
+                attachmentPaths,
+                enableClientSideUnwinding,
+                unwindingMode
         );
         return initialized;
     }
@@ -407,6 +437,4 @@ public class BacktraceDatabase implements Database {
     public long getDatabaseSize() {
         return backtraceDatabaseContext.getDatabaseSize();
     }
-
-    public native boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -412,5 +412,5 @@ public class BacktraceDatabase implements Database {
         return backtraceDatabaseContext.getDatabaseSize();
     }
 
-    public native boolean enableClientSideUnwinding();
+    public native boolean enableClientSideUnwinding(String path);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -3,9 +3,7 @@ package backtraceio.library;
 import android.content.Context;
 
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Calendar;
-import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -14,6 +12,7 @@ import java.util.concurrent.CountDownLatch;
 import backtraceio.library.base.BacktraceBase;
 import backtraceio.library.breadcrumbs.BacktraceBreadcrumbs;
 import backtraceio.library.common.FileHelper;
+import backtraceio.library.enums.UnwindingMode;
 import backtraceio.library.enums.database.RetryBehavior;
 import backtraceio.library.events.OnServerResponseEventListener;
 import backtraceio.library.interfaces.Api;
@@ -68,13 +67,11 @@ public class BacktraceDatabase implements Database {
      * @param attributeKeys             array of attribute keys
      * @param attributeValues           array of attribute values
      * @param attachmentPaths           array of paths to file attachments
-     * @param enableClientSideUnwinding enable client side stack unwinding
      * @return true - if backtrace-native was able to initialize correctly, otherwise false.
      */
     private native boolean initialize(String url, String databasePath, String handlerPath,
                                       String[] attributeKeys, String[] attributeValues,
-                                      String[] attachmentPaths,
-                                      boolean enableClientSideUnwinding);
+                                      String[] attachmentPaths);
 
     /**
      * Create disabled instance of BacktraceDatabase
@@ -168,8 +165,7 @@ public class BacktraceDatabase implements Database {
                 handlerPath,
                 keys,
                 values,
-                attachmentPaths,
-                true
+                attachmentPaths
         );
         return initialized;
     }
@@ -412,5 +408,5 @@ public class BacktraceDatabase implements Database {
         return backtraceDatabaseContext.getDatabaseSize();
     }
 
-    public native boolean enableClientSideUnwinding(String path);
+    public native boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -62,15 +62,19 @@ public class BacktraceDatabase implements Database {
     /**
      * Initialize Backtrace-native integration
      *
-     * @param url               url to Backtrace
-     * @param databasePath      path to Backtrace-native database
-     * @param handlerPath       path to error handler
-     * @param attributeKeys     array of attribute keys
-     * @param attributeValues   array of attribute values
-     * @param attachmentPaths   array of paths to file attachments
+     * @param url                       url to Backtrace
+     * @param databasePath              path to Backtrace-native database
+     * @param handlerPath               path to error handler
+     * @param attributeKeys             array of attribute keys
+     * @param attributeValues           array of attribute values
+     * @param attachmentPaths           array of paths to file attachments
+     * @param enableClientSideUnwinding enable client side stack unwinding
      * @return true - if backtrace-native was able to initialize correctly, otherwise false.
      */
-    private native boolean initialize(String url, String databasePath, String handlerPath, String[] attributeKeys, String[] attributeValues, String[] attachmentPaths);
+    private native boolean initialize(String url, String databasePath, String handlerPath,
+                                      String[] attributeKeys, String[] attributeValues,
+                                      String[] attachmentPaths,
+                                      boolean enableClientSideUnwinding);
 
     /**
      * Create disabled instance of BacktraceDatabase
@@ -164,7 +168,8 @@ public class BacktraceDatabase implements Database {
                 handlerPath,
                 keys,
                 values,
-                attachmentPaths
+                attachmentPaths,
+                true
         );
         return initialized;
     }
@@ -406,4 +411,6 @@ public class BacktraceDatabase implements Database {
     public long getDatabaseSize() {
         return backtraceDatabaseContext.getDatabaseSize();
     }
+
+    public native boolean enableClientSideUnwinding();
 }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -430,7 +430,7 @@ public class BacktraceBase implements Client {
 
     /**
      * Enable client-side callstack resolution
-     * @param path              path to use for the socket file if DUMPWITHOUTCRASH unwinding is used, can be null
+     * @param path              path to use for the socket file if remote unwinding is used, can be null
      * @return true on success, otherwise returns false
      */
     public boolean enableClientSideUnwinding(String path) {
@@ -439,7 +439,7 @@ public class BacktraceBase implements Client {
 
     /**
      * Enable client-side callstack resolution
-     * @param path              path to use for the socket file if DUMPWITHOUTCRASH unwinding is used, can be null
+     * @param path              path to use for the socket file if remote unwinding is used, can be null
      * @param unwindingMode     the unwinding mode to use for client side unwinding
      * @return true on success, otherwise returns false
      */

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -429,6 +429,15 @@ public class BacktraceBase implements Client {
         return database.getBreadcrumbs().addBreadcrumb(message, attributes, type, level);
     }
 
+    /**
+     * Enable client-side callstack resolution
+     *
+     * @return true on success, otherwise returns false
+     */
+    public boolean enableClientSideUnwinding() {
+        return database.enableClientSideUnwinding();
+    }
+
     public void nativeCrash() {
         crash();
     }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -12,6 +12,7 @@ import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.BacktraceDatabase;
 import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
+import backtraceio.library.enums.UnwindingMode;
 import backtraceio.library.events.OnBeforeSendEventListener;
 import backtraceio.library.events.OnServerErrorEventListener;
 import backtraceio.library.events.OnServerResponseEventListener;
@@ -429,11 +430,21 @@ public class BacktraceBase implements Client {
 
     /**
      * Enable client-side callstack resolution
-     *
+     * @param path              path to use for the socket file if DUMPWITHOUTCRASH unwinding is used, can be null
      * @return true on success, otherwise returns false
      */
     public boolean enableClientSideUnwinding(String path) {
-        return database.enableClientSideUnwinding(path);
+        return enableClientSideUnwinding(path, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+    }
+
+    /**
+     * Enable client-side callstack resolution
+     * @param path              path to use for the socket file if DUMPWITHOUTCRASH unwinding is used, can be null
+     * @param unwindingMode     the unwinding mode to use for client side unwinding
+     * @return true on success, otherwise returns false
+     */
+    public boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode) {
+        return database.enableClientSideUnwinding(path, unwindingMode);
     }
 
     public void nativeCrash() {

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -236,7 +236,6 @@ public class BacktraceBase implements Client {
         this.database.start();
     }
 
-
     /**
      * Capture unhandled native exceptions (Backtrace database integration is required to enable this feature).
      */
@@ -259,7 +258,6 @@ public class BacktraceBase implements Client {
     public Map<String, Object> getAttributes() {
         return attributes;
     }
-
 
     /**
      * Set event executed before sending data to Backtrace API
@@ -434,8 +432,8 @@ public class BacktraceBase implements Client {
      *
      * @return true on success, otherwise returns false
      */
-    public boolean enableClientSideUnwinding() {
-        return database.enableClientSideUnwinding();
+    public boolean enableClientSideUnwinding(String path) {
+        return database.enableClientSideUnwinding(path);
     }
 
     public void nativeCrash() {

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -245,6 +245,23 @@ public class BacktraceBase implements Client {
     }
 
     /**
+     * Capture unhandled native exceptions (Backtrace database integration is required to enable this feature).
+     * @param enableClientSideUnwinding Enable client side unwinding
+     */
+    public void enableNativeIntegration(boolean enableClientSideUnwinding) {
+        this.database.setupNativeIntegration(this, this.credentials, enableClientSideUnwinding);
+    }
+
+    /**
+     * Capture unhandled native exceptions (Backtrace database integration is required to enable this feature).
+     * @param enableClientSideUnwinding Enable client side unwinding
+     * @param unwindingMode             Unwinding mode to use for client side unwinding
+     */
+    public void enableNativeIntegration(boolean enableClientSideUnwinding, UnwindingMode unwindingMode) {
+        this.database.setupNativeIntegration(this, this.credentials, enableClientSideUnwinding, unwindingMode);
+    }
+
+    /**
      * Inform Backtrace API that we are using Proguard symbolication
      */
     public void enableProguard() {
@@ -426,25 +443,6 @@ public class BacktraceBase implements Client {
      */
     public boolean addBreadcrumb(String message, Map<String, Object> attributes, BacktraceBreadcrumbType type, BacktraceBreadcrumbLevel level) {
         return database.getBreadcrumbs().addBreadcrumb(message, attributes, type, level);
-    }
-
-    /**
-     * Enable client-side callstack resolution
-     * @param path              path to use for the socket file if remote unwinding is used, can be null
-     * @return true on success, otherwise returns false
-     */
-    public boolean enableClientSideUnwinding(String path) {
-        return enableClientSideUnwinding(path, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
-    }
-
-    /**
-     * Enable client-side callstack resolution
-     * @param path              path to use for the socket file if remote unwinding is used, can be null
-     * @param unwindingMode     the unwinding mode to use for client side unwinding
-     * @return true on success, otherwise returns false
-     */
-    public boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode) {
-        return database.enableClientSideUnwinding(path, unwindingMode);
     }
 
     public void nativeCrash() {

--- a/backtrace-library/src/main/java/backtraceio/library/enums/UnwindingMode.java
+++ b/backtrace-library/src/main/java/backtraceio/library/enums/UnwindingMode.java
@@ -1,0 +1,9 @@
+package backtraceio.library.enums;
+
+public enum UnwindingMode {
+    LOCAL,
+    REMOTE,
+    REMOTE_DUMPWITHOUTCRASH,
+    LOCAL_DUMPWITHOUTCRASH,
+    LOCAL_CONTEXT
+}

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -89,16 +89,30 @@ public interface Database {
     Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials);
 
     /**
+     * Setup native crash handler
+     *
+     * @param client                    Backtrace client
+     * @param credentials               Backtrace credentials
+     * @param enableClientSideUnwinding Enable client side unwinding
+     */
+    Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials,
+                                          boolean enableClientSideUnwinding);
+
+    /**
+     * Setup native crash handler
+     *
+     * @param client                    Backtrace client
+     * @param credentials               Backtrace credentials
+     * @param enableClientSideUnwinding Enable client side unwinding
+     * @param unwindingMode             Unwinding mode to use for client side unwinding
+     */
+    Boolean setupNativeIntegration(BacktraceBase client, BacktraceCredentials credentials,
+                                          boolean enableClientSideUnwinding, UnwindingMode unwindingMode);
+
+    /**
      * Get the breadcrumbs implementation
      *
      * @return the breadcrumbs implementation for this Database, if any
      */
     Breadcrumbs getBreadcrumbs();
-
-    /**
-     * Enable client-side callstack resolution
-     *
-     * @return true on success, otherwise returns false
-     */
-    boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -4,6 +4,7 @@ import java.util.Map;
 
 import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.base.BacktraceBase;
+import backtraceio.library.enums.UnwindingMode;
 import backtraceio.library.models.database.BacktraceDatabaseRecord;
 import backtraceio.library.models.database.BacktraceDatabaseSettings;
 import backtraceio.library.models.json.BacktraceReport;
@@ -99,5 +100,5 @@ public interface Database {
      *
      * @return true on success, otherwise returns false
      */
-    boolean enableClientSideUnwinding(String path);
+    boolean enableClientSideUnwinding(String path, UnwindingMode unwindingMode);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -99,5 +99,5 @@ public interface Database {
      *
      * @return true on success, otherwise returns false
      */
-    boolean enableClientSideUnwinding();
+    boolean enableClientSideUnwinding(String path);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -93,4 +93,11 @@ public interface Database {
      * @return the breadcrumbs implementation for this Database, if any
      */
     Breadcrumbs getBreadcrumbs();
+
+    /**
+     * Enable client-side callstack resolution
+     *
+     * @return true on success, otherwise returns false
+     */
+    boolean enableClientSideUnwinding();
 }

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -7,7 +7,6 @@ import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import java.util.Map;
 
-import backtraceio.library.BuildConfig;
 import backtraceio.library.common.DeviceAttributesHelper;
 import backtraceio.library.common.FileHelper;
 import backtraceio.library.logger.BacktraceLogger;

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import java.util.Map;
 
+import backtraceio.library.BuildConfig;
 import backtraceio.library.common.DeviceAttributesHelper;
 import backtraceio.library.common.FileHelper;
 import backtraceio.library.logger.BacktraceLogger;

--- a/example-app/src/main/cpp/CMakeLists.txt
+++ b/example-app/src/main/cpp/CMakeLists.txt
@@ -13,6 +13,7 @@ project("myapplication")
 # or SHARED, and provides the relative paths to its source code.
 # You can define multiple libraries, and CMake builds them for you.
 # Gradle automatically packages shared libraries with your APK.
+set(CMAKE_CXX_FLAGS -fno-omit-frame-pointer)
 
 add_library( # Sets the name of the library.
              native-lib

--- a/example-app/src/main/cpp/native-lib.cpp
+++ b/example-app/src/main/cpp/native-lib.cpp
@@ -1,12 +1,20 @@
 #include <jni.h>
 #include <signal.h>
+#include <unistd.h>
 #include "backtrace-android.h"
+
+void * volatile always_null;
+void anotherCrash()
+{
+    memset(always_null, 0x42, 1 << 20);
+}
 
 extern "C"
 {
 JNIEXPORT void JNICALL
 Java_backtraceio_backtraceio_MainActivity_cppCrash(JNIEnv *env, jobject thiz) {
-    raise(SIGSEGV);
+    //__builtin_trap();
+    anotherCrash();
 }
 
 ////////////////// Begin Native Breadcrumb Examples //////////////////
@@ -29,7 +37,6 @@ Java_backtraceio_backtraceio_MainActivity_addNativeBreadcrumbUserError(JNIEnv *e
                                     Backtrace::BreadcrumbType::USER,
                                     Backtrace::BreadcrumbLevel::ERROR);
 }
-
 
 JNIEXPORT jboolean JNICALL
 Java_backtraceio_backtraceio_MainActivity_registerNativeBreadcrumbs(JNIEnv *env, jobject thiz,

--- a/example-app/src/main/cpp/native-lib.cpp
+++ b/example-app/src/main/cpp/native-lib.cpp
@@ -4,17 +4,18 @@
 #include "backtrace-android.h"
 
 void * volatile always_null;
+
 void anotherCrash()
 {
-    memset(always_null, 0x42, 1 << 20);
+//    memset(always_null, 0x42, 1 << 20);
+    __builtin_trap();
 }
 
 extern "C"
 {
 JNIEXPORT void JNICALL
 Java_backtraceio_backtraceio_MainActivity_cppCrash(JNIEnv *env, jobject thiz) {
-    __builtin_trap();
-    //anotherCrash();
+    anotherCrash();
 }
 
 ////////////////// Begin Native Breadcrumb Examples //////////////////

--- a/example-app/src/main/cpp/native-lib.cpp
+++ b/example-app/src/main/cpp/native-lib.cpp
@@ -13,8 +13,8 @@ extern "C"
 {
 JNIEXPORT void JNICALL
 Java_backtraceio_backtraceio_MainActivity_cppCrash(JNIEnv *env, jobject thiz) {
-    //__builtin_trap();
-    anotherCrash();
+    __builtin_trap();
+    //anotherCrash();
 }
 
 ////////////////// Begin Native Breadcrumb Examples //////////////////

--- a/example-app/src/main/cpp/native-lib.cpp
+++ b/example-app/src/main/cpp/native-lib.cpp
@@ -7,6 +7,7 @@ void * volatile always_null;
 
 void anotherCrash()
 {
+    // Uncomment this to try a different type of crash
 //    memset(always_null, 0x42, 1 << 20);
     __builtin_trap();
 }

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -68,6 +68,7 @@ public class MainActivity extends AppCompatActivity {
         // Ensure you don't create any files with data you want to keep until
         // AFTER creating the BacktraceClient
         final String fileName = context.getFilesDir() + "/" + "myCustomFile.txt";
+
         List<String> attachments = new ArrayList<String>(){{
             add(fileName);
         }};
@@ -194,5 +195,14 @@ public class MainActivity extends AppCompatActivity {
 
     public void exit(View view) {
         System.exit(0);
+    }
+
+    public void dumpWithoutCrash(View view) {
+        backtraceClient.dumpWithoutCrash("DumpWithoutCrash");
+    }
+
+    public void dumpWithoutCrashThenCrash(View view) {
+        backtraceClient.dumpWithoutCrash("DumpWithoutCrash");
+        cppCrash();
     }
 }

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -25,6 +25,7 @@ import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.BacktraceDatabase;
 import backtraceio.library.base.BacktraceBase;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
+import backtraceio.library.enums.UnwindingMode;
 import backtraceio.library.enums.database.RetryBehavior;
 import backtraceio.library.enums.database.RetryOrder;
 import backtraceio.library.models.BacktraceExceptionHandler;
@@ -87,11 +88,8 @@ public class MainActivity extends AppCompatActivity {
         BacktraceExceptionHandler.enable(backtraceClient);
         backtraceClient.send("test");
 
-        // Enable client-side callstack resolution
-        backtraceClient.enableClientSideUnwinding(context.getFilesDir().getAbsolutePath());
-
         // Enable handling of native crashes
-        database.setupNativeIntegration(backtraceClient, credentials);
+        database.setupNativeIntegration(backtraceClient, credentials, true);
 
         // Enable ANR detection
         backtraceClient.enableAnr(anrTimeout);

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -200,9 +200,4 @@ public class MainActivity extends AppCompatActivity {
     public void dumpWithoutCrash(View view) {
         backtraceClient.dumpWithoutCrash("DumpWithoutCrash");
     }
-
-    public void dumpWithoutCrashThenCrash(View view) {
-        backtraceClient.dumpWithoutCrash("DumpWithoutCrash");
-        cppCrash();
-    }
 }

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -83,6 +83,9 @@ public class MainActivity extends AppCompatActivity {
 
         // Enable ANR detection
         backtraceClient.enableAnr(anrTimeout);
+
+        // Enable client-side callstack resolution
+        backtraceClient.enableClientSideUnwinding();
     }
 
     public native void cppCrash();

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -3,6 +3,8 @@ package backtraceio.backtraceio;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.system.ErrnoException;
+import android.system.Os;
 import android.util.Log;
 import android.view.View;
 
@@ -73,19 +75,25 @@ public class MainActivity extends AppCompatActivity {
         BacktraceDatabase database = new BacktraceDatabase(context, settings);
         backtraceClient = new BacktraceClient(context, credentials, database, attributes, attachments);
 
-        writeMyCustomFile(fileName);
+        final String fileNameDateString = context.getFilesDir() + "/" + "myCustomFile06_11_2021.txt";
+        try {
+            Os.symlink(fileNameDateString, fileName);
+        } catch (ErrnoException e) {
+            e.printStackTrace();
+        }
+        writeMyCustomFile(fileNameDateString);
 
         BacktraceExceptionHandler.enable(backtraceClient);
         backtraceClient.send("test");
+
+        // Enable client-side callstack resolution
+        backtraceClient.enableClientSideUnwinding(context.getFilesDir().getAbsolutePath());
 
         // Enable handling of native crashes
         database.setupNativeIntegration(backtraceClient, credentials);
 
         // Enable ANR detection
         backtraceClient.enableAnr(anrTimeout);
-
-        // Enable client-side callstack resolution
-        backtraceClient.enableClientSideUnwinding();
     }
 
     public native void cppCrash();

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -36,7 +36,7 @@
         android:layout_height="wrap_content"
         android:text="Native Crash"
         android:onClick="nativeCrash"
-        app:layout_constraintBottom_toTopOf="@+id/dumpWithoutCrashThenCrash"
+        app:layout_constraintBottom_toTopOf="@+id/dumpWithoutCrash"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -48,23 +48,11 @@
         android:layout_height="wrap_content"
         android:text="DumpWithoutCrash"
         android:onClick="dumpWithoutCrash"
-        app:layout_constraintBottom_toTopOf="@+id/dumpWithoutCrashThenCrash"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintHorizontal_bias="0.5"
-        app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/nativeCrash" />
-
-    <Button
-        android:id="@+id/dumpWithoutCrashThenCrash"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="DumpWithoutCrash then Crash"
-        android:onClick="dumpWithoutCrashThenCrash"
         app:layout_constraintBottom_toTopOf="@+id/anr"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/dumpWithoutCrash" />
+        app:layout_constraintTop_toBottomOf="@+id/nativeCrash" />
 
     <Button
         android:id="@+id/anr"
@@ -75,7 +63,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/dumpWithoutCrashThenCrash" />
+        app:layout_constraintTop_toBottomOf="@+id/dumpWithoutCrash" />
 
     <Button
         android:id="@+id/enableBreadcrumbs"

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -36,11 +36,35 @@
         android:layout_height="wrap_content"
         android:text="Native Crash"
         android:onClick="nativeCrash"
-        app:layout_constraintBottom_toTopOf="@+id/anr"
+        app:layout_constraintBottom_toTopOf="@+id/dumpWithoutCrashThenCrash"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/unhandledException" />
+
+    <Button
+        android:id="@+id/dumpWithoutCrash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="DumpWithoutCrash"
+        android:onClick="dumpWithoutCrash"
+        app:layout_constraintBottom_toTopOf="@+id/dumpWithoutCrashThenCrash"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/nativeCrash" />
+
+    <Button
+        android:id="@+id/dumpWithoutCrashThenCrash"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="DumpWithoutCrash then Crash"
+        android:onClick="dumpWithoutCrashThenCrash"
+        app:layout_constraintBottom_toTopOf="@+id/anr"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/dumpWithoutCrash" />
 
     <Button
         android:id="@+id/anr"
@@ -51,7 +75,7 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/nativeCrash" />
+        app:layout_constraintTop_toBottomOf="@+id/dumpWithoutCrashThenCrash" />
 
     <Button
         android:id="@+id/enableBreadcrumbs"

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ org.gradle.jvmargs=-Xmx1024m
 # org.gradle.parallel=true
 
 
-VERSION_NAME=3.2.2
-VERSION_CODE=322
+VERSION_NAME=3.3.0
+VERSION_CODE=330
 GROUP=com.github.backtrace-labs.backtrace-android
 
 POM_DESCRIPTION=Backtrace's integration with Android applications written in Java allows customers to capture and report handled and unhandled java exceptions.


### PR DESCRIPTION
This change allows client side unwinding. If client side unwinding is enabled, then when there is a native/crashpad crash, the call stack will be resolved by the device (client) before submission to the Backtrace server. This allows better resolution of call stacks 
when symbols for native libraries are not available, e.g for syscalls or opaque libraries.