### PR TITLE
Update permission Helpers

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/AndroidManifest.xml
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/AndroidManifest.xml
@@ -2,5 +2,6 @@
     package="backtraceio.library">
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <application/>
 </manifest>

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBroadcastReceiver.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBroadcastReceiver.java
@@ -5,7 +5,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
+
+import org.jetbrains.annotations.NotNull;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -20,7 +21,7 @@ public class BacktraceBroadcastReceiver extends BroadcastReceiver {
     private static final transient String LOG_TAG = BacktraceBroadcastReceiver.class.getSimpleName();
     private final BacktraceBreadcrumbs backtraceBreadcrumbs;
 
-    public BacktraceBroadcastReceiver(@NonNull BacktraceBreadcrumbs backtraceBreadcrumbs) {
+    public BacktraceBroadcastReceiver(@NotNull BacktraceBreadcrumbs backtraceBreadcrumbs) {
         this.backtraceBreadcrumbs = backtraceBreadcrumbs;
     }
 

--- a/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/DeviceAttributesHelper.java
@@ -5,6 +5,7 @@ import static android.content.Context.ACTIVITY_SERVICE;
 import android.annotation.SuppressLint;
 import android.app.ActivityManager;
 import android.bluetooth.BluetoothAdapter;
+import android.bluetooth.BluetoothManager;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
@@ -125,9 +126,12 @@ public class DeviceAttributesHelper {
         if (!PermissionHelper.isPermissionForBluetoothGranted(this.context)) {
             return BluetoothStatus.NOT_PERMITTED;
         }
-        BluetoothAdapter mBluetoothAdapter = BluetoothAdapter.getDefaultAdapter();
-        if (mBluetoothAdapter.isEnabled()) {
-            return BluetoothStatus.ENABLED;
+        BluetoothManager mBluetoothManager = (BluetoothManager) this.context.getSystemService(Context.BLUETOOTH_SERVICE);
+        if (mBluetoothManager != null) {
+            BluetoothAdapter mBluetoothAdapter = mBluetoothManager.getAdapter();
+            if (mBluetoothAdapter != null && mBluetoothAdapter.isEnabled()) {
+                return BluetoothStatus.ENABLED;
+            }
         }
         return BluetoothStatus.DISABLED;
     }

--- a/backtrace-library/src/main/java/backtraceio/library/common/PermissionHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/PermissionHelper.java
@@ -3,7 +3,7 @@ package backtraceio.library.common;
 import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
-import androidx.core.content.ContextCompat;
+import android.os.Build;
 
 /***
  * Helper class for checking permissions
@@ -11,38 +11,58 @@ import androidx.core.content.ContextCompat;
 public class PermissionHelper {
 
     /**
-     * Check is permission for Bluetooth is granted (permission.BLUETOOTH)
+     * Check if permission for Bluetooth is granted (permission.BLUETOOTH)
      *
      * @return true if permission is granted
+     * For Build versions prior to Android 6.0, permissions are granted during installation
      */
     public static boolean isPermissionForBluetoothGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context,
-                Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.checkSelfPermission(Manifest.permission.BLUETOOTH) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 
-
     /**
-     * Check is permission for Bluetooth is granted (permission.INTERNET)
+     * Check if permission for Internet is granted (permission.INTERNET)
      *
      * @return true if permission is granted
+     * For Build versions prior to Android 6.0, permissions are granted during installation
      */
     public static boolean isPermissionForInternetGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context,
-                Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED;
-    }
-
-    public static boolean isPermissionForAccessWifiStateGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context,
-                Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.checkSelfPermission(Manifest.permission.INTERNET) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 
     /**
-     * Check is permission for Read external storage grande
+     * Check if permission for Wifi state is granted (permission.ACCESS_WIFI_STATE)
      *
      * @return true if permission is granted
+     * For Build versions prior to Android 6.0, permissions are granted during installation
+     */
+    public static boolean isPermissionForAccessWifiStateGranted(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.checkSelfPermission(Manifest.permission.ACCESS_WIFI_STATE) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
+    }
+
+    /**
+     * Check if permission to Read external storage is granted (permission.READ_EXTERNAL_STORAGE)
+     *
+     * @return true if permission is granted
+     * For Build versions prior to Android 6.0, permissions are granted during installation
      */
     public static boolean isPermissionForReadExternalStorageGranted(Context context) {
-        return ContextCompat.checkSelfPermission(context,
-                Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return context.checkSelfPermission(Manifest.permission.READ_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED;
+        } else {
+            return true;
+        }
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceMetrics.java
@@ -2,7 +2,7 @@ package backtraceio.library.services;
 
 import android.content.Context;
 
-import androidx.annotation.NonNull;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -124,7 +124,7 @@ public final class BacktraceMetrics implements Metrics {
      * @param customReportAttributes Backtrace client custom report attributes (must be nonnull)
      * @param backtraceApi           Backtrace API for metrics sending
      */
-    public BacktraceMetrics(Context context, @NonNull Map<String, Object> customReportAttributes, Api backtraceApi, BacktraceCredentials credentials) {
+    public BacktraceMetrics(Context context, @NotNull Map<String, Object> customReportAttributes, Api backtraceApi, BacktraceCredentials credentials) {
         this.context = context;
         this.customReportAttributes = customReportAttributes;
         this.backtraceApi = backtraceApi;

--- a/example-app/src/main/AndroidManifest.xml
+++ b/example-app/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="backtraceio.backtraceio">
-
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH" />
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
@@ -19,6 +22,4 @@
             </intent-filter>
         </activity>
     </application>
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
Our friends at RDC encountered issues with `androidx` dependency when using our SDK (PermissionHelper class) with client projects that don't depend on it.

This PR:
- Replaces androidx's ContextCompat with Context when checking for self permissions and returns granted when checking for self permissions in Android versions prior to Android 6.0
- Replaces deprecated BluetoothAdapter with BluetoothManager
- Adds missing ACCESS_WIFI_STATE and BLUETOOTH permissions to example app and Tests AndroidManifest.