### PR TITLE
(Example-app) Remove unsupported Android Manifest package value

### DIFF
--- a/example-app/src/main/AndroidManifest.xml
+++ b/example-app/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="backtraceio.backtraceio">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />


### PR DESCRIPTION
During build process task `processDebugMainManifest` returns below error

```
package="backtraceio.backtraceio" found in source AndroidManifest.xml: /home/runner/work/backtrace-android/backtrace-android/example-app/src/main/AndroidManifest.xml.
Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported, and the value is ignored.
Recommendation: remove package="backtraceio.backtraceio" from the source AndroidManifest.xml: /home/runner/work/backtrace-android/backtrace-android/example-app/src/main/AndroidManifest.xml.
```

This change is removing unsupported attribute, it's already moved to build.gradle in example-app.

Ref: BT-3195