### PR TITLE
Upgrade gson version

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -65,7 +65,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.8.5'
+    implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.12'


### PR DESCRIPTION
https://ossindex.sonatype.org/vulnerability/sonatype-2021-1694?component-type=maven&component-name=com.google.code.gson%2Fgson&utm_source=ossindex-client&utm_medium=integration&utm_content=1.7.0