### PR TITLE
Unique event name override

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ BacktraceExceptionHandler.enable(backtraceClient);
 backtraceClient.enableAnr();
 
 // Enable Crash Free metrics
-backtraceClient.metrics.enable(new BacktraceMetricsSettings(credentials));
+backtraceClient.metrics.enable();
 ```
 
 ### Kotlin
@@ -64,7 +64,7 @@ BacktraceExceptionHandler.enable(backtraceClient)
 backtraceClient.enableAnr()
 
 // Enable Crash Free metrics
-backtraceClient.metrics.enable(BacktraceMetricsSettings(credentials))
+backtraceClient.metrics.enable()
 ```
 
 ## Documentation

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
@@ -12,7 +12,7 @@ import org.junit.runner.RunWith;
 public class BacktraceCredentialsTest {
 
     private final String fakeUniverse = "universe";
-    private final String fakeToken = "aaaaabbbbbccccf82668682e69f59b38e0a853bed941e08e85f4bf5eb2c5458";
+    private final String fakeToken = "aaaaabbbbbccccf82668682e69f59b38e0a853bed941e08e85f4bf5eb2c54584";
     private final String legacyUrl = "https://" + fakeUniverse + ".sp.backtrace.io:6098/post?format=json&token=" + fakeToken;
     private final String url = "https://submit.backtrace.io/" + fakeUniverse + "/" + fakeToken + "/json";
     private final String urlPrefix = "https://" + fakeUniverse + ".sp.backtrace.io:6098";

--- a/backtrace-library/src/androidTest/java/backtraceio/library/metrics/BacktraceMetricsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/metrics/BacktraceMetricsTest.java
@@ -76,7 +76,7 @@ public class BacktraceMetricsTest {
 
     @Test
     public void testDefaultUrl() {
-        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null);
+        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null, credentials);
         metrics.enable(new BacktraceMetricsSettings(credentials));
         TestCase.assertEquals(BacktraceMetrics.defaultBaseUrl, metrics.getBaseUrl());
     }
@@ -84,7 +84,7 @@ public class BacktraceMetricsTest {
     @Test
     public void testCustomUrl() {
         String customUrl = "https://my.custom.url";
-        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null);
+        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null, credentials);
         metrics.enable(new BacktraceMetricsSettings(credentials, customUrl));
         TestCase.assertEquals(customUrl, metrics.getBaseUrl());
     }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/metrics/BacktraceMetricsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/metrics/BacktraceMetricsTest.java
@@ -76,7 +76,7 @@ public class BacktraceMetricsTest {
 
     @Test
     public void testDefaultUrl() {
-        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null, credentials);
+        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null);
         metrics.enable(new BacktraceMetricsSettings(credentials));
         TestCase.assertEquals(BacktraceMetrics.defaultBaseUrl, metrics.getBaseUrl());
     }
@@ -84,7 +84,7 @@ public class BacktraceMetricsTest {
     @Test
     public void testCustomUrl() {
         String customUrl = "https://my.custom.url";
-        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null, credentials);
+        BacktraceMetrics metrics = new BacktraceMetrics(context, new HashMap<String, Object>(), null);
         metrics.enable(new BacktraceMetricsSettings(credentials, customUrl));
         TestCase.assertEquals(customUrl, metrics.getBaseUrl());
     }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -124,7 +124,7 @@ public class BacktraceCredentials {
         final String tokenQueryParam = "token=";
         String submissionUrl = getSubmissionUrl().toString();
         String token = submissionUrl.contains("submit.backtrace.io")
-                ? submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength + 1, submissionUrl.lastIndexOf("/"))
+                ? submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"))
                 : submissionUrl.substring(submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length(),
                     submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length() + tokenLength - 1);
         return token;

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -124,7 +124,7 @@ public class BacktraceCredentials {
         final String tokenQueryParam = "token=";
         String submissionUrl = getSubmissionUrl().toString();
         String token = submissionUrl.contains("submit.backtrace.io")
-                ? submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"))
+                ? submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength + 1, submissionUrl.lastIndexOf("/"))
                 : submissionUrl.substring(submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length(),
                     submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length() + tokenLength - 1);
         return token;

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -87,21 +87,16 @@ public class BacktraceCredentials {
     public String getUniverseName() {
         String submissionUrl = getSubmissionUrl().toString();
         final String backtraceSubmitUrl = "https://submit.backtrace.io/";
-        if (submissionUrl.startsWith(backtraceSubmitUrl))
-        {
+        if (submissionUrl.startsWith(backtraceSubmitUrl)) {
             int universeIndexStart = backtraceSubmitUrl.length();
             int universeIndexEnd = submissionUrl.indexOf('/', universeIndexStart);
-            if(universeIndexEnd == -1)
-            {
+            if (universeIndexEnd == -1) {
                 throw new IllegalArgumentException("Invalid Backtrace URL");
             }
             return submissionUrl.substring(universeIndexStart, universeIndexEnd);
-        }
-        else
-        {
+        } else {
             final String backtraceDomain = "backtrace.io";
-            if (submissionUrl.indexOf(backtraceDomain) == -1)
-            {
+            if (submissionUrl.indexOf(backtraceDomain) == -1) {
                 throw new IllegalArgumentException("Invalid Backtrace URL");
             }
 
@@ -123,7 +118,7 @@ public class BacktraceCredentials {
         final int tokenLength = 64;
         final String tokenQueryParam = "token=";
         String submissionUrl = getSubmissionUrl().toString();
-        if(submissionUrl.contains("submit.backtrace.io")) {
+        if (submissionUrl.contains("submit.backtrace.io")) {
             return submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"));
         }
         final int tokenQueryParamStartIndex = submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length();

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -123,10 +123,10 @@ public class BacktraceCredentials {
         final int tokenLength = 64;
         final String tokenQueryParam = "token=";
         String submissionUrl = getSubmissionUrl().toString();
-        String token = submissionUrl.contains("submit.backtrace.io")
-                ? submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"))
-                : submissionUrl.substring(submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length(),
-                    submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length() + tokenLength - 1);
-        return token;
+        if(submissionUrl.contains("submit.backtrace.io")) {
+            return submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"));
+        }
+        final int tokenQueryParamStartIndex = submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length();
+        return submissionUrl.substring(tokenQueryParamStartIndex, tokenQueryParamStartIndex + tokenLength);
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -238,7 +238,7 @@ public class BacktraceBase implements Client {
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
-        this.metrics = new BacktraceMetrics(context, attributes, backtraceApi, credentials);
+        this.metrics = new BacktraceMetrics(context, attributes, backtraceApi);
     }
 
     public native void crash();

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -238,7 +238,7 @@ public class BacktraceBase implements Client {
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
-        this.metrics = new BacktraceMetrics(context, attributes, backtraceApi);
+        this.metrics = new BacktraceMetrics(context, attributes, backtraceApi, credentials);
     }
 
     public native void crash();

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
@@ -13,11 +13,29 @@ import backtraceio.library.services.BacktraceMetrics;
 public interface Metrics {
 
     /**
+     * Enables metrics with BacktraceClient's credentials.
+     */
+    void enable();
+
+    /**
+     * Enables metrics with BacktraceClient's credentials and a custom session user identifier.
+     * @param defaultUniqueEventName custom session user identifier
+     */
+    void enable(String defaultUniqueEventName);
+    /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     void enable(BacktraceMetricsSettings settings);
+
+    /**
+     * Enable metrics
+     *
+     * @param settings for Backtrace metrics
+     * @param defaultUniqueEventName custom session user identifier
+     */
+    void enable(BacktraceMetricsSettings settings, String defaultUniqueEventName);
 
     /**
      * Send all outgoing messages (unique and summed) currently queued

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
@@ -13,29 +13,11 @@ import backtraceio.library.services.BacktraceMetrics;
 public interface Metrics {
 
     /**
-     * Enables metrics with BacktraceClient's credentials.
-     */
-    void enable();
-
-    /**
-     * Enables metrics with BacktraceClient's credentials and a custom session user identifier.
-     * @param defaultUniqueEventName custom session user identifier
-     */
-    void enable(String defaultUniqueEventName);
-    /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     void enable(BacktraceMetricsSettings settings);
-
-    /**
-     * Enable metrics
-     *
-     * @param settings for Backtrace metrics
-     * @param defaultUniqueEventName custom session user identifier
-     */
-    void enable(BacktraceMetricsSettings settings, String defaultUniqueEventName);
 
     /**
      * Send all outgoing messages (unique and summed) currently queued

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Metrics.java
@@ -13,12 +13,31 @@ import backtraceio.library.services.BacktraceMetrics;
 public interface Metrics {
 
     /**
+     * Enables metrics with BacktraceClient's credentials.
+     */
+    void enable();
+
+    /**
+     * Enables metrics with BacktraceClient's credentials and a custom session user identifier.
+     * @param defaultUniqueEventName custom session user identifier
+     */
+    void enable(String defaultUniqueEventName);
+    
+    /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     void enable(BacktraceMetricsSettings settings);
 
+    /**
+     * Enable metrics
+     *
+     * @param settings for Backtrace metrics
+     * @param defaultUniqueEventName custom session user identifier
+     */
+    void enable(BacktraceMetricsSettings settings, String defaultUniqueEventName);
+    
     /**
      * Send all outgoing messages (unique and summed) currently queued
      */

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -3,10 +3,12 @@ package backtraceio.library.services;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.common.BacktraceStringHelper;
 import backtraceio.library.common.BacktraceTimeHelper;
 import backtraceio.library.events.EventsOnServerResponseEventListener;
@@ -109,6 +111,11 @@ public final class BacktraceMetrics implements Metrics {
      * Backtrace API class for metrics sending
      */
     private final Api backtraceApi;
+    
+    /**
+     * Backtrace API credentials
+     */
+    private final BacktraceCredentials credentials;
 
     /**
      * Create new Backtrace metrics instance
@@ -117,18 +124,40 @@ public final class BacktraceMetrics implements Metrics {
      * @param customReportAttributes Backtrace client custom report attributes (must be nonnull)
      * @param backtraceApi           Backtrace API for metrics sending
      */
-    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi) {
+    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi, BacktraceCredentials credentials) {
         this.context = context;
         this.customReportAttributes = customReportAttributes;
         this.backtraceApi = backtraceApi;
+        this.credentials = credentials;
     }
 
+    /**
+     * Enables metrics with BacktraceClient's credentials.
+     */
+    public void enable() {
+        enable(new BacktraceMetricsSettings(this.credentials), defaultUniqueEventName);
+    }
+
+    /**
+     * Enables metrics with BacktraceClient's credentials and overrides default unique event name.
+     */
+    public void enable(String defaultUniqueEventName) {
+        enable(new BacktraceMetricsSettings(this.credentials, defaultUniqueEventName));
+    }
     /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     public void enable(BacktraceMetricsSettings settings) {
+        enable(settings, defaultUniqueEventName);
+    }
+
+    public void enable(BacktraceMetricsSettings settings, String uniqueEventName) {
+        if(uniqueEventName == null || uniqueEventName.length() == 0) {
+            throw new IllegalArgumentException("Unique event name must be defined!");
+        }
+        setStartupUniqueEventName(uniqueEventName);
         this.settings = settings;
         BacktraceAttributes.enableMetrics();
 

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -1,6 +1,7 @@
 package backtraceio.library.services;
 
 import android.content.Context;
+
 import androidx.annotation.NonNull;
 
 import java.security.InvalidParameterException;
@@ -111,7 +112,7 @@ public final class BacktraceMetrics implements Metrics {
      * Backtrace API class for metrics sending
      */
     private final Api backtraceApi;
-    
+
     /**
      * Backtrace API credentials
      */
@@ -144,6 +145,7 @@ public final class BacktraceMetrics implements Metrics {
     public void enable(String defaultUniqueEventName) {
         enable(new BacktraceMetricsSettings(this.credentials, defaultUniqueEventName));
     }
+
     /**
      * Enable metrics
      *
@@ -154,7 +156,7 @@ public final class BacktraceMetrics implements Metrics {
     }
 
     public void enable(BacktraceMetricsSettings settings, String uniqueEventName) {
-        if(uniqueEventName == null || uniqueEventName.length() == 0) {
+        if (uniqueEventName == null || uniqueEventName.length() == 0) {
             throw new IllegalArgumentException("Unique event name must be defined!");
         }
         setStartupUniqueEventName(uniqueEventName);

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -4,7 +4,6 @@ import android.content.Context;
 
 import androidx.annotation.NonNull;
 
-import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -3,10 +3,12 @@ package backtraceio.library.services;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
+import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
+import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.common.BacktraceStringHelper;
 import backtraceio.library.common.BacktraceTimeHelper;
 import backtraceio.library.events.EventsOnServerResponseEventListener;
@@ -111,24 +113,51 @@ public final class BacktraceMetrics implements Metrics {
     private final Api backtraceApi;
 
     /**
+     * Backtrace API credentials
+     */
+    private final BacktraceCredentials credentials;
+
+    /**
      * Create new Backtrace metrics instance
      *
      * @param context                Application context
      * @param customReportAttributes Backtrace client custom report attributes (must be nonnull)
      * @param backtraceApi           Backtrace API for metrics sending
      */
-    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi) {
+    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi, BacktraceCredentials credentials) {
         this.context = context;
         this.customReportAttributes = customReportAttributes;
         this.backtraceApi = backtraceApi;
+        this.credentials = credentials;
     }
 
+    /**
+     * Enables metrics with BacktraceClient's credentials.
+     */
+    public void enable() {
+        enable(new BacktraceMetricsSettings(this.credentials), defaultUniqueEventName);
+    }
+
+    /**
+     * Enables metrics with BacktraceClient's credentials and overrides default unique event name.
+     */
+    public void enable(String defaultUniqueEventName) {
+        enable(new BacktraceMetricsSettings(this.credentials, defaultUniqueEventName));
+    }
     /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     public void enable(BacktraceMetricsSettings settings) {
+        enable(settings, defaultUniqueEventName);
+    }
+
+    public void enable(BacktraceMetricsSettings settings, String uniqueEventName) {
+        if(uniqueEventName == null || uniqueEventName.length() == 0) {
+            throw new IllegalArgumentException("Unique event name must be defined!");
+        }
+        setStartupUniqueEventName(uniqueEventName);
         this.settings = settings;
         BacktraceAttributes.enableMetrics();
 

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -3,12 +3,10 @@ package backtraceio.library.services;
 import android.content.Context;
 import androidx.annotation.NonNull;
 
-import java.security.InvalidParameterException;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedDeque;
 
-import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.common.BacktraceStringHelper;
 import backtraceio.library.common.BacktraceTimeHelper;
 import backtraceio.library.events.EventsOnServerResponseEventListener;
@@ -113,51 +111,24 @@ public final class BacktraceMetrics implements Metrics {
     private final Api backtraceApi;
 
     /**
-     * Backtrace API credentials
-     */
-    private final BacktraceCredentials credentials;
-
-    /**
      * Create new Backtrace metrics instance
      *
      * @param context                Application context
      * @param customReportAttributes Backtrace client custom report attributes (must be nonnull)
      * @param backtraceApi           Backtrace API for metrics sending
      */
-    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi, BacktraceCredentials credentials) {
+    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi) {
         this.context = context;
         this.customReportAttributes = customReportAttributes;
         this.backtraceApi = backtraceApi;
-        this.credentials = credentials;
     }
 
-    /**
-     * Enables metrics with BacktraceClient's credentials.
-     */
-    public void enable() {
-        enable(new BacktraceMetricsSettings(this.credentials), defaultUniqueEventName);
-    }
-
-    /**
-     * Enables metrics with BacktraceClient's credentials and overrides default unique event name.
-     */
-    public void enable(String defaultUniqueEventName) {
-        enable(new BacktraceMetricsSettings(this.credentials, defaultUniqueEventName));
-    }
     /**
      * Enable metrics
      *
      * @param settings for Backtrace metrics
      */
     public void enable(BacktraceMetricsSettings settings) {
-        enable(settings, defaultUniqueEventName);
-    }
-
-    public void enable(BacktraceMetricsSettings settings, String uniqueEventName) {
-        if(uniqueEventName == null || uniqueEventName.length() == 0) {
-            throw new IllegalArgumentException("Unique event name must be defined!");
-        }
-        setStartupUniqueEventName(uniqueEventName);
         this.settings = settings;
         BacktraceAttributes.enableMetrics();
 

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -102,8 +102,7 @@ public class MainActivity extends AppCompatActivity {
         // Enable handling of native crashes
         database.setupNativeIntegration(backtraceClient, credentials, true);
 
-        final String baseUrl = submissionUrl.contains("backtrace.sp") ? "https://events-test.backtrace.io" : "https://events.backtrace.io";
-        backtraceClient.metrics.enable(new BacktraceMetricsSettings(credentials, baseUrl));
+        backtraceClient.metrics.enable();
 
         // Enable ANR detection
         backtraceClient.enableAnr(anrTimeout);

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -46,7 +46,7 @@
         android:id="@+id/dumpWithoutCrash"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="DumpWithoutCrash"
+        android:text="Generate sample crash report"
         android:onClick="dumpWithoutCrash"
         app:layout_constraintBottom_toTopOf="@+id/anr"
         app:layout_constraintEnd_toEndOf="parent"

--- a/example-app/src/main/res/layout/activity_main.xml
+++ b/example-app/src/main/res/layout/activity_main.xml
@@ -46,7 +46,7 @@
         android:id="@+id/dumpWithoutCrash"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Generate sample crash report"
+        android:text="DumpWithoutCrash"
         android:onClick="dumpWithoutCrash"
         app:layout_constraintBottom_toTopOf="@+id/anr"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
# Why

This diff adds an option to override default unique event name. In some systems we have a different attributes responsible for generating unique user attribute that we should use on the service side