### PR TITLE
Feature/disable native integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Backtrace Android Release Notes
 
+## Version 3.5.1 - 13.10.2021
+- Added method to disable native crash reporting
+
 ## Version 3.5.0 - 14.09.2021
 - Added support for native crash reporting in NDK 16b
 - Bug fixes and expanded supported NDK versions for client side unwinding

--- a/README.md
+++ b/README.md
@@ -501,10 +501,10 @@ bool success = Backtrace::AddBreadcrumb(env,
 
 ## Enabling native integration
 
-If you would like to capture NDK Crashes you can use the `BacktraceDatabase` `setupNativeIntegration` method.
+If you would like to capture NDK Crashes you can use the `BacktraceClient` `enableNativeIntegration` method.
 
 ```java
-database.setupNativeIntegration(backtraceClient, credentials);
+backtraceClient.enableNativeIntegration();
 ```
 
 In addition, you may need to add the [extractNativeLibs](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs) option to your AndroidManifest.xml:
@@ -516,9 +516,16 @@ In addition, you may need to add the [extractNativeLibs](https://developer.andro
 ```
 More details about [extractNativeLibs](https://developer.android.com/guide/topics/manifest/application-element#extractNativeLibs) are available from the Android documentation
 
+You can also disable (and re-enable) native integration:
+```java
+backtraceClient.disableNativeIntegration();
+```
+
 **NOTE:** If your native app is built with NDK 16b, the Breakpad native crash client will be used instead of our recommended Crashpad crash client. To avoid this please use NDK 17c+ to build your native app.
 
 **NOTE:** Breakpad crash reports are submitted on the next app startup, instead of at crash time like Crashpad crash reports
+
+**NOTE:** Breakpad does not currently support `disableNativeIntegration`
 
 ## Uploading symbols to Backtrace
 For an NDK application, debugging symbols are not available to Backtrace by default. You will need to upload the application symbols for your native code to Backtrace. You can do this by uploading the native libraries themselves, which are usually found in the .apk bundle. [Click here to learn more about symbolification](https://support.backtrace.io/hc/en-us/articles/360040517071-Symbolication-Overview)

--- a/backtrace-library/src/main/cpp/backends/backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/backend.cpp
@@ -21,27 +21,24 @@ bool Initialize(jstring url,
                 jobjectArray attachmentPaths,
                 jboolean enableClientSideUnwinding,
                 jint unwindingMode) {
-    static std::once_flag initialize_flag;
-
-    std::call_once(initialize_flag, [&] {
 #ifdef CRASHPAD_BACKEND
-        initialized = InitializeCrashpad(url,
-                                         database_path, handler_path,
-                                         attributeKeys, attributeValues,
-                                         attachmentPaths, enableClientSideUnwinding,
-                                         unwindingMode);
+    initialized = InitializeCrashpad(url,
+                                     database_path, handler_path,
+                                     attributeKeys, attributeValues,
+                                     attachmentPaths, enableClientSideUnwinding,
+                                     unwindingMode);
 #elif BREAKPAD_BACKEND
-        initialized = InitializeBreakpad(url,
-                                         database_path, handler_path,
-                                         attributeKeys, attributeValues,
-                                         attachmentPaths, enableClientSideUnwinding,
-                                         unwindingMode);
+    initialized = InitializeBreakpad(url,
+                                     database_path, handler_path,
+                                     attributeKeys, attributeValues,
+                                     attachmentPaths, enableClientSideUnwinding,
+                                     unwindingMode);
 #else
-        initialized = false;
-        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
-                            "No native crash reporting backend defined");
+    initialized = false;
+    __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
+                        "No native crash reporting backend defined");
 #endif
-    });
+
     return initialized;
 }
 
@@ -64,6 +61,15 @@ void AddAttribute(jstring key, jstring value) {
 #else
     __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
                         "AddAttribute not supported on this backend");
+#endif
+}
+
+void Disable() {
+#ifdef CRASHPAD_BACKEND
+    DisableCrashpad();
+#else
+    __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
+                        "Disable not supported on this backend");
 #endif
 }
 }

--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -19,17 +19,6 @@ bool InitializeCrashpad(jstring url,
                         jobjectArray attachmentPaths,
                         jboolean enableClientSideUnwinding,
                         jint unwindingMode) {
-    // Re-enable uploads if disabled
-    if (initialized && disabled) {
-        if (database == nullptr) {
-            __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Crashpad database is null, this should not happen");
-            return false;
-        }
-        database->GetSettings()->SetUploadsEnabled(true);
-        disabled = false;
-        return true;
-    }
-
     // avoid multi initialization
     if (initialized) {
         __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Crashpad is already initialized");
@@ -226,4 +215,16 @@ void DisableCrashpad() {
     // Disable automated uploads.
     database->GetSettings()->SetUploadsEnabled(false);
     disabled = true;
+}
+
+void ReEnableCrashpad() {
+    // Re-enable uploads if disabled
+    if (disabled) {
+        if (database == nullptr) {
+            __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Crashpad database is null, this should not happen");
+            return;
+        }
+        database->GetSettings()->SetUploadsEnabled(true);
+        disabled = false;
+    }
 }

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -27,6 +27,8 @@ static JavaVM *javaVm;
 
 // check if native crash client is already initialized
 std::atomic_bool initialized;
+// check if native crash client is disabled
+std::atomic_bool disabled;
 std::mutex attribute_synchronization;
 std::string thread_id;
 
@@ -126,6 +128,11 @@ Java_backtraceio_library_base_BacktraceBase_dumpWithoutCrash__Ljava_lang_String_
                                                                                    jstring message,
                                                                                    jboolean set_main_thread_as_faulting_thread) {
     DumpWithoutCrash(message, set_main_thread_as_faulting_thread);
+}
+
+JNIEXPORT void JNICALL
+Java_backtraceio_library_BacktraceDatabase_disable(JNIEnv *env, jobject thiz) {
+    Disable();
 }
 
 }

--- a/backtrace-library/src/main/cpp/include/backend.h
+++ b/backtrace-library/src/main/cpp/include/backend.h
@@ -17,6 +17,8 @@ bool Initialize(jstring url,
 void DumpWithoutCrash(jstring message, jboolean set_main_thread_as_faulting_thread);
 
 void AddAttribute(jstring key, jstring value);
+
+void Disable();
 }
 
 #endif //BACKTRACE_ANDROID_BACKEND_H

--- a/backtrace-library/src/main/cpp/include/crashpad-backend.h
+++ b/backtrace-library/src/main/cpp/include/crashpad-backend.h
@@ -26,4 +26,6 @@ void AddAttributeCrashpad(jstring key, jstring value);
 
 void DisableCrashpad();
 
+void ReEnableCrashpad();
+
 #endif //BACKTRACE_ANDROID_CRASHPAD_BACKEND_H

--- a/backtrace-library/src/main/cpp/include/crashpad-backend.h
+++ b/backtrace-library/src/main/cpp/include/crashpad-backend.h
@@ -24,4 +24,6 @@ void DumpWithoutCrashCrashpad(jstring message, jboolean set_main_thread_as_fault
 
 void AddAttributeCrashpad(jstring key, jstring value);
 
+void DisableCrashpad();
+
 #endif //BACKTRACE_ANDROID_CRASHPAD_BACKEND_H

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -77,6 +77,11 @@ public class BacktraceDatabase implements Database {
                                       UnwindingMode unwindingMode);
 
     /**
+     * Disable Backtrace-native integration
+     */
+    private native void disable();
+
+    /**
      * Create disabled instance of BacktraceDatabase
      */
     public BacktraceDatabase() {
@@ -202,6 +207,14 @@ public class BacktraceDatabase implements Database {
                 unwindingMode
         );
         return initialized;
+    }
+
+    /**
+     * Disable native integration
+     */
+    @Override
+    public void disableNativeIntegration() {
+        disable();
     }
 
     @Override

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -261,6 +261,10 @@ public class BacktraceBase implements Client {
         this.database.setupNativeIntegration(this, this.credentials, enableClientSideUnwinding, unwindingMode);
     }
 
+    public void disableNativeIntegration() {
+        this.database.disableNativeIntegration();
+    }
+
     /**
      * Inform Backtrace API that we are using Proguard symbolication
      */

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Database.java
@@ -110,6 +110,11 @@ public interface Database {
                                           boolean enableClientSideUnwinding, UnwindingMode unwindingMode);
 
     /**
+     * Disable native crash handler
+     */
+    void disableNativeIntegration();
+
+    /**
      * Get the breadcrumbs implementation
      *
      * @return the breadcrumbs implementation for this Database, if any

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -195,4 +195,12 @@ public class MainActivity extends AppCompatActivity {
     public void dumpWithoutCrash(View view) {
         backtraceClient.dumpWithoutCrash("DumpWithoutCrash");
     }
+
+    public void disableNativeIntegration(View view) {
+        backtraceClient.disableNativeIntegration();
+    }
+
+    public void enableNativeIntegration(View view) {
+        backtraceClient.enableNativeIntegration();
+    }
 }

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -99,6 +99,28 @@
         app:layout_constraintTop_toBottomOf="@+id/enableBreadcrumbsUserOnly" />
 
     <Button
+        android:id="@+id/disableNativeIntegration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Disable Native Integration"
+        android:onClick="disableNativeIntegration"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/sendReport" />
+
+    <Button
+        android:id="@+id/enableNativeIntegration"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Re-Enable Native Integration"
+        android:onClick="enableNativeIntegration"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0.5"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/disableNativeIntegration" />
+
+    <Button
         android:id="@+id/exit"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
@@ -107,6 +129,6 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintHorizontal_bias="0.5"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/sendReport" />
+        app:layout_constraintTop_toBottomOf="@+id/enableNativeIntegration" />
 
 </android.support.constraint.ConstraintLayout>


### PR DESCRIPTION
This allows us to selectively disable and re-enable Crashpad integration in backtrace-android. Many times customers have issues with known bugs, etc. which can't be resolved and will add unnecessary noise to crash reporting and stability monitoring. 

For these cases, the customer can disable Crashpad integration to prevent these kinds of unfixable known bugs from being reported to their Backtrace instance.