### PR TITLE
Update libs (gson, androidx.test)

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -78,15 +78,15 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.11.0'
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test:rules:1.6.1'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'org.mockito:mockito-core:5.2.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'org.mockito:mockito-core:2.28.2'
     androidTestImplementation "org.mockito:mockito-android:2.28.2"
 }
 

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -82,11 +82,11 @@ dependencies {
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation 'org.mockito:mockito-core:2.28.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'org.mockito:mockito-core:5.2.0'
     androidTestImplementation "org.mockito:mockito-android:2.28.2"
 }
 

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -77,16 +77,16 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.10.1'
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation 'org.mockito:mockito-core:2.28.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'org.mockito:mockito-core:5.2.0'
     androidTestImplementation "org.mockito:mockito-android:2.28.2"
 }
 

--- a/coroner-client/build.gradle
+++ b/coroner-client/build.gradle
@@ -9,7 +9,7 @@ java {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'com.google.code.gson:gson:2.10.1'
+    implementation 'com.google.code.gson:gson:2.11.0'
     testImplementation 'junit:junit:4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.2.0'
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -62,13 +62,13 @@ String getProperty(String name, String defaultValue) {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'androidx.appcompat:appcompat:1.7.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation project(':backtrace-library')
     androidTestImplementation project(path: ':coroner-client')
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -65,10 +65,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
-    androidTestImplementation 'androidx.test:rules:1.5.0'
+    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
+    androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
     implementation project(':backtrace-library')
     androidTestImplementation project(path: ':coroner-client')
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -62,13 +62,13 @@ String getProperty(String name, String defaultValue) {
 
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
-    implementation 'androidx.appcompat:appcompat:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.2.1'
-    androidTestImplementation 'androidx.test:rules:1.6.1'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test:rules:1.5.0'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     implementation project(':backtrace-library')
     androidTestImplementation project(path: ':coroner-client')
 }


### PR DESCRIPTION
**Description:**

This pull request updates the dependencies in the Backtrace-Android library, with a primary focus on upgrading the Gson library to its latest version. These updates help ensure better compatibility, security, and performance.

**Key changes:**
- Upgraded Gson to the latest version.
- Updated other dependencies to their latest stable releases.

Ref: BT-3194