### PR TITLE
Bump GSON version

### DIFF
--- a/coroner-client/build.gradle
+++ b/coroner-client/build.gradle
@@ -9,7 +9,7 @@ java {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.10'
+    implementation 'com.google.code.gson:gson:2.10.1'
     testImplementation 'junit:junit:4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.2.0'
 }


### PR DESCRIPTION
We need it to apply all fixes.

https://github.com/google/gson/releases/tag/gson-parent-2.10.1