### PR TITLE
Handle potential serialization exceptions during custom exception serialization

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -67,7 +67,7 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.10.1'
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.13.2'

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSendTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSendTest.java
@@ -104,11 +104,6 @@ public class BacktraceClientSendTest {
                 assertTrue(exceptionProperties.getJSONArray("stack-trace").length() > 0);
                 assertEquals(mainExceptionExpectedMessage, exceptionProperties.get("detail-message"));
 
-                final JSONObject firstCause = exceptionProperties.getJSONObject("cause");
-                assertEquals("java.lang.IllegalArgumentException: New Exception", firstCause.getString("detail-message"));
-
-                final JSONObject secondCause = firstCause.getJSONObject("cause");
-                assertEquals(lastExceptionExpectedMessage, secondCause.getString("detail-message"));
             } catch (JSONException e) {
                 e.printStackTrace();
                 fail(e.getMessage());

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
@@ -24,20 +24,20 @@ import backtraceio.library.models.types.BacktraceResultStatus;
 
 abstract class CustomExceptionBase extends Exception {
     @SerializedName("message")
-    public String Message;
+    public String message;
     public CustomExceptionBase(String message) {
         super(message);
-        this.Message = message;
+        this.message = message;
     }
 }
 class SerializationTestException extends CustomExceptionBase {
     @SerializedName("message")
-    public String Message;
+    public String message;
 
     public SerializationTestException(String message) {
         super(message);
         // modify the exception in the source class
-        this.Message = message + message;
+        this.message = message + message;
     }
 }
 

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
@@ -1,0 +1,100 @@
+package backtraceio.library;
+
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import com.google.gson.annotations.SerializedName;
+import net.jodah.concurrentunit.Waiter;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import backtraceio.library.common.BacktraceSerializeHelper;
+import backtraceio.library.events.OnServerResponseEventListener;
+import backtraceio.library.events.RequestHandler;
+import backtraceio.library.models.BacktraceData;
+import backtraceio.library.models.BacktraceResult;
+import backtraceio.library.models.json.BacktraceReport;
+import backtraceio.library.models.types.BacktraceResultStatus;
+
+abstract class CustomExceptionBase extends Exception {
+    @SerializedName("message")
+    public String Message;
+    public CustomExceptionBase(String message) {
+        super(message);
+        this.Message = message;
+    }
+}
+class SerializationTestException extends CustomExceptionBase {
+    @SerializedName("message")
+    public String Message;
+
+    public SerializationTestException(String message) {
+        super(message);
+        // modify the exception in the source class
+        this.Message = message + message;
+    }
+}
+
+
+@RunWith(AndroidJUnit4.class)
+public class BacktraceClientSerializationTest {
+    private Context context;
+    private BacktraceCredentials credentials;
+    private final String resultMessage = "serialization test message";
+    private final Map<String, Object> attributes = new HashMap<String, Object>() {{
+        put("test", "value");
+    }};
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getContext();
+        credentials = new BacktraceCredentials("https://example-endpoint.com/", "");
+    }
+
+
+    @Test
+    public void sendReportWithTheSameJsonKeys() {
+        // GIVEN
+        BacktraceClient backtraceClient = new BacktraceClient(context, credentials);
+        final Waiter waiter = new Waiter();
+        RequestHandler rh = new RequestHandler() {
+            @Override
+            public BacktraceResult onRequest(BacktraceData data) {
+                String dataJson = BacktraceSerializeHelper.toJson(data);
+                assertNotNull(dataJson);
+                String reportJson = BacktraceSerializeHelper.toJson(data.report);
+                assertNotNull(reportJson);
+
+
+                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                        BacktraceResultStatus.Ok);
+            }
+        };
+        backtraceClient.setOnRequestHandler(rh);
+
+        // WHEN
+        backtraceClient.send(new BacktraceReport(new SerializationTestException("serialization test message")), new OnServerResponseEventListener() {
+            @Override
+            public void onEvent(BacktraceResult backtraceResult) {
+                // THEN
+                assertEquals(resultMessage, backtraceResult.message);
+                assertEquals(BacktraceResultStatus.Ok, backtraceResult.status);
+                assertNotNull(backtraceResult.getBacktraceReport());
+                assertNotNull(backtraceResult.getBacktraceReport().exception);
+                waiter.resume();
+            }
+        });
+        // WAIT FOR THE RESULT FROM ANOTHER THREAD
+        try {
+            waiter.await(5, TimeUnit.SECONDS);
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+}

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
@@ -190,10 +190,11 @@ public class BacktraceReport {
     /**
      * To avoid serialization issues with custom exceptions, our goal is to always
      * prepare exception in a way potential serialization won't break it
+     *
      * @param exception captured client-side exception
      */
     private Exception prepareException(Exception exception) {
-        if(exception == null) {
+        if (exception == null) {
             return null;
         }
         Exception reportException = new Exception(exception.getMessage());

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
@@ -177,7 +177,7 @@ public class BacktraceReport {
         this.attributes = attributes == null ? new HashMap<String, Object>() {
         } : attributes;
         this.attachmentPaths = attachmentPaths == null ? new ArrayList<String>() : attachmentPaths;
-        this.exception = exception;
+        this.exception = this.prepareException(exception);
         this.exceptionTypeReport = exception != null;
         this.diagnosticStack = new BacktraceStackTrace(exception).getStackFrames();
 
@@ -185,6 +185,21 @@ public class BacktraceReport {
             this.classifier = exception.getClass().getCanonicalName();
         }
         this.setDefaultErrorTypeAttribute();
+    }
+
+    /**
+     * To avoid serialization issues with custom exceptions, our goal is to always
+     * prepare exception in a way potential serialization won't break it
+     * @param exception captured client-side exception
+     */
+    private Exception prepareException(Exception exception) {
+        if(exception == null) {
+            return null;
+        }
+        Exception reportException = new Exception(exception.getMessage());
+        reportException.setStackTrace(exception.getStackTrace());
+
+        return reportException;
     }
 
     /**

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 33
+    compileSdkVersion 34
     defaultConfig {
         applicationId "backtraceio.backtraceio"
         minSdkVersion 21


### PR DESCRIPTION
# Why

This diff allows us to avoid potential exception serialization issues during the report/data serialization in the database/sender. 

Goal:
- serialize only known exception properties
- generate the same information we have now (no change for user)