### PR TITLE
Bring back support for crash_handler.so for backward compatibility

### DIFF
--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -126,12 +126,6 @@ bool InitializeCrashpad(jstring url,
         }
     }
 
-    std::map<std::string, std::string> attributes = generateInitializationAttributes(env,
-                                                                                     attributeKeys,
-                                                                                     attributeValues);
-
-    std::vector<std::string> arguments = generateInitializationArguments(env, attachmentPaths);
-
     // Backtrace url
     const char *backtraceUrl = env->GetStringUTFChars(url, 0);
 
@@ -149,6 +143,12 @@ bool InitializeCrashpad(jstring url,
 
     // Start crash handler
     client = new crashpad::CrashpadClient();
+
+    std::map<std::string, std::string> attributes = generateInitializationAttributes(env,
+                                                                                     attributeKeys,
+                                                                                     attributeValues);
+
+    std::vector<std::string> arguments = generateInitializationArguments(env, attachmentPaths);
 
     std::map<std::string, std::string>::iterator guidIterator = attributes.find("guid");
     if (guidIterator != attributes.end()) {

--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -340,8 +340,7 @@ void AddAttributeCrashpad(jstring key, jstring value) {
 
 void DisableCrashpad() {
     if (database == nullptr) {
-        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
-                            "Crashpad database is null, this should not happen");
+        __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Crashpad database is null, this should not happen");
         return;
     }
     // Disable automated uploads.
@@ -353,8 +352,7 @@ void ReEnableCrashpad() {
     // Re-enable uploads if disabled
     if (disabled) {
         if (database == nullptr) {
-            __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
-                                "Crashpad database is null, this should not happen");
+            __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Crashpad database is null, this should not happen");
             return;
         }
         database->GetSettings()->SetUploadsEnabled(true);

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -72,7 +72,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *jvm, void *reserved) {
     javaVm = jvm;
 
     char thread_id_cstr[25];
-    sprintf(thread_id_cstr, "%jd", (intmax_t)gettid());
+    sprintf(thread_id_cstr, "%jd", (intmax_t) gettid());
     thread_id = std::string(thread_id_cstr);
     return JNI_VERSION_1_4;
 }
@@ -102,12 +102,57 @@ Java_backtraceio_library_BacktraceDatabase_initialize(JNIEnv *env,
                                                       jobjectArray attributeValues,
                                                       jobjectArray attachmentPaths = nullptr,
                                                       jboolean enableClientSideUnwinding = false,
-                                                      jobject unwindingMode = nullptr,
-                                                      jobjectArray environmentVariables = nullptr) {
+                                                      jobject unwindingMode = nullptr) {
     jint unwindingModeInt = ExtractClientSideUnwindingMode(env, unwindingMode);
     return Initialize(url, database_path, handler_path, attributeKeys,
                       attributeValues, attachmentPaths, enableClientSideUnwinding,
-                      unwindingModeInt, environmentVariables);
+                      unwindingModeInt);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_backtraceio_library_nativeCalls_BacktraceCrashHandler_initializeCrashHandler(JNIEnv *env,
+                                                                                  jobject thiz,
+                                                                                  jstring url,
+                                                                                  jstring database_path,
+                                                                                  jstring handler_path,
+                                                                                  jobjectArray attribute_keys,
+                                                                                  jobjectArray attribute_values,
+                                                                                  jobjectArray attachment_paths,
+                                                                                  jboolean enable_client_side_unwinding,
+                                                                                  jobject unwinding_mode) {
+    return Java_backtraceio_library_BacktraceDatabase_initialize(env, thiz, url, database_path,
+                                                                 handler_path, attribute_keys,
+                                                                 attribute_values, attachment_paths,
+                                                                 enable_client_side_unwinding,
+                                                                 unwinding_mode);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_backtraceio_library_nativeCalls_BacktraceCrashHandler_initializeJavaCrashHandler(JNIEnv *env,
+                                                                                      jobject thiz,
+                                                                                      jstring url,
+                                                                                      jstring database_path,
+                                                                                      jstring class_path,
+                                                                                      jobjectArray attributeKeys,
+                                                                                      jobjectArray attributeValues,
+                                                                                      jobjectArray attachmentPaths = nullptr,
+                                                                                      jobjectArray environmentVariables = nullptr) {
+    return InitializeJavaCrashHandler(url, database_path, class_path, attributeKeys,
+                                      attributeValues, attachmentPaths, environmentVariables);
+}
+
+JNIEXPORT jboolean JNICALL
+Java_backtraceio_library_BacktraceDatabase_initializeJavaCrashHandler(JNIEnv *env,
+                                                                      jobject thiz,
+                                                                      jstring url,
+                                                                      jstring database_path,
+                                                                      jstring class_path,
+                                                                      jobjectArray attributeKeys,
+                                                                      jobjectArray attributeValues,
+                                                                      jobjectArray attachmentPaths = nullptr,
+                                                                      jobjectArray environmentVariables = nullptr) {
+    return InitializeJavaCrashHandler(url, database_path, class_path, attributeKeys,
+                                      attributeValues, attachmentPaths, environmentVariables);
 }
 
 JNIEXPORT void JNICALL

--- a/backtrace-library/src/main/cpp/backtrace-native.cpp
+++ b/backtrace-library/src/main/cpp/backtrace-native.cpp
@@ -72,7 +72,7 @@ JNIEXPORT jint JNI_OnLoad(JavaVM *jvm, void *reserved) {
     javaVm = jvm;
 
     char thread_id_cstr[25];
-    sprintf(thread_id_cstr, "%jd", (intmax_t) gettid());
+    sprintf(thread_id_cstr, "%jd", (intmax_t)gettid());
     thread_id = std::string(thread_id_cstr);
     return JNI_VERSION_1_4;
 }

--- a/backtrace-library/src/main/cpp/include/backend.h
+++ b/backtrace-library/src/main/cpp/include/backend.h
@@ -12,8 +12,15 @@ bool Initialize(jstring url,
                 jobjectArray attributeValues,
                 jobjectArray attachmentPaths = nullptr,
                 jboolean enableClientSideUnwinding = false,
-                jint unwindingMode = UNWINDING_MODE_DEFAULT,
-                jobjectArray environmentVariables = nullptr);
+                jint unwindingMode = UNWINDING_MODE_DEFAULT);
+
+bool InitializeJavaCrashHandler(jstring url,
+                                jstring database_path,
+                                jstring class_path,
+                                jobjectArray attributeKeys,
+                                jobjectArray attributeValues,
+                                jobjectArray attachmentPaths = nullptr,
+                                jobjectArray environmentVariables = nullptr);
 
 bool CaptureCrash(jobjectArray args);
 

--- a/backtrace-library/src/main/cpp/include/crashpad-backend.h
+++ b/backtrace-library/src/main/cpp/include/crashpad-backend.h
@@ -18,8 +18,15 @@ bool InitializeCrashpad(jstring url,
                         jobjectArray attributeValues,
                         jobjectArray attachmentPaths = nullptr,
                         jboolean enableClientSideUnwinding = false,
-                        jint unwindingMode = UNWINDING_MODE_DEFAULT,
-                        jobjectArray environmentVariables = nullptr);
+                        jint unwindingMode = UNWINDING_MODE_DEFAULT);
+
+bool InitializeCrashpadJavaCrashHandler(jstring url,
+                                        jstring database_path,
+                                        jstring class_path,
+                                        jobjectArray attributeKeys,
+                                        jobjectArray attributeValues,
+                                        jobjectArray attachmentPaths = nullptr,
+                                        jobjectArray environmentVariables = nullptr);
 
 bool CaptureCrashCrashpad(jobjectArray args);
 

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/NativeCommunication.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/NativeCommunication.java
@@ -1,0 +1,15 @@
+package backtraceio.library.interfaces;
+
+import backtraceio.library.enums.UnwindingMode;
+
+public interface NativeCommunication {
+    boolean handleCrash(String[] args);
+
+    boolean initializeJavaCrashHandler(String url, String databasePath, String classPath, String[] attributeKeys, String[] attributeValues,
+                                       String[] attachmentPaths, String[] environmentVariables);
+
+    boolean initializeCrashHandler(String url, String databasePath, String handlerPath,
+                                   String[] attributeKeys, String[] attributeValues,
+                                   String[] attachmentPaths, boolean enableClientSideUnwinding,
+                                   UnwindingMode unwindingMode);
+}

--- a/backtrace-library/src/main/java/backtraceio/library/nativeCalls/BacktraceCrashHandler.java
+++ b/backtrace-library/src/main/java/backtraceio/library/nativeCalls/BacktraceCrashHandler.java
@@ -1,5 +1,15 @@
 package backtraceio.library.nativeCalls;
 
+import backtraceio.library.enums.UnwindingMode;
+
 public class BacktraceCrashHandler {
     public static native boolean handleCrash(String[] args);
+
+    public static native boolean initializeJavaCrashHandler(String url, String databasePath, String classPath, String[] attributeKeys, String[] attributeValues,
+                                                            String[] attachmentPaths, String[] environmentVariables);
+
+    public static native boolean initializeCrashHandler(String url, String databasePath, String handlerPath,
+                                                        String[] attributeKeys, String[] attributeValues,
+                                                        String[] attachmentPaths, boolean enableClientSideUnwinding,
+                                                        UnwindingMode unwindingMode);
 }

--- a/backtrace-library/src/main/java/backtraceio/library/nativeCalls/BacktraceCrashHandlerWrapper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/nativeCalls/BacktraceCrashHandlerWrapper.java
@@ -1,7 +1,22 @@
 package backtraceio.library.nativeCalls;
 
-public class BacktraceCrashHandlerWrapper {
+import backtraceio.library.enums.UnwindingMode;
+import backtraceio.library.interfaces.NativeCommunication;
+
+public class BacktraceCrashHandlerWrapper implements NativeCommunication {
     public boolean handleCrash(String[] args) {
         return BacktraceCrashHandler.handleCrash(args);
+    }
+
+    public boolean initializeJavaCrashHandler(String url, String databasePath, String classPath, String[] attributeKeys, String[] attributeValues,
+                                              String[] attachmentPaths, String[] environmentVariables) {
+        return BacktraceCrashHandler.initializeJavaCrashHandler(url, databasePath, classPath, attributeKeys, attributeValues, attachmentPaths, environmentVariables);
+    }
+
+    public boolean initializeCrashHandler(String url, String databasePath, String handlerPath,
+                                          String[] attributeKeys, String[] attributeValues,
+                                          String[] attachmentPaths, boolean enableClientSideUnwinding,
+                                          UnwindingMode unwindingMode) {
+        return BacktraceCrashHandler.initializeCrashHandler(url, databasePath, handlerPath, attributeKeys, attributeValues, attachmentPaths, enableClientSideUnwinding, unwindingMode);
     }
 }


### PR DESCRIPTION
# Why

This pull request returns support for libcrashpad_handler executable available in the apk. WIth this change, our NDK interface doesn't introduce any breaking change for other our libraries