### PR TITLE
Update build.gradle

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -34,7 +34,7 @@ android {
     }
     
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_1_6
         targetCompatibility JavaVersion.VERSION_1_6
     }
 

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -32,6 +32,11 @@ android {
             abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
         }
     }
+    
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_6
+    }
 
     buildTypes {
         buildTypes {


### PR DESCRIPTION
Problem in Unreal builds:

```
UATHelper: Packaging (Android (ASTC)):   * What went wrong:
UATHelper: Packaging (Android (ASTC)):   Execution failed for task ':app:mergeExtDexDebug'.
UATHelper: Packaging (Android (ASTC)):   > Could not resolve all files for configuration ':app:debugRuntimeClasspath'.
UATHelper: Packaging (Android (ASTC)):      > Failed to transform backtrace-library-3.7.3.aar (com.github.backtrace-labs.backtrace-android:backtrace-library:3.7.3) to match attributes {artifactType=android-dex, dexing-enable-desugaring=false, dexing-incremental-desugaring-v2=false, dexing-is-debuggable=true, dexing-min-sdk=21, org.gradle.category=library, or
g.gradle.dependency.bundling=external, org.gradle.libraryelements=aar, org.gradle.status=release, org.gradle.usage=java-runtime}.
UATHelper: Packaging (Android (ASTC)):         > Execution failed for DexingNoClasspathTransform: C:\Users\Mac Clark\.gradle\caches\transforms-2\files-2.1\58f91da303ddcb56a3e5a784fff8fa7b\backtrace-library-3.7.3-runtime.jar.
UATHelper: Packaging (Android (ASTC)):            > Error while dexing.
UATHelper: Packaging (Android (ASTC)):              The dependency contains Java 8 bytecode. Please enable desugaring by adding the following to build.gradle
UATHelper: Packaging (Android (ASTC)):              android {
UATHelper: Packaging (Android (ASTC)):                  compileOptions {
UATHelper: Packaging (Android (ASTC)):                      sourceCompatibility 1.8
UATHelper: Packaging (Android (ASTC)):                      targetCompatibility 1.8
UATHelper: Packaging (Android (ASTC)):                  }
UATHelper: Packaging (Android (ASTC)):              }
UATHelper: Packaging (Android (ASTC)):              See https://developer.android.com/studio/write/java8-support.html for details. Alternatively, increase the minSdkVersion to 26 or above.
```

