### PR TITLE
Session id example

### DIFF
--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -97,12 +97,11 @@ public class MainActivity extends AppCompatActivity {
         BacktraceClient backtraceClient = new BacktraceClient(context, credentials, database, attributes, attachments);
 
         BacktraceExceptionHandler.enable(backtraceClient);
-        // backtraceClient.send("test");
+
+        backtraceClient.metrics.enable();
 
         // Enable handling of native crashes
         database.setupNativeIntegration(backtraceClient, credentials, true);
-
-        backtraceClient.metrics.enable();
 
         // Enable ANR detection
         backtraceClient.enableAnr(anrTimeout);


### PR DESCRIPTION
# Why

This diff fixes session id in the sample application - by doing it in the wrong order, native errors might miss information about the current application session