### PR TITLE
Improve `setLevel` method doc in `BacktraceLogger`

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/logger/BacktraceLogger.java
+++ b/backtrace-library/src/main/java/backtraceio/library/logger/BacktraceLogger.java
@@ -78,8 +78,8 @@ public class BacktraceLogger {
      * Set logging level from which all messages should be logged to the console
      * @param level login level (debug, warn, error, off)
      *
-     * @deprecated setting the logging level should be done directly in the passed custom logger
-     * implementation so as not to depend on the internal implementation of
+     * @deprecated Setting the logging level should now be done directly in the passed custom logger
+     * implementation. LogLevel should not depend on the internal implementation of
      * Backtrace internal logger and used LogLevel types.
      *
      */

--- a/backtrace-library/src/main/java/backtraceio/library/logger/BacktraceLogger.java
+++ b/backtrace-library/src/main/java/backtraceio/library/logger/BacktraceLogger.java
@@ -79,8 +79,8 @@ public class BacktraceLogger {
      * @param level login level (debug, warn, error, off)
      *
      * @deprecated setting the logging level should be done directly in the passed custom logger
-     * implementation so as not to depend on the internal implementation of Backtrace internal
-     * LogLevel types.
+     * implementation so as not to depend on the internal implementation of
+     * Backtrace internal logger and used LogLevel types.
      *
      */
     @Deprecated


### PR DESCRIPTION
Improve `setLevel` method doc to emphasize why this method is now deprecated.