### PR TITLE
Handle invalid server URL

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
@@ -1,8 +1,10 @@
 package backtraceio.library;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import android.net.Uri;
+
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 
 import org.junit.Test;
@@ -75,5 +77,17 @@ public class BacktraceCredentialsTest {
     public void createBacktraceCredentialsWithLegacyUriAndGetSubmissionToken() {
         BacktraceCredentials backtraceCredentials = new BacktraceCredentials(Uri.parse(legacyUrl));
         assertEquals(fakeToken, backtraceCredentials.getSubmissionToken());
+    }
+
+    @Test
+    public void generateEmptyTokenForInvalidSubmissionUrl() {
+        BacktraceCredentials backtraceCredentials = new BacktraceCredentials("https://submit.backtrace.io/");
+        assertTrue(backtraceCredentials.getSubmissionToken() == null);
+    }
+
+    @Test
+    public void generateEmptyTokenForInvalidLegacyUrl() {
+        BacktraceCredentials backtraceCredentials = new BacktraceCredentials("https://universe.sp.backtrace.io/");
+        assertTrue(backtraceCredentials.getSubmissionToken() == null);
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceCredentialsTest.java
@@ -1,6 +1,7 @@
 package backtraceio.library;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import android.net.Uri;
@@ -82,12 +83,12 @@ public class BacktraceCredentialsTest {
     @Test
     public void generateEmptyTokenForInvalidSubmissionUrl() {
         BacktraceCredentials backtraceCredentials = new BacktraceCredentials("https://submit.backtrace.io/");
-        assertTrue(backtraceCredentials.getSubmissionToken() == null);
+        assertNull(backtraceCredentials.getSubmissionToken());
     }
 
     @Test
     public void generateEmptyTokenForInvalidLegacyUrl() {
         BacktraceCredentials backtraceCredentials = new BacktraceCredentials("https://universe.sp.backtrace.io/");
-        assertTrue(backtraceCredentials.getSubmissionToken() == null);
+        assertNull(backtraceCredentials.getSubmissionToken());
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceCredentials.java
@@ -118,10 +118,19 @@ public class BacktraceCredentials {
         final int tokenLength = 64;
         final String tokenQueryParam = "token=";
         String submissionUrl = getSubmissionUrl().toString();
+        final int tokenEndIndex = submissionUrl.lastIndexOf("/");
         if (submissionUrl.contains("submit.backtrace.io")) {
-            return submissionUrl.substring(submissionUrl.lastIndexOf("/") - tokenLength, submissionUrl.lastIndexOf("/"));
+            if (tokenEndIndex - tokenLength < 0) {
+                return null;
+            }
+            return submissionUrl.substring(tokenEndIndex - tokenLength, tokenEndIndex);
         }
-        final int tokenQueryParamStartIndex = submissionUrl.indexOf(tokenQueryParam) + tokenQueryParam.length();
-        return submissionUrl.substring(tokenQueryParamStartIndex, tokenQueryParamStartIndex + tokenLength);
+        final int tokenQueryParamStartIndex = submissionUrl.indexOf(tokenQueryParam);
+        if (tokenQueryParamStartIndex == -1) {
+            return null;
+        }
+
+        final int tokenParamStartIndex = tokenQueryParamStartIndex + tokenQueryParam.length();
+        return submissionUrl.substring(tokenParamStartIndex, tokenParamStartIndex + tokenLength);
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -567,14 +567,15 @@ public class BacktraceBase implements Client {
         return new OnServerResponseEventListener() {
             @Override
             public void onEvent(BacktraceResult backtraceResult) {
-                if (customCallback != null) {
-                    customCallback.onEvent(backtraceResult);
-                }
                 if (record != null) {
                     record.close();
                 }
                 if (backtraceResult != null && backtraceResult.status == BacktraceResultStatus.Ok) {
                     database.delete(record);
+                }
+
+                if (customCallback != null) {
+                    customCallback.onEvent(backtraceResult);
                 }
             }
         };


### PR DESCRIPTION
# Why

This diff handles invalid submission URL/token provided by the user to the BacktraceCredentials. In some situations when we need to :
* create a fake client for testing purposes,
* use database connection to determine when to send reports

the URL provided by the user might not be valid. This diff handles a situation when the user doesn't pass a valid credentials to the BacktraceClient