### PR TITLE
Improve handling of immutable collections (attributes and attachments) in BacktraceBase and BacktraceReport

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -10,6 +10,7 @@ import java.util.Map;
 
 import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.BacktraceDatabase;
+import backtraceio.library.common.CollectionUtils;
 import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
 import backtraceio.library.enums.UnwindingMode;
@@ -233,8 +234,8 @@ public class BacktraceBase implements Client {
     public BacktraceBase(Context context, BacktraceCredentials credentials, Database database, Map<String, Object> attributes, List<String> attachments) {
         this.context = context;
         this.credentials = credentials;
-        this.attributes = this.createAttributes(attributes);
-        this.attachments = this.createAttachments(attachments);
+        this.attributes = CollectionUtils.copyMap(attributes);
+        this.attachments = CollectionUtils.copyList(attachments);
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
@@ -623,25 +624,6 @@ public class BacktraceBase implements Client {
 
     private boolean isBreadcrumbsAvailable() {
         return database != null && database.getBreadcrumbs() != null;
-    }
-
-    private HashMap<String, Object> createAttributes(Map<String, Object> userAttributes) {
-        HashMap<String, Object> attributes = new HashMap<>();
-
-        if (userAttributes != null) {
-            attributes.putAll(userAttributes);
-        }
-        return attributes;
-    }
-
-    private List<String> createAttachments(List<String> userAttachments) {
-        List<String> attachments = new ArrayList<>();
-
-        if (userAttachments != null) {
-            attachments.addAll(userAttachments);
-        }
-
-        return attachments;
     }
 
 }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -233,8 +233,8 @@ public class BacktraceBase implements Client {
     public BacktraceBase(Context context, BacktraceCredentials credentials, Database database, Map<String, Object> attributes, List<String> attachments) {
         this.context = context;
         this.credentials = credentials;
-        this.attributes = createAttributes(attributes);
-        this.attachments = attachments != null ? attachments : new ArrayList<>();
+        this.attributes = this.createAttributes(attributes);
+        this.attachments = this.createAttachments(attachments);
         this.database = database != null ? database : new BacktraceDatabase();
         this.setBacktraceApi(new BacktraceApi(credentials));
         this.database.start();
@@ -369,7 +369,6 @@ public class BacktraceBase implements Client {
             return false;
         }
         return database.getBreadcrumbs().enableBreadcrumbs(context);
-
     }
 
     /**
@@ -387,7 +386,6 @@ public class BacktraceBase implements Client {
             return false;
         }
         return database.getBreadcrumbs().enableBreadcrumbs(context, maxBreadcrumbLogSizeBytes);
-
     }
 
     /**
@@ -634,6 +632,16 @@ public class BacktraceBase implements Client {
             attributes.putAll(userAttributes);
         }
         return attributes;
+    }
+
+    private List<String> createAttachments(List<String> userAttachments) {
+        List<String> attachments = new ArrayList<>();
+
+        if (userAttachments != null) {
+            attachments.addAll(userAttachments);
+        }
+
+        return attachments;
     }
 
 }

--- a/backtrace-library/src/main/java/backtraceio/library/common/CollectionUtils.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/CollectionUtils.java
@@ -1,0 +1,28 @@
+package backtraceio.library.common;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class CollectionUtils {
+    public static <T> List<T> copyList(List<T> userList) {
+        List<T> copiedList = new ArrayList<>();
+
+        if (userList != null) {
+            copiedList.addAll(userList);
+        }
+
+        return copiedList;
+    }
+
+    public static <K, V> Map<K, V> copyMap(Map<K, V> userMap) {
+        HashMap<K, V> copiedMap = new HashMap<>();
+
+        if (userMap != null) {
+            copiedMap.putAll(userMap);
+        }
+
+        return copiedMap;
+    }
+}

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
@@ -175,9 +175,8 @@ public class BacktraceReport {
             Map<String, Object> attributes,
             List<String> attachmentPaths) {
 
-        this.attributes = attributes == null ? new HashMap<String, Object>() {
-        } : attributes;
-        this.attachmentPaths = attachmentPaths == null ? new ArrayList<String>() : attachmentPaths;
+        this.attributes = this.createAttributes(attributes);
+        this.attachmentPaths = this.createAttachments(attachmentPaths);
         this.exception = this.prepareException(exception);
         this.exceptionTypeReport = exception != null;
         this.diagnosticStack = new BacktraceStackTrace(exception).getStackFrames();
@@ -242,6 +241,25 @@ public class BacktraceReport {
         }
         reportAttributes.putAll(attributes);
         return reportAttributes;
+    }
+
+    private HashMap<String, Object> createAttributes(Map<String, Object> userAttributes) {
+        HashMap<String, Object> attributes = new HashMap<>();
+
+        if (userAttributes != null) {
+            attributes.putAll(userAttributes);
+        }
+        return attributes;
+    }
+
+    private List<String> createAttachments(List<String> userAttachments) {
+        List<String> attachments = new ArrayList<>();
+
+        if (userAttachments != null) {
+            attachments.addAll(userAttachments);
+        }
+
+        return attachments;
     }
 
     public BacktraceData toBacktraceData(Context context, Map<String, Object> clientAttributes) {

--- a/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/json/BacktraceReport.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import backtraceio.library.common.BacktraceTimeHelper;
+import backtraceio.library.common.CollectionUtils;
 import backtraceio.library.models.BacktraceAttributeConsts;
 import backtraceio.library.models.BacktraceData;
 import backtraceio.library.models.BacktraceStackFrame;
@@ -175,8 +176,8 @@ public class BacktraceReport {
             Map<String, Object> attributes,
             List<String> attachmentPaths) {
 
-        this.attributes = this.createAttributes(attributes);
-        this.attachmentPaths = this.createAttachments(attachmentPaths);
+        this.attributes = CollectionUtils.copyMap(attributes);
+        this.attachmentPaths = CollectionUtils.copyList(attachmentPaths);
         this.exception = this.prepareException(exception);
         this.exceptionTypeReport = exception != null;
         this.diagnosticStack = new BacktraceStackTrace(exception).getStackFrames();
@@ -241,25 +242,6 @@ public class BacktraceReport {
         }
         reportAttributes.putAll(attributes);
         return reportAttributes;
-    }
-
-    private HashMap<String, Object> createAttributes(Map<String, Object> userAttributes) {
-        HashMap<String, Object> attributes = new HashMap<>();
-
-        if (userAttributes != null) {
-            attributes.putAll(userAttributes);
-        }
-        return attributes;
-    }
-
-    private List<String> createAttachments(List<String> userAttachments) {
-        List<String> attachments = new ArrayList<>();
-
-        if (userAttachments != null) {
-            attachments.addAll(userAttachments);
-        }
-
-        return attachments;
     }
 
     public BacktraceData toBacktraceData(Context context, Map<String, Object> clientAttributes) {

--- a/backtrace-library/src/test/java/backtraceio/library/common/CollectionUtilsTest.java
+++ b/backtrace-library/src/test/java/backtraceio/library/common/CollectionUtilsTest.java
@@ -1,0 +1,88 @@
+package backtraceio.library.common;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+
+public class CollectionUtilsTest {
+
+    @Test
+    public void testCopyList_NullList() {
+        // WHEN
+        List<String> result = CollectionUtils.copyList(null);
+
+        // THEN
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCopyList_EmptyList() {
+        // GIVEN
+        List<String> emptyList = new ArrayList<>();
+        // WHEN
+        List<String> result = CollectionUtils.copyList(emptyList);
+        // THEN
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCopyList_NonEmptyList() {
+        // GIVEN
+        List<String> userList = Arrays.asList("one", "two", "three");
+
+        // WHEN
+        List<String> result = CollectionUtils.copyList(userList);
+
+        // THEN
+        assertNotNull(result);
+        assertEquals(userList.size(), result.size());
+        assertTrue(result.containsAll(userList));
+    }
+
+    @Test
+    public void testCopyMap_NullMap() {
+        // WHEN
+        Map<String, Object> result = CollectionUtils.copyMap(null);
+        // THEN
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCopyMap_EmptyMap() {
+        // GIVEN
+        Map<String, Object> emptyMap = new HashMap<>();
+
+        // WHEN
+        Map<String, Object> result = CollectionUtils.copyMap(emptyMap);
+
+        // THEN
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void testCopyMap_NonEmptyMap() {
+        // GIVEN
+        Map<String, Object> userMap = new HashMap<>();
+        userMap.put("key1", "value1");
+        userMap.put("key2", 2);
+
+        // WHEN
+        Map<String, Object> result = CollectionUtils.copyMap(userMap);
+
+        // THEN
+        assertNotNull(result);
+        assertEquals(userMap.size(), result.size());
+        assertEquals(userMap, result);
+    }
+}


### PR DESCRIPTION
This change addresses issues arising from modifying immutable collections passed by users, which could lead to exceptions. By copying collections before operating on them, we ensure safer manipulation and improved reliability. The update involves refactoring duplicated code into utility functions and adding unit tests to verify the correct handling of collection copies.

BT-2523