### PR TITLE
Handle corrupt or empty database records

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -415,7 +415,7 @@ public class BacktraceDatabase implements Database {
 
         for (File file : files) {
             BacktraceDatabaseRecord record = BacktraceDatabaseRecord.readFromFile(file);
-            if (!record.valid()) {
+            if (record == null || !record.valid()) {
                 record.delete();
                 continue;
             }


### PR DESCRIPTION
In cases where a crash record file is corrupted or empty, `BacktraceDatabaseRecord.readFromFile` may return null, causing a crash when the result accessed

This PR adds handling for this case by treating null return values as an invalid record