### PR TITLE
Fix default timeout in BacktraceANRSettings

### DIFF
--- a/backtrace-library/src/main/java/backtraceio/library/anr/BacktraceANRSettings.java
+++ b/backtrace-library/src/main/java/backtraceio/library/anr/BacktraceANRSettings.java
@@ -2,28 +2,82 @@ package backtraceio.library.anr;
 
 import backtraceio.library.watchdog.OnApplicationNotRespondingEvent;
 
+
+/**
+ * Configuration settings for Application Not Responding (ANR) detection.
+ * This class allows customization of ANR monitoring behavior, such as the timeout duration
+ * and callback events.
+ */
 public class BacktraceANRSettings {
-    private int timeout = 0;
-    private boolean debug = false;
-    private OnApplicationNotRespondingEvent onApplicationNotRespondingEvent = null;
+    /**
+     * Default timeout value in milliseconds
+     */
+    public final static int DEFAULT_ANR_TIMEOUT = 5000;
 
-    public BacktraceANRSettings() { }
+    /**
+     * The timeout in milliseconds after which an ANR is reported if the main thread is blocked.
+     */
+    private final int timeout;
 
-    public BacktraceANRSettings(int timeout, OnApplicationNotRespondingEvent onApplicationNotRespondingEvent, boolean debug) {
-        super();
-        this.debug = debug;
-        this.onApplicationNotRespondingEvent = onApplicationNotRespondingEvent;
-        this.timeout = timeout;
+    /**
+     * Flag to enable or disable additional debug logging for ANR detection.
+     * When true, more verbose logging related to ANR monitoring might be produced.
+     */
+    private final boolean debug;
+
+    /**
+     * Callback interface to be invoked when an Application Not Responding event is detected.
+     * This allows custom handling of ANR events.
+     */
+    private final OnApplicationNotRespondingEvent onApplicationNotRespondingEvent;
+
+    /**
+     * Default constructor.
+     * Initializes ANR settings with default values.
+     */
+    public BacktraceANRSettings() {
+        this(DEFAULT_ANR_TIMEOUT, null, false);
     }
 
+    /**
+     * Constructs ANR settings with specified parameters.
+     *
+     * @param timeout                         The timeout in milliseconds for ANR detection.
+     *                                        A value of 0 might disable ANR detection or use a default.
+     * @param onApplicationNotRespondingEvent The callback to be invoked when an ANR is detected.
+     *                                        Can be null if no custom callback is needed.
+     * @param debug                           True to enable debug logging for ANR detection, false otherwise.
+     */
+    public BacktraceANRSettings(int timeout, OnApplicationNotRespondingEvent onApplicationNotRespondingEvent, boolean debug) {
+        this.timeout = timeout;
+        this.onApplicationNotRespondingEvent = onApplicationNotRespondingEvent;
+        this.debug = debug;
+    }
+
+    /**
+     * Gets the configured ANR timeout in milliseconds.
+     *
+     * @return The timeout in milliseconds. A value of 0 might indicate disabled ANR detection
+     * or reliance on a default.
+     */
     public int getTimeout() {
         return timeout;
     }
 
+    /**
+     * Checks if debug logging for ANR detection is enabled.
+     *
+     * @return True if debug logging is enabled, false otherwise.
+     */
     public boolean isDebug() {
         return debug;
     }
 
+    /**
+     * Gets the configured callback for ANR events.
+     *
+     * @return The {@link OnApplicationNotRespondingEvent} callback, or null if none is set.
+     */
     public OnApplicationNotRespondingEvent getOnApplicationNotRespondingEvent() {
         return onApplicationNotRespondingEvent;
     }

--- a/backtrace-library/src/main/java/backtraceio/library/anr/BacktraceANRSettings.java
+++ b/backtrace-library/src/main/java/backtraceio/library/anr/BacktraceANRSettings.java
@@ -43,7 +43,6 @@ public class BacktraceANRSettings {
      * Constructs ANR settings with specified parameters.
      *
      * @param timeout                         The timeout in milliseconds for ANR detection.
-     *                                        A value of 0 might disable ANR detection or use a default.
      * @param onApplicationNotRespondingEvent The callback to be invoked when an ANR is detected.
      *                                        Can be null if no custom callback is needed.
      * @param debug                           True to enable debug logging for ANR detection, false otherwise.
@@ -57,8 +56,7 @@ public class BacktraceANRSettings {
     /**
      * Gets the configured ANR timeout in milliseconds.
      *
-     * @return The timeout in milliseconds. A value of 0 might indicate disabled ANR detection
-     * or reliance on a default.
+     * @return The timeout in milliseconds.
      */
     public int getTimeout() {
         return timeout;

--- a/backtrace-library/src/main/java/backtraceio/library/watchdog/BacktraceANRHandlerWatchdog.java
+++ b/backtrace-library/src/main/java/backtraceio/library/watchdog/BacktraceANRHandlerWatchdog.java
@@ -8,6 +8,7 @@ import java.util.Calendar;
 
 import backtraceio.library.BacktraceClient;
 import backtraceio.library.anr.BacktraceANRHandler;
+import backtraceio.library.anr.BacktraceANRSettings;
 import backtraceio.library.logger.BacktraceLogger;
 
 
@@ -18,11 +19,6 @@ import backtraceio.library.logger.BacktraceLogger;
 public class BacktraceANRHandlerWatchdog extends Thread implements BacktraceANRHandler {
 
     private final static String LOG_TAG = BacktraceANRHandlerWatchdog.class.getSimpleName();
-
-    /**
-     * Default timeout value in milliseconds
-     */
-    private final static int DEFAULT_ANR_TIMEOUT = 5000;
 
     /**
      * Current Backtrace client instance which will be used to send information about exception
@@ -60,7 +56,7 @@ public class BacktraceANRHandlerWatchdog extends Thread implements BacktraceANRH
      * @param client current Backtrace client instance which will be used to send information about exception
      */
     public BacktraceANRHandlerWatchdog(BacktraceClient client) {
-        this(client, DEFAULT_ANR_TIMEOUT);
+        this(client, BacktraceANRSettings.DEFAULT_ANR_TIMEOUT);
     }
 
     /**

--- a/backtrace-library/src/test/java/backtraceio/library/anr/BacktraceANRSettingsTest.java
+++ b/backtrace-library/src/test/java/backtraceio/library/anr/BacktraceANRSettingsTest.java
@@ -1,0 +1,41 @@
+package backtraceio.library.anr;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import backtraceio.library.watchdog.BacktraceWatchdogTimeoutException;
+import backtraceio.library.watchdog.OnApplicationNotRespondingEvent;
+
+public class BacktraceANRSettingsTest {
+
+    @Test
+    public void defaultConstructor() {
+        // WHEN
+        BacktraceANRSettings settings = new BacktraceANRSettings();
+        // THEN
+        assertEquals(BacktraceANRSettings.DEFAULT_ANR_TIMEOUT, settings.getTimeout());
+        assertNull(settings.getOnApplicationNotRespondingEvent());
+        assertFalse(settings.isDebug());
+    }
+
+    @Test
+    public void paramsConstructor() {
+        // GIVEN
+        int timeout = 2000;
+        boolean debug = true;
+        OnApplicationNotRespondingEvent event = exception -> {
+
+        };
+        // WHEN
+        BacktraceANRSettings settings = new BacktraceANRSettings(timeout, event, debug);
+
+        // THEN
+        assertEquals(timeout, settings.getTimeout());
+        assertEquals(event, settings.getOnApplicationNotRespondingEvent());
+        assertEquals(debug, settings.isDebug());
+    }
+
+}


### PR DESCRIPTION
### Overview
This PR corrects the default timeout configuration for BacktraceANRSettings, changing it from an unintended `0` (no wait) to a proper, non-zero default value.

### Changes
- Updated the default timeout value to a meaningful duration instead of `0`.
- Adjusted documentation to reflect the new default timeout setting.

### Why It Matters
A zero-valued default timeout could lead to immediate timeouts or unintended behavior. Establishing a sensible default enhances API reliability and improves crash handling in common usage scenarios.

### Notes
No functional logic is altered, this change strictly corrects configuration defaults and supports documentation clarity.