### PR TITLE
Remove check of throwable type in uncaughtException handler

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/models/SkipExceptionHandler.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/models/SkipExceptionHandler.java
@@ -1,0 +1,10 @@
+package backtraceio.library.models;
+
+public class SkipExceptionHandler implements Thread.UncaughtExceptionHandler {
+    @Override
+    public void uncaughtException(Thread t, Throwable e) {
+        System.err.println("Exception caught in thread " + t.getName() + ":");
+        e.printStackTrace();
+        System.err.println("Exception skipped");
+    }
+}

--- a/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
@@ -125,10 +125,9 @@ public class UncaughtExceptionHandlerTest {
         // THEN
         assertNotNull(testedAtomicReportData);
         final BacktraceData testedReportData = testedAtomicReportData.get();
-        assertEquals("java.lang.OutOfMemoryError", testedReportData.report.exception.getMessage());
         assertNull(testedReportData.report.message);
         assertTrue(testedReportData.report.diagnosticStack.size() > 0);
-        assertEquals("java.lang.Exception", testedReportData.report.classifier);
+        assertEquals("java.lang.OutOfMemoryError", testedReportData.report.classifier);
         assertEquals("Unhandled Exception", testedReportData.report.attributes.get("error.type"));
         assertTrue(testedReportData.report.exceptionTypeReport);
     }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
@@ -1,0 +1,135 @@
+package backtraceio.library.models;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.content.Context;
+
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import net.jodah.concurrentunit.Waiter;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import backtraceio.library.BacktraceClient;
+import backtraceio.library.BacktraceCredentials;
+import backtraceio.library.models.types.BacktraceResultStatus;
+
+public class UncaughtExceptionHandlerTest {
+
+    private Context context;
+    private BacktraceCredentials credentials;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        credentials = new BacktraceCredentials("https://example-endpoint.com/", "");
+    }
+
+    private static void setRootHandler(Thread.UncaughtExceptionHandler customRootHandler, Thread.UncaughtExceptionHandler newRootHandler) {
+        try {
+            Field field = BacktraceExceptionHandler.class.getDeclaredField("rootHandler");
+            field.setAccessible(true);
+            field.set(customRootHandler, newRootHandler);
+        } catch (NoSuchFieldException | IllegalAccessException e) {
+            e.printStackTrace();
+        }
+    }
+
+
+    private static BacktraceExceptionHandler createBacktraceExceptionHandler(BacktraceClient client) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException, InstantiationException {
+        Constructor<BacktraceExceptionHandler> constructor = BacktraceExceptionHandler.class.getDeclaredConstructor(BacktraceClient.class);
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        BacktraceExceptionHandler exceptionHandler = constructor.newInstance(client);
+        setRootHandler(exceptionHandler, new SkipExceptionHandler());
+        return exceptionHandler;
+    }
+
+    @Test()
+    public void testUncaughtException() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, InstantiationException {
+        // GIVEN
+        final Waiter waiter = new Waiter();
+        final Exception exception = new IllegalArgumentException("Test message");
+        final BacktraceClient client = new BacktraceClient(context, credentials);
+
+        final AtomicReference<BacktraceData> testedAtomicReportData = new AtomicReference<>();
+        client.setOnRequestHandler(data -> {
+            testedAtomicReportData.set(data);
+            waiter.resume();
+            return new BacktraceResult(data.report, data.report.message,
+                    BacktraceResultStatus.Ok);
+        });
+
+        final BacktraceExceptionHandler handler = createBacktraceExceptionHandler(client);
+
+        // WHEN
+        handler.uncaughtException(Thread.currentThread(), exception);
+
+        // WAIT FOR THE RESULT FROM ANOTHER THREAD
+        try {
+            waiter.await(5, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        // THEN
+        assertNotNull(testedAtomicReportData);
+        final BacktraceData testedReportData = testedAtomicReportData.get();
+        assertEquals("Test message", testedReportData.report.exception.getMessage());
+        assertNull(testedReportData.report.message);
+        assertTrue(testedReportData.report.diagnosticStack.size() > 0);
+        assertEquals("java.lang.IllegalArgumentException", testedReportData.report.classifier);
+        assertEquals("Unhandled Exception", testedReportData.report.attributes.get("error.type"));
+        assertTrue(testedReportData.report.exceptionTypeReport);
+    }
+
+    @Test
+    public void testUncaughtError() throws InvocationTargetException, NoSuchMethodException, IllegalAccessException, InstantiationException {
+        // GIVEN
+        final Waiter waiter = new Waiter();
+        final Error error = new OutOfMemoryError();
+        final BacktraceClient client = new BacktraceClient(context, credentials);
+
+        final AtomicReference<BacktraceData> testedAtomicReportData = new AtomicReference<>();
+        client.setOnRequestHandler(data -> {
+            testedAtomicReportData.set(data);
+            waiter.resume();
+            return new BacktraceResult(data.report, data.report.message,
+                    BacktraceResultStatus.Ok);
+        });
+
+        final BacktraceExceptionHandler handler = createBacktraceExceptionHandler(client);
+
+        // WHEN
+        handler.uncaughtException(Thread.currentThread(), error);
+
+        // WAIT FOR THE RESULT FROM ANOTHER THREAD
+        try {
+            waiter.await(5, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+
+        // THEN
+        assertNotNull(testedAtomicReportData);
+        final BacktraceData testedReportData = testedAtomicReportData.get();
+        assertEquals("java.lang.OutOfMemoryError", testedReportData.report.exception.getMessage());
+        assertNull(testedReportData.report.message);
+        assertTrue(testedReportData.report.diagnosticStack.size() > 0);
+        assertEquals("java.lang.Exception", testedReportData.report.classifier);
+        assertEquals("Unhandled Exception", testedReportData.report.attributes.get("error.type"));
+        assertTrue(testedReportData.report.exceptionTypeReport);
+    }
+}

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -39,7 +39,6 @@ public class BacktraceDatabase implements Database {
 
     private final String _crashpadHandlerName = "/libcrashpad_handler.so";
     private final String _crashpadDatabasePathPrefix = "/crashpad";
-
     private static boolean _timerBackgroundWork = false;
     private static Timer _timer;
     private transient final String LOG_TAG = BacktraceDatabase.class.getSimpleName();
@@ -410,6 +409,10 @@ public class BacktraceDatabase implements Database {
 
     public void delete(BacktraceDatabaseRecord record) {
         if (this.backtraceDatabaseContext == null) {
+            return;
+        }
+
+        if (record == null){
             return;
         }
         this.backtraceDatabaseContext.delete(record);

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -570,7 +570,8 @@ public class BacktraceBase implements Client {
                 if (record != null) {
                     record.close();
                 }
-                if (backtraceResult != null && backtraceResult.status == BacktraceResultStatus.Ok) {
+
+                if (backtraceResult != null && record != null && backtraceResult.status == BacktraceResultStatus.Ok) {
                     database.delete(record);
                 }
 

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
@@ -70,9 +70,8 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
             return (Exception) throwable;
         }
 
-        Exception exception = new Exception(throwable);
+        Exception exception = new Exception(throwable.toString(), throwable);
         exception.setStackTrace(throwable.getStackTrace());
-
         return exception;
     }
 

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
@@ -53,23 +53,18 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
     public void uncaughtException(final Thread thread, final Throwable throwable) {
         OnServerResponseEventListener callback = getCallbackToDefaultHandler(thread, throwable);
 
-        if (throwable instanceof Exception) {
-            BacktraceLogger.e(LOG_TAG, "Sending uncaught exception to Backtrace API", throwable);
-            BacktraceReport report = new BacktraceReport((Exception) throwable, BacktraceExceptionHandler.customAttributes);
-            report.attributes.put(BacktraceAttributeConsts.ErrorType, BacktraceAttributeConsts.UnhandledExceptionAttributeType);
-            this.client.send(report, callback);
-            BacktraceLogger.d(LOG_TAG, "Uncaught exception sent to Backtrace API");
-        }
-        BacktraceLogger.d(LOG_TAG, "Default uncaught exception handler");
+        BacktraceLogger.e(LOG_TAG, "Sending uncaught exception to Backtrace API", throwable);
+        BacktraceReport report = new BacktraceReport((Exception) throwable, BacktraceExceptionHandler.customAttributes);
+        report.attributes.put(BacktraceAttributeConsts.ErrorType, BacktraceAttributeConsts.UnhandledExceptionAttributeType);
+        this.client.send(report, callback);
+        BacktraceLogger.d(LOG_TAG, "Uncaught exception sent to Backtrace API");
+
         try {
             signal.await();
         } catch (Exception ex) {
             BacktraceLogger.e(LOG_TAG, "Exception during waiting for response", ex);
         }
-    }
-
-    private boolean isMainThread() {
-        return Looper.myLooper() == Looper.getMainLooper();
+        BacktraceLogger.d(LOG_TAG, "Default uncaught exception handler");
     }
 
     private OnServerResponseEventListener getCallbackToDefaultHandler(final Thread thread, final Throwable throwable) {

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
@@ -58,11 +58,11 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
         BacktraceLogger.d(LOG_TAG, "Uncaught exception sent to Backtrace API");
 
         try {
+            BacktraceLogger.d(LOG_TAG, "Default uncaught exception handler");
             signal.await();
         } catch (Exception ex) {
             BacktraceLogger.e(LOG_TAG, "Exception during waiting for response", ex);
         }
-        BacktraceLogger.d(LOG_TAG, "Default uncaught exception handler");
     }
 
     private Exception getCausedException(Throwable throwable) {
@@ -70,9 +70,7 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
             return (Exception) throwable;
         }
 
-        Exception exception = new Exception(throwable.toString(), throwable);
-        exception.setStackTrace(throwable.getStackTrace());
-        return exception;
+        return new UnhandledThrowableWrapper(throwable);
     }
 
     private OnServerResponseEventListener getCallbackToDefaultHandler(final Thread thread, final Throwable throwable) {

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceExceptionHandler.java
@@ -1,7 +1,5 @@
 package backtraceio.library.models;
 
-import android.os.Looper;
-
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
@@ -54,7 +52,7 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
         OnServerResponseEventListener callback = getCallbackToDefaultHandler(thread, throwable);
 
         BacktraceLogger.e(LOG_TAG, "Sending uncaught exception to Backtrace API", throwable);
-        BacktraceReport report = new BacktraceReport((Exception) throwable, BacktraceExceptionHandler.customAttributes);
+        BacktraceReport report = new BacktraceReport(this.getCausedException(throwable), BacktraceExceptionHandler.customAttributes);
         report.attributes.put(BacktraceAttributeConsts.ErrorType, BacktraceAttributeConsts.UnhandledExceptionAttributeType);
         this.client.send(report, callback);
         BacktraceLogger.d(LOG_TAG, "Uncaught exception sent to Backtrace API");
@@ -65,6 +63,17 @@ public class BacktraceExceptionHandler implements Thread.UncaughtExceptionHandle
             BacktraceLogger.e(LOG_TAG, "Exception during waiting for response", ex);
         }
         BacktraceLogger.d(LOG_TAG, "Default uncaught exception handler");
+    }
+
+    private Exception getCausedException(Throwable throwable) {
+        if (throwable instanceof Exception) {
+            return (Exception) throwable;
+        }
+
+        Exception exception = new Exception(throwable);
+        exception.setStackTrace(throwable.getStackTrace());
+
+        return exception;
     }
 
     private OnServerResponseEventListener getCallbackToDefaultHandler(final Thread thread, final Throwable throwable) {

--- a/backtrace-library/src/main/java/backtraceio/library/models/UnhandledThrowableWrapper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/UnhandledThrowableWrapper.java
@@ -1,0 +1,38 @@
+package backtraceio.library.models;
+
+
+import androidx.annotation.NonNull;
+
+public class UnhandledThrowableWrapper extends Exception {
+
+    private final transient Throwable instance;
+
+    public UnhandledThrowableWrapper(Throwable throwable) {
+        this.instance = throwable;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.instance.getMessage();
+    }
+
+    @Override
+    public String getLocalizedMessage() {
+        return this.instance.getLocalizedMessage();
+    }
+
+    @Override
+    public synchronized Throwable getCause() {
+        return this.instance.getCause();
+    }
+
+    @NonNull
+    @Override
+    public StackTraceElement[] getStackTrace() {
+        return this.instance.getStackTrace();
+    }
+
+    public String getClassifier() {
+        return this.instance.getClass().getCanonicalName();
+    }
+}

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
@@ -13,6 +13,7 @@ import backtraceio.library.models.BacktraceAttributeConsts;
 import backtraceio.library.models.BacktraceData;
 import backtraceio.library.models.BacktraceStackFrame;
 import backtraceio.library.models.BacktraceStackTrace;
+import backtraceio.library.models.UnhandledThrowableWrapper;
 
 /**
  * Captured application error
@@ -182,11 +183,17 @@ public class BacktraceReport {
         this.diagnosticStack = new BacktraceStackTrace(exception).getStackFrames();
 
         if (this.exceptionTypeReport && exception != null) {
-            this.classifier = exception.getClass().getCanonicalName();
+            this.classifier = getExceptionClassifier(exception);
         }
         this.setDefaultErrorTypeAttribute();
     }
 
+    public String getExceptionClassifier(Exception exception) {
+        if (exception instanceof UnhandledThrowableWrapper) {
+            return ((UnhandledThrowableWrapper) exception).getClassifier();
+        }
+        return exception.getClass().getCanonicalName();
+    }
     /**
      * To avoid serialization issues with custom exceptions, our goal is to always
      * prepare exception in a way potential serialization won't break it


### PR DESCRIPTION
This pull request addresses a specific issue related to the uncaughtException handler. Currently, the code checks if the throwable object is of type Exception. However, this prevents the registration of errors such as OutOfMemoryError, which do not extend from the Exception class.

In this pull request, I am proposing the removal of the check for the specific type Exception to ensure that errors like OutOfMemoryError are appropriately captured and handled.

Please review the changes at your earliest convenience. I believe this modification will improve the robustness of our error handling mechanism. This pull requests contains also unit tests for both cases: exception and error.