### PR TITLE
Use getter getReport instead of report field

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientAttachmentsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientAttachmentsTest.java
@@ -61,7 +61,7 @@ public class BacktraceClientAttachmentsTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.report.exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -104,7 +104,7 @@ public class BacktraceClientAttachmentsTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.report.exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientAttributeTests.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientAttributeTests.java
@@ -136,7 +136,7 @@ public class BacktraceClientAttributeTests {
             Object value = data.attributes.get(attributeKey);
             assertNotNull(value);
             assertEquals(value, attributeValue);
-            return new BacktraceResult(data.report, data.report.exception.getMessage(),
+            return new BacktraceResult(data.getReport(), data.report.exception.getMessage(),
                     BacktraceResultStatus.Ok);
         };
         backtraceClient.setOnRequestHandler(rh);

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientBreadcrumbsTest.java
@@ -73,7 +73,7 @@ public class BacktraceClientBreadcrumbsTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.report.exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -122,7 +122,7 @@ public class BacktraceClientBreadcrumbsTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.report.exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -181,7 +181,7 @@ public class BacktraceClientBreadcrumbsTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientProguardTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientProguardTest.java
@@ -59,7 +59,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertEquals("proguard", data.symbolication);
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };
@@ -98,7 +98,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertNull(data.symbolication);
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };
@@ -139,7 +139,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertEquals("proguard", data.symbolication);
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -181,7 +181,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertNull(data.symbolication);
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -225,7 +225,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertEquals("proguard", data.symbolication);
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -267,7 +267,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertNull(data.symbolication);
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -310,7 +310,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertEquals("proguard", data.symbolication);
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };
@@ -352,7 +352,7 @@ public class BacktraceClientProguardTest {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
                 assertNull(data.symbolication);
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSendTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSendTest.java
@@ -55,7 +55,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(null, data.report.exception.getMessage(),
+                return new BacktraceResult(null, data.getReport().exception.getMessage(),
                         BacktraceResultStatus.ServerError);
             }
         };
@@ -110,7 +110,7 @@ public class BacktraceClientSendTest {
                 fail(e.getMessage());
             }
 
-            return new BacktraceResult(data.report, data.report.message,
+            return new BacktraceResult(data.getReport(), data.report.message,
                     BacktraceResultStatus.Ok);
         };
         backtraceClient.setOnRequestHandler(rh);
@@ -136,7 +136,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };
@@ -171,7 +171,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.message,
+                return new BacktraceResult(data.getReport(), data.getReport().message,
                         BacktraceResultStatus.Ok);
             }
         };
@@ -209,7 +209,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -244,7 +244,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };
@@ -287,7 +287,7 @@ public class BacktraceClientSendTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceClientSerializationTest.java
@@ -75,11 +75,11 @@ public class BacktraceClientSerializationTest {
             public BacktraceResult onRequest(BacktraceData data) {
                 String dataJson = BacktraceSerializeHelper.toJson(data);
                 assertNotNull(dataJson);
-                String reportJson = BacktraceSerializeHelper.toJson(data.report);
+                String reportJson = BacktraceSerializeHelper.toJson(data.getReport());
                 assertNotNull(reportJson);
 
 
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceErrorTypeAttributeTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceErrorTypeAttributeTest.java
@@ -62,7 +62,7 @@ public class BacktraceErrorTypeAttributeTest {
         RequestHandler rh = new RequestHandler() {
             @Override
             public BacktraceResult onRequest(BacktraceData data) {
-                return new BacktraceResult(data.report, data.report.exception.getMessage(),
+                return new BacktraceResult(data.getReport(), data.getReport().exception.getMessage(),
                         BacktraceResultStatus.Ok);
             }
         };

--- a/backtrace-library/src/androidTest/java/backtraceio/library/SettingAttributesTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/SettingAttributesTest.java
@@ -143,7 +143,7 @@ public class SettingAttributesTest {
                 assertNotNull(data.attributes);
                 assertTrue(data.attributes.containsKey(customClientAttributeKey));
                 assertEquals(data.attributes.get(customClientAttributeKey), customClientAttributeValue);
-                return new BacktraceResult(data.report, "", BacktraceResultStatus.Ok);
+                return new BacktraceResult(data.getReport(), "", BacktraceResultStatus.Ok);
             }
         };
         backtraceClient.setOnRequestHandler(rh);
@@ -176,12 +176,12 @@ public class SettingAttributesTest {
                     @Override
                     public BacktraceResult onRequest(BacktraceData data) {
                         // THEN
-                        waiter.assertTrue(data.report.attributes.containsKey(customClientAttributeKey));
-                        waiter.assertEquals(customClientAttributeValue, data.report.attributes.get(customClientAttributeKey));
-                        waiter.assertEquals(exceptionMessage, data.report.exception.getMessage());
-                        waiter.assertEquals(data.report.attributes.get(BacktraceAttributeConsts.ErrorType), BacktraceAttributeConsts.UnhandledExceptionAttributeType);
+                        waiter.assertTrue(data.getReport().attributes.containsKey(customClientAttributeKey));
+                        waiter.assertEquals(customClientAttributeValue, data.getReport().attributes.get(customClientAttributeKey));
+                        waiter.assertEquals(exceptionMessage, data.getReport().exception.getMessage());
+                        waiter.assertEquals(data.getReport().attributes.get(BacktraceAttributeConsts.ErrorType), BacktraceAttributeConsts.UnhandledExceptionAttributeType);
                         waiter.resume();
-                        return new BacktraceResult(data.report, "", BacktraceResultStatus.Ok);
+                        return new BacktraceResult(data.getReport(), "", BacktraceResultStatus.Ok);
                     }
                 });
                 BacktraceExceptionHandler.enable(backtraceClient);

--- a/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseProguardTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseProguardTest.java
@@ -49,9 +49,9 @@ public class BacktraceDatabaseProguardTest {
         database.add(report, null);
 
         // THEN
-        assertEquals(report, database.get().iterator().next().getBacktraceData(context).report);
+        assertEquals(report, database.get().iterator().next().getBacktraceData(context).getReport());
         assertNull(database.get().iterator().next().getBacktraceData(context).symbolication);
-        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).report.message);
+        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).getReport().message);
         assertEquals(1, database.count());
     }
 
@@ -67,9 +67,9 @@ public class BacktraceDatabaseProguardTest {
         database.add(report, null, true);
 
         // THEN
-        assertEquals(report, database.get().iterator().next().getBacktraceData(context).report);
+        assertEquals(report, database.get().iterator().next().getBacktraceData(context).getReport());
         assertEquals("proguard", database.get().iterator().next().getBacktraceData(context).symbolication);
-        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).report.message);
+        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).getReport().message);
         assertEquals(1, database.count());
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseRecordTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseRecordTest.java
@@ -65,7 +65,7 @@ public class BacktraceDatabaseRecordTest {
         // THEN
         assertTrue(saveResult);
         assertTrue(validResult);
-        assertEquals(data.report.message, loadedData.report.message);
+        assertEquals(data.getReport().message, loadedData.getReport().message);
     }
 
     @Test
@@ -99,7 +99,7 @@ public class BacktraceDatabaseRecordTest {
         // THEN
         assertTrue(saveResult);
         assertTrue(validResult);
-        assertEquals(data.report.message, loadedData.report.message);
+        assertEquals(data.getReport().message, loadedData.getReport().message);
         assertTrue(loadedData.getAttachments().contains(attachment0));
         assertTrue(loadedData.getAttachments().contains(attachment1));
     }
@@ -173,6 +173,6 @@ public class BacktraceDatabaseRecordTest {
         BacktraceData dataFromFile = recordFromFile.getBacktraceData(context);
 
         // THEN
-        assertEquals(data.report.message, dataFromFile.report.message);
+        assertEquals(data.getReport().message, dataFromFile.getReport().message);
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseTest.java
@@ -106,8 +106,8 @@ public class BacktraceDatabaseTest {
         database.add(report, null);
 
         // THEN
-        assertEquals(report, database.get().iterator().next().getBacktraceData(context).report);
-        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).report.message);
+        assertEquals(report, database.get().iterator().next().getBacktraceData(context).getReport());
+        assertEquals(testMessage, database.get().iterator().next().getBacktraceData(context).getReport().message);
         assertEquals(1, database.count());
     }
 
@@ -142,8 +142,8 @@ public class BacktraceDatabaseTest {
 
         BacktraceDatabaseRecord recordFromDatabase = database.get().iterator().next();
         assertEquals(record2, recordFromDatabase);
-        assertEquals(report2, recordFromDatabase.getBacktraceData(context).report);
-        assertEquals(report2.exception.getMessage(), recordFromDatabase.getBacktraceData(context).report.exception.getMessage());
+        assertEquals(report2, recordFromDatabase.getBacktraceData(context).getReport());
+        assertEquals(report2.exception.getMessage(), recordFromDatabase.getBacktraceData(context).getReport().exception.getMessage());
     }
 
 
@@ -235,7 +235,7 @@ public class BacktraceDatabaseTest {
 
         // THEN
         assertEquals(1, database.count());
-        assertEquals(report2.message, database.get().iterator().next().getBacktraceData(context).report.message);
+        assertEquals(report2.message, database.get().iterator().next().getBacktraceData(context).getReport().message);
     }
 
     @Test

--- a/backtrace-library/src/androidTest/java/backtraceio/library/models/BacktraceDataTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/models/BacktraceDataTest.java
@@ -34,7 +34,7 @@ public class BacktraceDataTest {
 
         // THEN
         assertEquals(backtraceData.classifiers, new String[]{"java.lang.IllegalAccessException"});
-        assertEquals(backtraceData.report, report);
+        assertEquals(backtraceData.getReport(), report);
         assertEquals(backtraceData.attributes.get("classifier"), "java.lang.IllegalAccessException");
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/models/UncaughtExceptionHandlerTest.java
@@ -68,7 +68,7 @@ public class UncaughtExceptionHandlerTest {
         client.setOnRequestHandler(data -> {
             testedAtomicReportData.set(data);
             waiter.resume();
-            return new BacktraceResult(data.report, data.report.message,
+            return new BacktraceResult(data.getReport(), data.getReport().message,
                     BacktraceResultStatus.Ok);
         });
 
@@ -87,12 +87,12 @@ public class UncaughtExceptionHandlerTest {
         // THEN
         assertNotNull(testedAtomicReportData);
         final BacktraceData testedReportData = testedAtomicReportData.get();
-        assertEquals("Test message", testedReportData.report.exception.getMessage());
-        assertNull(testedReportData.report.message);
-        assertTrue(testedReportData.report.diagnosticStack.size() > 0);
-        assertEquals("java.lang.IllegalArgumentException", testedReportData.report.classifier);
-        assertEquals("Unhandled Exception", testedReportData.report.attributes.get("error.type"));
-        assertTrue(testedReportData.report.exceptionTypeReport);
+        assertEquals("Test message", testedReportData.getReport().exception.getMessage());
+        assertNull(testedReportData.getReport().message);
+        assertTrue(testedReportData.getReport().diagnosticStack.size() > 0);
+        assertEquals("java.lang.IllegalArgumentException", testedReportData.getReport().classifier);
+        assertEquals("Unhandled Exception", testedReportData.getReport().attributes.get("error.type"));
+        assertTrue(testedReportData.getReport().exceptionTypeReport);
     }
 
     @Test
@@ -106,7 +106,7 @@ public class UncaughtExceptionHandlerTest {
         client.setOnRequestHandler(data -> {
             testedAtomicReportData.set(data);
             waiter.resume();
-            return new BacktraceResult(data.report, data.report.message,
+            return new BacktraceResult(data.getReport(), data.getReport().message,
                     BacktraceResultStatus.Ok);
         });
 
@@ -125,10 +125,10 @@ public class UncaughtExceptionHandlerTest {
         // THEN
         assertNotNull(testedAtomicReportData);
         final BacktraceData testedReportData = testedAtomicReportData.get();
-        assertNull(testedReportData.report.message);
-        assertTrue(testedReportData.report.diagnosticStack.size() > 0);
-        assertEquals("java.lang.OutOfMemoryError", testedReportData.report.classifier);
-        assertEquals("Unhandled Exception", testedReportData.report.attributes.get("error.type"));
-        assertTrue(testedReportData.report.exceptionTypeReport);
+        assertNull(testedReportData.getReport().message);
+        assertTrue(testedReportData.getReport().diagnosticStack.size() > 0);
+        assertEquals("java.lang.OutOfMemoryError", testedReportData.getReport().classifier);
+        assertEquals("Unhandled Exception", testedReportData.getReport().attributes.get("error.type"));
+        assertTrue(testedReportData.getReport().exceptionTypeReport);
     }
 }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/watchdog/BacktraceWatchdogSharedTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/watchdog/BacktraceWatchdogSharedTest.java
@@ -59,7 +59,7 @@ public class BacktraceWatchdogSharedTest {
         backtraceClient.clearBreadcrumbs();
 
         backtraceClient.setOnRequestHandler(data -> {
-            String breadcrumbPath = data.report.attachmentPaths.get(0);
+            String breadcrumbPath = data.getReport().attachmentPaths.get(0);
 
             assertTrue(breadcrumbPath.contains("bt-breadcrumbs"));
             assertEquals(data.attributes.get("error.type"), AnrAttributeType);

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -313,7 +313,7 @@ public class BacktraceDatabase implements Database {
                 while (record != null) {
                     final CountDownLatch threadWaiter = new CountDownLatch(1);
                     BacktraceData backtraceData = record.getBacktraceData(_applicationContext);
-                    if (backtraceData == null || backtraceData.report == null) {
+                    if (backtraceData == null || backtraceData.getReport() == null) {
                         BacktraceLogger.d(LOG_TAG, "Timer - backtrace data or report is null - " +
                                 "deleting record");
                         delete(record);

--- a/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/BacktraceData.java
@@ -140,6 +140,11 @@ public class BacktraceData {
         return FileHelper.filterOutFiles(this.context, report.attachmentPaths);
     }
 
+
+    public BacktraceReport getReport() {
+        return report;
+    }
+
     /***
      * Set annotations object
      * @param complexAttributes

--- a/backtrace-library/src/main/java/backtraceio/library/models/database/BacktraceDatabaseRecord.java
+++ b/backtrace-library/src/main/java/backtraceio/library/models/database/BacktraceDatabaseRecord.java
@@ -168,7 +168,7 @@ public class BacktraceDatabaseRecord {
         try {
             BacktraceLogger.d(LOG_TAG, "Trying saving data to internal app storage");
             this.diagnosticDataPath = save(record, String.format("%s-attachment", id));
-            this.reportPath = save(record.report, String.format("%s-report", id));
+            this.reportPath = save(record.getReport(), String.format("%s-report", id));
 
             this.recordPath = new File(this._path,
                     String.format("%s-record.json", this.id)).getAbsolutePath();


### PR DESCRIPTION
Change to use backtrace data getter for report instead of field directly.

Motivation:
Using getters instead of directly accessing fields in Java ensures encapsulation, allows for data validation, and provides control over how fields are accessed and modified. This practice enhances code flexibility, supports design patterns, and enables easier debugging and maintenance by allowing internal implementation changes without affecting external code.

What is more in the future we should consider moving or removing BacktraceReport field from BacktraceData because we are not serializing and using that in proper way. When this change will be apply we can easily control that without breaking API.