### PR TITLE
Fix jacoco coverage tests and bump mockito to latest

### DIFF
--- a/backtrace-library/build.gradle
+++ b/backtrace-library/build.gradle
@@ -41,13 +41,17 @@ android {
     buildTypes {
         buildTypes {
             debug {
-                testCoverageEnabled false
+                testCoverageEnabled true
             }
         }
         release {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+    }
+
+    testCoverage {
+        jacocoVersion = "0.8.13"
     }
 
     externalNativeBuild {
@@ -116,14 +120,12 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.squareup:tape:1.2.3'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.mockito:mockito-core:5.18.0"
+    testImplementation "org.mockito:mockito-core:5.19.0"
     testImplementation 'org.json:json:20250517'
     testImplementation "com.google.guava:guava:33.4.8-jre"
     androidTestImplementation 'net.jodah:concurrentunit:0.4.6'
-    androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
-    androidTestImplementation 'org.mockito:mockito-core:5.18.0'
-    androidTestImplementation "org.mockito:mockito-android:5.18.0"
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
+    androidTestImplementation "org.mockito:mockito-android:5.19.0"
 }

--- a/coroner-client/build.gradle
+++ b/coroner-client/build.gradle
@@ -11,5 +11,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.google.code.gson:gson:2.13.1'
     testImplementation 'junit:junit:4.13.2'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.18.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '5.19.0'
 }

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -68,7 +68,7 @@ dependencies {
     androidTestImplementation 'androidx.test.ext:junit:1.3.0'
     androidTestImplementation 'androidx.test:rules:1.7.0'
     androidTestImplementation 'net.jodah:concurrentunit:0.4.6'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.6.1'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.7.0'
     implementation project(':backtrace-library')
     androidTestImplementation project(path: ':coroner-client')
 }


### PR DESCRIPTION
Changes:
- Use latest JaCoCo for test coverage
- Enable test coverage
- Use latest `mockito-core`, `mockito-android` and `espresso-core`
- Remove duplicated imports