### PR TITLE
Update BacktraceQueueFileHelper.java

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceQueueFileHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceQueueFileHelper.java
@@ -51,7 +51,6 @@ public class BacktraceQueueFileHelper {
 
     public boolean add(byte[] bytes) {
         try {
-            int usedBytes = (int) this.usedBytes.invoke(breadcrumbStore);
             int breadcrumbLength = bytes.length;
 
             if (breadcrumbLength > 4096) {
@@ -61,8 +60,10 @@ public class BacktraceQueueFileHelper {
 
             // We clear the space we need from the QueueFile first to prevent
             // the QueueFile from expanding to accommodate the new breadcrumb
+            int usedBytes = (long) this.usedBytes.invoke(breadcrumbStore);
             while (!breadcrumbStore.isEmpty() && (usedBytes + breadcrumbLength) > maxQueueFileSizeBytes) {
                 breadcrumbStore.remove();
+                usedBytes = (long) this.usedBytes.invoke(breadcrumbStore);
             }
 
             breadcrumbStore.add(bytes);


### PR DESCRIPTION
There's a situation where the breadcrumb file gets erased completely because `usedBytes` isn't updated in the while loop