### PR TITLE
Logging debug time of breadcrumbs init and setup native integration

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -14,6 +14,7 @@ import backtraceio.library.base.BacktraceBase;
 import backtraceio.library.breadcrumbs.BacktraceBreadcrumbs;
 import backtraceio.library.common.FileHelper;
 import backtraceio.library.common.TypeHelper;
+import backtraceio.library.common.serialization.DebugHelper;
 import backtraceio.library.enums.UnwindingMode;
 import backtraceio.library.enums.database.RetryBehavior;
 import backtraceio.library.events.OnServerResponseEventListener;
@@ -173,6 +174,7 @@ public class BacktraceDatabase implements Database {
             return false;
         }
 
+        final long startSetupNativeIntegrationTime = DebugHelper.getCurrentTimeMillis();
         String minidumpSubmissionUrl = credentials.getMinidumpSubmissionUrl().toString();
         if (minidumpSubmissionUrl == null) {
             return false;
@@ -215,6 +217,10 @@ public class BacktraceDatabase implements Database {
                 this.addAttribute("breadcrumbs.lastId", Long.toString((breadcrumbId)));
             });
         }
+
+        final long endSetupNativeIntegrationTime = DebugHelper.getCurrentTimeMillis();
+        BacktraceLogger.d(LOG_TAG, "Setup native integration took " + (endSetupNativeIntegrationTime - startSetupNativeIntegrationTime) + " milliseconds");
+
         return _enabledNativeIntegration;
     }
 

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -10,6 +10,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Map;
 
+import backtraceio.library.common.serialization.DebugHelper;
 import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
 import backtraceio.library.events.OnSuccessfulBreadcrumbAddEventListener;
@@ -32,12 +33,12 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     private EnumSet<BacktraceBreadcrumbType> enabledBreadcrumbTypes;
 
     /**
-     * The Backtrace BroadcastReciever instance
+     * The Backtrace BroadcastReceiver instance
      */
     private BacktraceBroadcastReceiver backtraceBroadcastReceiver;
 
     /**
-     * The Backtrace ComponentCallbacks2 listener
+     * The Backtrace ComponentCallbacks listener
      */
     private BacktraceComponentListener backtraceComponentListener;
 
@@ -147,6 +148,19 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     @Override
     public boolean enableBreadcrumbs(Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
         this.context = context;
+
+        final long startEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
+
+        final boolean enabled = enableBreadcrumbs(breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes);
+
+        final long endEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
+
+        BacktraceLogger.d(LOG_TAG, "Enabling breadcrumbs took " + (endEnablingReportsTime - startEnablingReportsTime) + " milliseconds");
+
+        return enabled;
+    }
+
+    private boolean enableBreadcrumbs(EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
         if (backtraceBreadcrumbsLogManager == null) {
             try {
                 backtraceBreadcrumbsLogManager = new BacktraceBreadcrumbsLogManager(

--- a/backtrace-library/src/main/java/backtraceio/library/common/serialization/DebugHelper.java
+++ b/backtrace-library/src/main/java/backtraceio/library/common/serialization/DebugHelper.java
@@ -1,0 +1,8 @@
+package backtraceio.library.common.serialization;
+
+public class DebugHelper {
+
+    public static long getCurrentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+}


### PR DESCRIPTION
Log information about how long took breadcrumbs init and setup native integration for debug purposes.