### PR TITLE
Invalid intent flag #104

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Backtrace Android Release Notes
 
+## Version 3.7.8
+
+- Fixed missing breadcrumbs intent filter in SDK 33+.
+
 ## Version 3.7.7
 
 - Added a new attribute to native reports - `breadcrumbs.lastId`

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -6,8 +6,6 @@ import android.app.Application;
 import android.content.Context;
 import android.os.Build;
 
-import androidx.core.content.ContextCompat;
-
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -107,7 +107,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
 
         backtraceBroadcastReceiver = new BacktraceBroadcastReceiver(this);
 
-        if(Build.VERSION.SDK_INT >= 33) {
+        if (Build.VERSION.SDK_INT >= 33) {
             context.registerReceiver(backtraceBroadcastReceiver,
                     backtraceBroadcastReceiver.getIntentFilter(), RECEIVER_EXPORTED);
         } else {
@@ -356,6 +356,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
 
     /**
      * Determinate if Breadcrumbs are enabled.
+     *
      * @return true if breadcrumbs are enabled.
      */
     public boolean isEnabled() {

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -1,7 +1,12 @@
 package backtraceio.library.breadcrumbs;
 
+import static android.content.Context.RECEIVER_EXPORTED;
+
 import android.app.Application;
 import android.content.Context;
+import android.os.Build;
+
+import androidx.core.content.ContextCompat;
 
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -103,8 +108,14 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         }
 
         backtraceBroadcastReceiver = new BacktraceBroadcastReceiver(this);
-        context.registerReceiver(backtraceBroadcastReceiver,
-                backtraceBroadcastReceiver.getIntentFilter());
+
+        if(Build.VERSION.SDK_INT >= 33) {
+            context.registerReceiver(backtraceBroadcastReceiver,
+                    backtraceBroadcastReceiver.getIntentFilter(), RECEIVER_EXPORTED);
+        } else {
+            context.registerReceiver(backtraceBroadcastReceiver,
+                    backtraceBroadcastReceiver.getIntentFilter());
+        }
 
         if (enabledBreadcrumbTypes.contains(BacktraceBreadcrumbType.SYSTEM)) {
             backtraceComponentListener = new BacktraceComponentListener(this);

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -104,16 +104,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
             BacktraceLogger.d(LOG_TAG, "No breadcrumbs are enabled, not registering any new breadcrumb receivers");
             return;
         }
-
-        backtraceBroadcastReceiver = new BacktraceBroadcastReceiver(this);
-
-        if (Build.VERSION.SDK_INT >= 33) {
-            context.registerReceiver(backtraceBroadcastReceiver,
-                    backtraceBroadcastReceiver.getIntentFilter(), RECEIVER_EXPORTED);
-        } else {
-            context.registerReceiver(backtraceBroadcastReceiver,
-                    backtraceBroadcastReceiver.getIntentFilter());
-        }
+        registerBroadcastReceiver();
 
         if (enabledBreadcrumbTypes.contains(BacktraceBreadcrumbType.SYSTEM)) {
             backtraceComponentListener = new BacktraceComponentListener(this);
@@ -123,6 +114,18 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
                 backtraceActivityLifecycleListener = new BacktraceActivityLifecycleListener(this);
                 ((Application) context).registerActivityLifecycleCallbacks(backtraceActivityLifecycleListener);
             }
+        }
+    }
+
+    private void registerBroadcastReceiver() {
+        backtraceBroadcastReceiver = new BacktraceBroadcastReceiver(this);
+
+        if (Build.VERSION.SDK_INT >= 33) {
+            context.registerReceiver(backtraceBroadcastReceiver,
+                    backtraceBroadcastReceiver.getIntentFilter(), RECEIVER_EXPORTED);
+        } else {
+            context.registerReceiver(backtraceBroadcastReceiver,
+                    backtraceBroadcastReceiver.getIntentFilter());
         }
     }
 

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -5,7 +5,7 @@ android {
     defaultConfig {
         applicationId "backtraceio.backtraceio"
         minSdkVersion 21
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'


### PR DESCRIPTION
# Why

We need to pass receiver flags from Android SDK 33+ to register a custom broadcast receiver. Otherwise, on Android SDK 34+, a missing flag will generate an error. 

This fixes a potential exception thrown in the Android SDK 34+ when no receiver flags are passed.  