### PR TITLE
(Bugfix) ConcurrentModificationException in BacktraceDatabaseContext

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseContextTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/database/BacktraceDatabaseContextTest.java
@@ -201,6 +201,22 @@ public class BacktraceDatabaseContextTest {
     }
 
     @Test
+    public void delete2RecordsFromDatabaseContext() {
+        // GIVEN
+        List<BacktraceDatabaseRecord> records = fillDatabase();
+
+        // WHEN
+        boolean result1 = databaseContext.delete(records.get(0));
+        boolean result2 = databaseContext.delete(records.get(1));
+
+        // THEN
+        assertTrue(result1);
+        assertTrue(result2);
+        assertEquals(1, databaseContext.count());
+        assertTrue(databaseContext.contains(records.get(2)));
+    }
+
+    @Test
     public void deleteSameRecordFromDatabaseContext() {
         // GIVEN
         List<BacktraceDatabaseRecord> records = fillDatabase();

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseContext.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceDatabaseContext.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
@@ -177,22 +178,27 @@ public class BacktraceDatabaseContext implements DatabaseContext {
         for (int key : batchRetry.keySet()) {
             List<BacktraceDatabaseRecord> records = batchRetry.get(key);
 
-            for (BacktraceDatabaseRecord databaseRecord : records) {
-                if (databaseRecord == null || record.id != databaseRecord.id) {
+            if (records == null) {
+                continue;
+            }
+
+            Iterator<BacktraceDatabaseRecord> iterator = records.iterator();
+            while (iterator.hasNext()) {
+                BacktraceDatabaseRecord databaseRecord = iterator.next();
+                if (databaseRecord == null || !record.id.equals(databaseRecord.id)) {
                     continue;
                 }
 
                 databaseRecord.delete();
                 try {
-                    records.remove(databaseRecord);
+                    iterator.remove();
                     this.totalRecords--;
                     this.totalSize -= databaseRecord.getSize();
+                    return true;
+                } catch (Exception e) {
+                    BacktraceLogger.d(LOG_TAG, "Exception on removing record "
+                            + databaseRecord.id.toString() + "from db context: " + e.getMessage());
                 }
-                catch (Exception e) {
-                    BacktraceLogger.d(LOG_TAG, "Exception on removing record from db context: " + e.getMessage());
-                }
-                
-                return true;
             }
         }
         return false;


### PR DESCRIPTION
This PR addresses a bug that can lead to a ConcurrentModificationException when deleting records from BacktraceDatabaseContext within the BacktraceHandlerThread. The issue arises when the records list is modified during a for-each loop, which is not allowed in Java as it causes a ConcurrentModificationException.

Changes:
- Refactored the code to avoid modifying the records list during iteration by direct usage of iterator.
- Implemented a safe mechanism to handle record deletion without impacting the integrity of the loop.
- Unit tests which deleting two records from database context

This fix ensures that the database operations in BacktraceHandlerThread are handled more reliably, preventing runtime exceptions and improving overall stability.

Ref: BT-3082 