### PR TITLE
Use java 17 on uploading archives

### DIFF
--- a/.github/workflows/uploadArchives.yml
+++ b/.github/workflows/uploadArchives.yml
@@ -25,11 +25,11 @@ jobs:
        token: ${{ secrets.ACCESS_TOKEN }}
        persist-credentials: false
 
-   - name: set up JDK 11
+   - name: set up JDK 17
      uses: actions/setup-java@v3
      with:
-       java-version: 11.0.10
-       distribution: 'adopt'
+       java-version: 17.0.10
+       distribution: "adopt"
        cache: gradle
    
    - name: Add Maven credentials to gradle.properties

--- a/backtrace-library/publish.gradle
+++ b/backtrace-library/publish.gradle
@@ -80,10 +80,10 @@ afterEvaluate { project ->
     publishing {
         publications {
             release(MavenPublication) {
-                from components.findByName('release')
                 groupId GROUP
                 artifactId POM_ARTIFACT_ID
                 version version
+                from components.release
             }
         }
 
@@ -111,10 +111,12 @@ afterEvaluate { project ->
         }
 
         task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
+            classifier = 'javadoc'
             from androidJavadocs.destinationDir
         }
 
         task androidSourcesJar(type: Jar) {
+            classifier = 'sources'
             from android.sourceSets.main.java.source
         }
     }

--- a/backtrace-library/publish.gradle
+++ b/backtrace-library/publish.gradle
@@ -111,12 +111,12 @@ afterEvaluate { project ->
         }
 
         task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-            classifier = 'javadoc'
+            archiveClassifier = 'javadoc'
             from androidJavadocs.destinationDir
         }
 
         task androidSourcesJar(type: Jar) {
-            classifier = 'sources'
+            archiveClassifier = 'sources'
             from android.sourceSets.main.java.source
         }
     }

--- a/backtrace-library/publish.gradle
+++ b/backtrace-library/publish.gradle
@@ -80,10 +80,10 @@ afterEvaluate { project ->
     publishing {
         publications {
             release(MavenPublication) {
+                from components.findByName('release')
                 groupId GROUP
                 artifactId POM_ARTIFACT_ID
                 version version
-                from components.release
             }
         }
 


### PR DESCRIPTION
Use java 17 in Github CI/CD actions because it's required by Gradle plugin