### PR TITLE
Bump Android SDK to v34

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -10,13 +10,11 @@ androidGitVersion {
 }
 
 android {
-
-    compileSdkVersion 34
     namespace "backtraceio.library"
     defaultConfig {
         minSdkVersion 21
         compileSdk 34
-        targetSdkVersion 33
+        targetSdkVersion 34
         versionName androidGitVersion.name()
         versionCode androidGitVersion.code()
         buildConfigField("String", "VERSION_NAME", "\"${versionName}\"")
@@ -89,8 +87,8 @@ dependencies {
     androidTestImplementation 'androidx.test:rules:1.6.1'
     androidTestImplementation 'androidx.test.ext:junit:1.2.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'org.mockito:mockito-core:5.2.0'
-    androidTestImplementation "org.mockito:mockito-android:2.28.2"
+    androidTestImplementation 'org.mockito:mockito-core:5.12.0'
+    androidTestImplementation "org.mockito:mockito-android:5.12.0"
 }
 
 apply from: 'publish.gradle'

--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -11,10 +11,11 @@ androidGitVersion {
 
 android {
 
-    compileSdkVersion 33
+    compileSdkVersion 34
     namespace "backtraceio.library"
     defaultConfig {
         minSdkVersion 21
+        compileSdk 34
         targetSdkVersion 33
         versionName androidGitVersion.name()
         versionCode androidGitVersion.code()

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.0'
+        classpath 'com.android.tools.build:gradle:8.3.2'
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
     }

--- a/coroner-client/build.gradle
+++ b/coroner-client/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.11.0'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.2.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.12.0'
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -1,9 +1,9 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 34
     namespace "backtraceio.backtraceio"
     defaultConfig {
+        compileSdk 34
         applicationId "backtraceio.backtraceio"
         minSdkVersion 21
         targetSdkVersion 34


### PR DESCRIPTION
Bump Android SDK from v33 to v34 and `compileSdkVersion` field is deprecated.