### PR TITLE
backtrace.version attribute

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -9,6 +9,7 @@ android {
         targetSdkVersion 30
         versionCode 360
         versionName "3.6.0"
+        buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
 
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
 

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -178,7 +178,8 @@ public class BacktraceDatabase implements Database {
         // Path to Crashpad native handler
         String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + _crashpadHandlerName;
 
-        BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, null, client.attributes);
+        // setup default native attribtues
+        BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, client.attributes);
         crashpadAttributes.attributes.put(BacktraceAttributeConsts.ErrorType, BacktraceAttributeConsts.CrashAttributeType);
         String[] keys = crashpadAttributes.attributes.keySet().toArray(new String[0]);
         String[] values = crashpadAttributes.attributes.values().toArray(new String[0]);

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -51,7 +51,7 @@ public class BacktraceBase implements Client {
     /**
      * Backtrace client version
      */
-    public static String Version = BuildConfig.VERSION_NAME;
+    public static String version = BuildConfig.VERSION_NAME;
 
     /**
      * Get custom client attributes. Every argument stored in dictionary will be send to Backtrace API

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -39,6 +39,10 @@ public class BacktraceBase implements Client {
 
     private static final transient String LOG_TAG = BacktraceBase.class.getSimpleName();
 
+    static {
+        System.loadLibrary("backtrace-native");
+    }
+
     /**
      * Backtrace database instance
      */

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.BacktraceDatabase;
+import backtraceio.library.BuildConfig;
 import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
 import backtraceio.library.enums.UnwindingMode;
@@ -38,14 +39,15 @@ public class BacktraceBase implements Client {
 
     private static final transient String LOG_TAG = BacktraceBase.class.getSimpleName();
 
-    static {
-        System.loadLibrary("backtrace-native");
-    }
-
     /**
      * Backtrace database instance
      */
     public final Database database;
+
+    /**
+     * Backtrace client version
+     */
+    public static String Version = BuildConfig.VERSION_NAME;
 
     /**
      * Get custom client attributes. Every argument stored in dictionary will be send to Backtrace API

--- a/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
@@ -49,7 +49,7 @@ public class DeviceAttributesHelper {
         result.put("guid", this.generateDeviceId());
         result.put("uname.sysname", "Android");
         result.put("uname.machine", System.getProperty("os.arch"));
-        if(includeDynamicAttributes == false) {
+        if (includeDynamicAttributes == false) {
             return result;
         }
         result.put("device.airplane_mode", String.valueOf(isAirplaneModeOn()));

--- a/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
@@ -44,13 +44,14 @@ public class DeviceAttributesHelper {
      *
      * @return device attributes
      */
-    public HashMap<String, String> getDeviceAttributes() {
+    public HashMap<String, String> getDeviceAttributes(Boolean includeDynamicAttributes) {
         HashMap<String, String> result = new HashMap<>();
         result.put("guid", this.generateDeviceId());
         result.put("uname.sysname", "Android");
         result.put("uname.machine", System.getProperty("os.arch"));
-        result.put("cpu.boottime", String.valueOf(java.lang.System.currentTimeMillis() - android.os.SystemClock
-                .elapsedRealtime()));
+        if(includeDynamicAttributes == false) {
+            return result;
+        }
         result.put("device.airplane_mode", String.valueOf(isAirplaneModeOn()));
         result.put("device.location", getLocationServiceStatus().toString());
         result.put("device.nfc.status", getNfcStatus().toString());
@@ -65,6 +66,9 @@ public class DeviceAttributesHelper {
         result.put("app.storage_used", getAppUsedStorageSize());
         result.put("battery.level", String.valueOf(getBatteryLevel()));
         result.put("battery.state", getBatteryState().toString());
+        result.put("cpu.boottime", String.valueOf(java.lang.System.currentTimeMillis() - android.os.SystemClock
+                .elapsedRealtime()));
+
         return result;
     }
 

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 
 import backtraceio.library.BacktraceClient;
-import backtraceio.library.common.DeviceAttributesHelper;
 import backtraceio.library.common.FileHelper;
 import backtraceio.library.logger.BacktraceLogger;
 import backtraceio.library.models.json.Annotations;
@@ -179,7 +178,7 @@ public class BacktraceData {
         timestamp = report.timestamp;
         classifiers = report.exceptionTypeReport ? new String[]{report.classifier} : null;
         langVersion = System.getProperty("java.version"); //TODO: Fix problem with read Java version
-        agentVersion = BacktraceClient.Version;
+        agentVersion = BacktraceClient.version;
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName;
 import java.util.List;
 import java.util.Map;
 
+import backtraceio.library.BacktraceClient;
 import backtraceio.library.common.DeviceAttributesHelper;
 import backtraceio.library.common.FileHelper;
 import backtraceio.library.logger.BacktraceLogger;
@@ -178,12 +179,7 @@ public class BacktraceData {
         timestamp = report.timestamp;
         classifiers = report.exceptionTypeReport ? new String[]{report.classifier} : null;
         langVersion = System.getProperty("java.version"); //TODO: Fix problem with read Java version
-        try {
-            agentVersion = context.getPackageManager().getPackageInfo(context.getPackageName(), 0).versionName;
-        } catch (Exception e) {
-            BacktraceLogger.e(LOG_TAG, "Could not resolve package version name");
-            agentVersion = "";
-        }
+        agentVersion = BacktraceClient.Version;
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -28,8 +28,6 @@ import backtraceio.library.logger.BacktraceLogger;
 public class BacktraceAttributes {
     private static final transient String LOG_TAG = BacktraceAttributes.class.getSimpleName();
 
-    public static String LibraryVersion = null;
-
     /**
      * Get built-in primitive attributes
      */
@@ -129,7 +127,7 @@ public class BacktraceAttributes {
             // But we keep version attribute name as to not break any customer workflows
             this.attributes.put("version", version);
         }
-        this.attributes.put("backtrace.version", BacktraceClient.Version);
+        this.attributes.put("backtrace.version", BacktraceClient.version);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -129,7 +129,7 @@ public class BacktraceAttributes {
             // But we keep version attribute name as to not break any customer workflows
             this.attributes.put("version", version);
         }
-//        this.attributes.put("backtrace.version", BacktraceClient.Version);
+        this.attributes.put("backtrace.version", BacktraceClient.Version);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -64,6 +64,15 @@ public class BacktraceAttributes {
      */
     public BacktraceAttributes(Context context, BacktraceReport report, Map<String, Object>
             clientAttributes) {
+        this(context, report, clientAttributes, true);
+    }
+
+    public BacktraceAttributes(Context context, Map<String, Object> clientAttributes) {
+        this(context, null, clientAttributes, false);
+    }
+
+    public BacktraceAttributes(Context context, BacktraceReport report, Map<String, Object>
+            clientAttributes, Boolean includeDynamicAttributes) {
         this.context = context;
         if (report != null) {
             this.convertReportAttributes(report);
@@ -76,8 +85,8 @@ public class BacktraceAttributes {
             BacktraceReport.concatAttributes(report, clientAttributes);
         }
         setAppInformation();
-        setDeviceInformation();
-        setScreenInformation();
+        setDeviceInformation(includeDynamicAttributes);
+        setScreenInformation(includeDynamicAttributes);
 
         // For tracking crash-free sessions we need to add
         // application.session and application.version to Backtrace attributes
@@ -93,7 +102,7 @@ public class BacktraceAttributes {
     /**
      * Set information about device eg. lang, model, brand, sdk, manufacturer, os version
      */
-    private void setDeviceInformation() {
+    private void setDeviceInformation(Boolean includeDynamicAttributes) {
         this.attributes.put("uname.version", Build.VERSION.RELEASE);
         this.attributes.put("culture", Locale.getDefault().getDisplayLanguage());
         this.attributes.put("build.type", BuildConfig.DEBUG ? "Debug" : "Release");
@@ -106,7 +115,7 @@ public class BacktraceAttributes {
         this.attributes.put("device.os_version", System.getProperty("os.version"));
 
         DeviceAttributesHelper deviceAttributesHelper = new DeviceAttributesHelper(this.context);
-        this.attributes.putAll(deviceAttributesHelper.getDeviceAttributes());
+        this.attributes.putAll(deviceAttributesHelper.getDeviceAttributes(includeDynamicAttributes));
     }
 
     private void setAppInformation() {
@@ -120,13 +129,13 @@ public class BacktraceAttributes {
             // But we keep version attribute name as to not break any customer workflows
             this.attributes.put("version", version);
         }
-        this.attributes.put("backtrace.version", BacktraceClient.Version);
+//        this.attributes.put("backtrace.version", BacktraceClient.Version);
     }
 
     /**
      * Set information about screen such as screen width, height, dpi, orientation
      */
-    private void setScreenInformation() {
+    private void setScreenInformation(Boolean includeDynamicAttributes) {
         WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
         Display display = wm.getDefaultDisplay();
         DisplayMetrics metrics = new DisplayMetrics();
@@ -134,6 +143,9 @@ public class BacktraceAttributes {
         this.attributes.put("screen.width", String.valueOf(metrics.widthPixels));
         this.attributes.put("screen.height", String.valueOf(metrics.heightPixels));
         this.attributes.put("screen.dpi", String.valueOf(metrics.densityDpi));
+        if(includeDynamicAttributes == false) {
+            return;
+        }
         this.attributes.put("screen.orientation", getScreenOrientation().toString());
         this.attributes.put("screen.brightness", String.valueOf(getScreenBrightness()));
     }

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -14,6 +14,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 
+import backtraceio.library.BacktraceClient;
 import backtraceio.library.BuildConfig;
 import backtraceio.library.common.BacktraceStringHelper;
 import backtraceio.library.common.DeviceAttributesHelper;
@@ -26,6 +27,8 @@ import backtraceio.library.logger.BacktraceLogger;
  */
 public class BacktraceAttributes {
     private static final transient String LOG_TAG = BacktraceAttributes.class.getSimpleName();
+
+    public static String LibraryVersion = null;
 
     /**
      * Get built-in primitive attributes
@@ -117,6 +120,7 @@ public class BacktraceAttributes {
             // But we keep version attribute name as to not break any customer workflows
             this.attributes.put("version", version);
         }
+        this.attributes.put("backtrace.version", BacktraceClient.Version);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceAttributes.java
@@ -143,7 +143,7 @@ public class BacktraceAttributes {
         this.attributes.put("screen.width", String.valueOf(metrics.widthPixels));
         this.attributes.put("screen.height", String.valueOf(metrics.heightPixels));
         this.attributes.put("screen.dpi", String.valueOf(metrics.densityDpi));
-        if(includeDynamicAttributes == false) {
+        if (includeDynamicAttributes == false) {
             return;
         }
         this.attributes.put("screen.orientation", getScreenOrientation().toString());


### PR DESCRIPTION
# Why

This diff: 
* fixes agent.version property used by the backtraceData to set reporter version,
* adds backtrace.version attribute to report attributes,
* removes invalid attributes from passing to the backtrace-database native method.