### PR TITLE
Include missing aar in the final library 

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -35,6 +35,12 @@ android {
         buildFeatures {
             buildConfig = true
         }
+        publishing {
+            singleVariant("release") {
+                withSourcesJar()
+                withJavadocJar()
+            }
+        }
     }
 
     buildTypes {

--- a/backtrace-library/publish.gradle
+++ b/backtrace-library/publish.gradle
@@ -80,7 +80,7 @@ afterEvaluate { project ->
     publishing {
         publications {
             release(MavenPublication) {
-                from components.findByName('release')
+                from components.release
                 groupId GROUP
                 artifactId POM_ARTIFACT_ID
                 version version
@@ -101,62 +101,9 @@ afterEvaluate { project ->
         }
     }
 
-    if (project.getPlugins().hasPlugin('com.android.application') ||
-            project.getPlugins().hasPlugin('com.android.library')) {
-
-        task androidJavadocs(type: Javadoc) {
-            source = android.sourceSets.main.java.source
-            classpath += project.files(android.getBootClasspath().join(File.pathSeparator))
-            excludes = ['**/*.kt']
-        }
-
-        task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-            archiveClassifier = 'javadoc'
-            from androidJavadocs.destinationDir
-        }
-
-        task androidSourcesJar(type: Jar) {
-            archiveClassifier = 'sources'
-            from android.sourceSets.main.java.source
-        }
-    }
-
-    if (JavaVersion.current().isJava8Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addStringOption('Xdoclint:none', '-quiet')
-            }
-        }
-    }
-
-    if (JavaVersion.current().isJava9Compatible()) {
-        allprojects {
-            tasks.withType(Javadoc) {
-                options.addBooleanOption('html5', true)
-            }
-        }
-    }
-
-    artifacts {
-        if (project.getPlugins().hasPlugin('com.android.application') ||
-                project.getPlugins().hasPlugin('com.android.library')) {
-            archives androidSourcesJar
-            archives androidJavadocsJar
-        }
-    }
-
-    android.libraryVariants.all { variant ->
-        tasks.androidJavadocs.doFirst {
-            classpath += files(variant.javaCompileProvider.get().classpath.files.join(File.pathSeparator))
-        }
-    }
-
     publishing.publications.all { publication ->
         publication.groupId = GROUP
         publication.version = version
-
-        publication.artifact androidSourcesJar
-        publication.artifact androidJavadocsJar
 
         configurePom(publication.pom)
     }


### PR DESCRIPTION
# Why

Update to the latest AGP required some changes in the publish/build gradle setting. We don't need to use some options, since they're already available in the platform. With this update, we should be able to ship our libraries with aar. 