### PR TITLE
Upgrade Android Gradle plugin so we can build with NDK 22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Backtrace Android Release Notes
 
-## Version 3.5.0 - 02.09.2021
+## Version 3.4.0 - 07.09.2021
 - Added support for NDK 22
 
 ## Version 3.3.0 - 15.07.2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Backtrace Android Release Notes
 
+## Version 3.5.0 - 02.09.2021
+- Added support for NDK 22
 
 ## Version 3.3.0 - 15.07.2021
 - Added support for client side unwinding of native crashes

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ catch (e: Exception) {
 * Minimum SDK version 21 (Android 5.0)
 * Target SDK version 28 (Android 9.0)
 * Minimum NDK version 17c
-* Maximum NDK version 21
+* Maximum NDK version 22
 
 # Supported platforms
 * arm32/arm64

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -7,8 +7,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 28
-        versionCode 330
-        versionName "3.3.0"
+        versionCode 340
+        versionName "3.4.0"
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -184,7 +184,12 @@ public class BacktraceData {
         timestamp = report.timestamp;
         classifiers = report.exceptionTypeReport ? new String[]{report.classifier} : null;
         langVersion = System.getProperty("java.version"); //TODO: Fix problem with read Java version
-        agentVersion = BuildConfig.VERSION_NAME;
+        try {
+            agentVersion = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
+        } catch (Exception e) {
+            BacktraceLogger.e(LOG_TAG, "Could not resolve package version name");
+            agentVersion = "";
+        }
     }
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.2.1'
+        classpath 'com.android.tools.build:gradle:4.2.2'
 
 
         // NOTE: Do not place your application dependencies here; they belong

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -8,7 +8,6 @@ android {
         targetSdkVersion 28
         versionCode 1
         versionName "1.0"
-        buildToolsVersion "28.0.2"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     buildTypes {
@@ -24,8 +23,6 @@ android {
             version "3.10.2"
         }
     }
-
-    buildToolsVersion '28.0.3'
 }
 
 dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,8 @@ org.gradle.jvmargs=-Xmx1024m
 # org.gradle.parallel=true
 
 
-VERSION_NAME=3.3.0
-VERSION_CODE=330
+VERSION_NAME=3.4.0
+VERSION_CODE=340
 GROUP=com.github.backtrace-labs.backtrace-android
 
 POM_DESCRIPTION=Backtrace's integration with Android applications written in Java allows customers to capture and report handled and unhandled java exceptions.

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Sep 02 16:28:56 EDT 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-bin.zip


### PR DESCRIPTION
For reviewers:

This change will upgrade Android Gradle plugin so we can build with NDK 22, and so we can work with the latest versions of Android Studio