### PR TITLE
Handle invalid Crashpad handler path

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -177,12 +177,11 @@ public class BacktraceDatabase implements Database {
         }
         // Path to Crashpad native handler
         String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + _crashpadHandlerName;
-        File handlerPathFile = new File(handlerPath);
-        if (!handlerPathFile.exists()) {
+        if (!FileHelper.isFileExists(handlerPath)) {
             return false;
         }
 
-        // setup default native attribtues
+        // setup default native attributes
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, client.attributes);
         crashpadAttributes.attributes.put(BacktraceAttributeConsts.ErrorType, BacktraceAttributeConsts.CrashAttributeType);
         String[] keys = crashpadAttributes.attributes.keySet().toArray(new String[0]);

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -177,6 +177,10 @@ public class BacktraceDatabase implements Database {
         }
         // Path to Crashpad native handler
         String handlerPath = _applicationContext.getApplicationInfo().nativeLibraryDir + _crashpadHandlerName;
+        File handlerPathFile = new File(handlerPath);
+        if (!handlerPathFile.exists()) {
+            return false;
+        }
 
         // setup default native attribtues
         BacktraceAttributes crashpadAttributes = new BacktraceAttributes(_applicationContext, client.attributes);


### PR DESCRIPTION
# Why

Backtrace-android must start a separate process in the system to handle crashes. This can be done via the crashpad handler path. By default we should always know the path to the handler, however, there are situations where libraries like crashpad handler are hidden or unavailable. Because of that, we have false positive information about the started process. 

This diff checks if the crashpad handler exists before we start the integration