### PR TITLE
Update Github actions to v4

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
           submodules: recursive
@@ -21,7 +21,7 @@ jobs:
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: 17.0.10
           distribution: "adopt"
@@ -37,31 +37,31 @@ jobs:
         run: ./gradlew assembleDebug assembleDebugAndroidTest build check
 
       - name: Upload symbols.zip
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: native-debug-symbols.zip
           path: example-app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
 
       - name: Upload example-app APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: example-app-debug.apk
           path: example-app/build/outputs/apk/debug/example-app-debug.apk
 
       - name: Upload example-app Test APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: example-app-debug-androidTest.apk
           path: example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk
 
       - name: Upload backtrace-library AAR
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backtrace-library-debug.aar
           path: backtrace-library/build/outputs/aar/backtrace-library-debug.aar
 
       - name: Upload backtrace-library Test APK
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: backtrace-library-debug-androidTest.apk
           path: backtrace-library/build/outputs/apk/androidTest/debug/backtrace-library-debug-androidTest.apk
@@ -81,12 +81,12 @@ jobs:
 
     steps:
       - name: Download APK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: example-app-debug.apk
 
       - name: Download Test APK
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.test-apk }}
 

--- a/.github/workflows/uploadArchives.yml
+++ b/.github/workflows/uploadArchives.yml
@@ -18,7 +18,7 @@ jobs:
 
    steps:
    - name: Checkout submodules
-     uses: actions/checkout@v3
+     uses: actions/checkout@v4
      with:
        fetch-depth: 2
        submodules: recursive
@@ -26,7 +26,7 @@ jobs:
        persist-credentials: false
 
    - name: set up JDK 17
-     uses: actions/setup-java@v3
+     uses: actions/setup-java@v4
      with:
        java-version: 17.0.10
        distribution: "adopt"


### PR DESCRIPTION
Node 16 is in EOL so we need to use github actions v4 which are using supported node 20.