### PR TITLE
feature: add minimum breadcrumb level filtering

### DIFF
--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
@@ -9,6 +9,7 @@ import static junit.framework.TestCase.fail;
 import android.content.Context;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
+import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
 import java.io.File;
 import java.io.IOException;
@@ -140,6 +141,146 @@ public class BacktraceBreadcrumbsTest {
 
             JSONObject parsedBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
             assertEquals("test-manual", parsedBreadcrumb.get("message"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddBreadcrumbRejectsLevelBelowMinimum() {
+        try {
+            cleanUp();
+
+            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs.enableBreadcrumbs(
+                    context, BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+
+            // Below threshold, dropped
+            assertFalse(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-debug", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+            assertFalse(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-info", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.INFO));
+
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
+
+            // Only the configuration breadcrumb should be present.
+            assertEquals(1, breadcrumbLogFileData.size());
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddBreadcrumbAcceptsLevelAtOrAboveMinimum() {
+        try {
+            cleanUp();
+
+            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs.enableBreadcrumbs(
+                    context, BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+
+            // At threshold, retain
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-warning", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.WARNING));
+            // Above threshold, retain
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-error", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.ERROR));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-fatal", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.FATAL));
+
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
+
+            // Configuration breadcrumb + three added.
+            assertEquals(4, breadcrumbLogFileData.size());
+
+            assertEquals("test-warning", new JSONObject(breadcrumbLogFileData.get(1)).get("message"));
+            assertEquals("test-error", new JSONObject(breadcrumbLogFileData.get(2)).get("message"));
+            assertEquals("test-fatal", new JSONObject(breadcrumbLogFileData.get(3)).get("message"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testAddBreadcrumbDefaultMinLevelAcceptsAllLevels() {
+        try {
+            // default min level should be DEBUG on setUp()
+            assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
+
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-debug", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-info", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.INFO));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-warning", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.WARNING));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-error", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.ERROR));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "test-fatal", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.FATAL));
+
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
+
+            // Configuration breadcrumb + five added.
+            assertEquals(6, breadcrumbLogFileData.size());
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testReEnableBreadcrumbsUpdatesMinLevel() {
+        try {
+            cleanUp();
+
+            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs.enableBreadcrumbs(
+                    context, BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.DEBUG);
+            assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
+
+            // Initial threshold lets DEBUG through.
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "pre-change", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+
+            // Tighten threshold by re-enabling.
+            backtraceBreadcrumbs.enableBreadcrumbs(
+                    context, BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.ERROR);
+            assertEquals(BacktraceBreadcrumbLevel.ERROR, backtraceBreadcrumbs.getMinBreadcrumbLevel());
+
+            // Now DEBUG is dropped; ERROR still goes through.
+            assertFalse(backtraceBreadcrumbs.addBreadcrumb(
+                    "post-change-debug", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "post-change-error", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.ERROR));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
+    }
+
+    @Test
+    public void testConfigurationBreadcrumbIncludesMinLevel() {
+        try {
+            cleanUp();
+
+            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs.enableBreadcrumbs(
+                    context, BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
+
+            JSONObject configBreadcrumb = new JSONObject(breadcrumbLogFileData.get(0));
+            assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
+            assertEquals(
+                    "warning",
+                    configBreadcrumb.getJSONObject("attributes").get("min_breadcrumb_level"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
@@ -273,49 +273,52 @@ public class BacktraceBreadcrumbsTest {
             fail(ex.getMessage());
         }
     }
-@Test
-public void testNullMinBreadcrumbLevelDefaultsToDebug() {
-    try {
-        cleanUp();
 
-        backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+    @Test
+    public void testNullMinBreadcrumbLevelDefaultsToDebug() {
+        try {
+            cleanUp();
 
-        assertTrue(backtraceBreadcrumbs.enableBreadcrumbs(context, (BacktraceBreadcrumbLevel) null));
-        assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
+            backtraceBreadcrumbs =
+                    new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
 
-        assertTrue(backtraceBreadcrumbs.addBreadcrumb(
-                "debug-after-null-min-level", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+            assertTrue(backtraceBreadcrumbs.enableBreadcrumbs(context, (BacktraceBreadcrumbLevel) null));
+            assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
 
-        List<String> breadcrumbLogFileData =
-                BreadcrumbsReader.readBreadcrumbLogFile(context.getFilesDir().getAbsolutePath());
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                    "debug-after-null-min-level", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
 
-        JSONObject configBreadcrumb = new JSONObject(breadcrumbLogFileData.get(0));
-        assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
-        assertEquals("debug", configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
 
-        JSONObject debugBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
-        assertEquals("debug-after-null-min-level", debugBreadcrumb.get("message"));
-        assertEquals("debug", debugBreadcrumb.get("level"));
-    } catch (Exception ex) {
-        fail(ex.getMessage());
+            JSONObject configBreadcrumb = new JSONObject(breadcrumbLogFileData.get(0));
+            assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
+            assertEquals("debug", configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
+
+            JSONObject debugBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
+            assertEquals("debug-after-null-min-level", debugBreadcrumb.get("message"));
+            assertEquals("debug", debugBreadcrumb.get("level"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
     }
-}
 
-@Test
-public void testNullBreadcrumbLevelDefaultsToInfo() {
-    try {
-        assertTrue(backtraceBreadcrumbs.addBreadcrumb("null-level", BacktraceBreadcrumbType.MANUAL, null));
+    @Test
+    public void testNullBreadcrumbLevelDefaultsToInfo() {
+        try {
+            assertTrue(backtraceBreadcrumbs.addBreadcrumb("null-level", BacktraceBreadcrumbType.MANUAL, null));
 
-        List<String> breadcrumbLogFileData =
-                BreadcrumbsReader.readBreadcrumbLogFile(context.getFilesDir().getAbsolutePath());
+            List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
+                    context.getFilesDir().getAbsolutePath());
 
-        JSONObject parsedBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
-        assertEquals("null-level", parsedBreadcrumb.get("message"));
-        assertEquals("info", parsedBreadcrumb.get("level"));
-    } catch (Exception ex) {
-        fail(ex.getMessage());
+            JSONObject parsedBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
+            assertEquals("null-level", parsedBreadcrumb.get("message"));
+            assertEquals("info", parsedBreadcrumb.get("level"));
+        } catch (Exception ex) {
+            fail(ex.getMessage());
+        }
     }
-}
+
     @Test
     public void testConfigurationBreadcrumbIncludesMinLevel() {
         try {

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
@@ -280,7 +280,7 @@ public class BacktraceBreadcrumbsTest {
             assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
             assertEquals(
                     "warning",
-                    configBreadcrumb.getJSONObject("attributes").get("min_breadcrumb_level"));
+                    configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
@@ -151,10 +151,13 @@ public class BacktraceBreadcrumbsTest {
         try {
             cleanUp();
 
-            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs =
+                    new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
             backtraceBreadcrumbs.enableBreadcrumbs(
-                    context, BacktraceBreadcrumbType.ALL,
-                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+                    context,
+                    BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES,
+                    BacktraceBreadcrumbLevel.WARNING);
 
             // Below threshold, dropped
             assertFalse(backtraceBreadcrumbs.addBreadcrumb(
@@ -177,10 +180,13 @@ public class BacktraceBreadcrumbsTest {
         try {
             cleanUp();
 
-            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs =
+                    new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
             backtraceBreadcrumbs.enableBreadcrumbs(
-                    context, BacktraceBreadcrumbType.ALL,
-                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+                    context,
+                    BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES,
+                    BacktraceBreadcrumbLevel.WARNING);
 
             // At threshold, retain
             assertTrue(backtraceBreadcrumbs.addBreadcrumb(
@@ -237,10 +243,13 @@ public class BacktraceBreadcrumbsTest {
         try {
             cleanUp();
 
-            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs =
+                    new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
             backtraceBreadcrumbs.enableBreadcrumbs(
-                    context, BacktraceBreadcrumbType.ALL,
-                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.DEBUG);
+                    context,
+                    BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES,
+                    BacktraceBreadcrumbLevel.DEBUG);
             assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
 
             // Initial threshold lets DEBUG through.
@@ -249,8 +258,10 @@ public class BacktraceBreadcrumbsTest {
 
             // Tighten threshold by re-enabling.
             backtraceBreadcrumbs.enableBreadcrumbs(
-                    context, BacktraceBreadcrumbType.ALL,
-                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.ERROR);
+                    context,
+                    BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES,
+                    BacktraceBreadcrumbLevel.ERROR);
             assertEquals(BacktraceBreadcrumbLevel.ERROR, backtraceBreadcrumbs.getMinBreadcrumbLevel());
 
             // Now DEBUG is dropped; ERROR still goes through.
@@ -268,19 +279,20 @@ public class BacktraceBreadcrumbsTest {
         try {
             cleanUp();
 
-            backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+            backtraceBreadcrumbs =
+                    new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
             backtraceBreadcrumbs.enableBreadcrumbs(
-                    context, BacktraceBreadcrumbType.ALL,
-                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES, BacktraceBreadcrumbLevel.WARNING);
+                    context,
+                    BacktraceBreadcrumbType.ALL,
+                    BacktraceBreadcrumbs.DEFAULT_MAX_LOG_SIZE_BYTES,
+                    BacktraceBreadcrumbLevel.WARNING);
 
             List<String> breadcrumbLogFileData = BreadcrumbsReader.readBreadcrumbLogFile(
                     context.getFilesDir().getAbsolutePath());
 
             JSONObject configBreadcrumb = new JSONObject(breadcrumbLogFileData.get(0));
             assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
-            assertEquals(
-                    "warning",
-                    configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
+            assertEquals("warning", configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
         } catch (Exception ex) {
             fail(ex.getMessage());
         }

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbsTest.java
@@ -273,7 +273,49 @@ public class BacktraceBreadcrumbsTest {
             fail(ex.getMessage());
         }
     }
+@Test
+public void testNullMinBreadcrumbLevelDefaultsToDebug() {
+    try {
+        cleanUp();
 
+        backtraceBreadcrumbs = new BacktraceBreadcrumbs(context.getFilesDir().getAbsolutePath());
+
+        assertTrue(backtraceBreadcrumbs.enableBreadcrumbs(context, (BacktraceBreadcrumbLevel) null));
+        assertEquals(BacktraceBreadcrumbLevel.DEBUG, backtraceBreadcrumbs.getMinBreadcrumbLevel());
+
+        assertTrue(backtraceBreadcrumbs.addBreadcrumb(
+                "debug-after-null-min-level", BacktraceBreadcrumbType.MANUAL, BacktraceBreadcrumbLevel.DEBUG));
+
+        List<String> breadcrumbLogFileData =
+                BreadcrumbsReader.readBreadcrumbLogFile(context.getFilesDir().getAbsolutePath());
+
+        JSONObject configBreadcrumb = new JSONObject(breadcrumbLogFileData.get(0));
+        assertEquals("Breadcrumbs configuration", configBreadcrumb.get("message"));
+        assertEquals("debug", configBreadcrumb.getJSONObject("attributes").get("breadcrumb.level"));
+
+        JSONObject debugBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
+        assertEquals("debug-after-null-min-level", debugBreadcrumb.get("message"));
+        assertEquals("debug", debugBreadcrumb.get("level"));
+    } catch (Exception ex) {
+        fail(ex.getMessage());
+    }
+}
+
+@Test
+public void testNullBreadcrumbLevelDefaultsToInfo() {
+    try {
+        assertTrue(backtraceBreadcrumbs.addBreadcrumb("null-level", BacktraceBreadcrumbType.MANUAL, null));
+
+        List<String> breadcrumbLogFileData =
+                BreadcrumbsReader.readBreadcrumbLogFile(context.getFilesDir().getAbsolutePath());
+
+        JSONObject parsedBreadcrumb = new JSONObject(breadcrumbLogFileData.get(1));
+        assertEquals("null-level", parsedBreadcrumb.get("message"));
+        assertEquals("info", parsedBreadcrumb.get("level"));
+    } catch (Exception ex) {
+        fail(ex.getMessage());
+    }
+}
     @Test
     public void testConfigurationBreadcrumbIncludesMinLevel() {
         try {

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
@@ -69,30 +69,3 @@ public class BreadcrumbsReader {
         }
     }
 }
-        FileInputStream inputStream = new FileInputStream(breadcrumbLogFile.getAbsolutePath());
-
-        StringBuilder stringBuilder = new StringBuilder();
-        while (inputStream.available() > 0) {
-            char c = (char) inputStream.read();
-            if (c == '\n') {
-                String line = stringBuilder.toString();
-                int braceStart = line.indexOf('{');
-                if (braceStart >= 0) {
-                    String candidate = line.substring(braceStart);
-                    try {
-                        JSONObject parsed = new JSONObject(candidate);
-                        if (parsed.has("timestamp")) {
-                            breadcrumbLogFileData.add(candidate);
-                        }
-                    } catch (JSONException ignored) {
-                    }
-                }
-                stringBuilder = new StringBuilder();
-                continue;
-            }
-            stringBuilder.append(c);
-        }
-
-        return breadcrumbLogFileData;
-    }
-}

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
@@ -28,6 +28,47 @@ public class BreadcrumbsReader {
         File breadcrumbLogFile = new File(breadcrumbs.getBreadcrumbLogPath());
 
         List<String> breadcrumbLogFileData = new ArrayList<String>();
+
+        try (FileInputStream inputStream = new FileInputStream(breadcrumbLogFile.getAbsolutePath())) {
+            StringBuilder stringBuilder = new StringBuilder();
+            int readByte;
+
+            while ((readByte = inputStream.read()) != -1) {
+                char c = (char) readByte;
+                if (c == '\n') {
+                    addBreadcrumbJsonRecordIfValid(breadcrumbLogFileData, stringBuilder.toString());
+                    stringBuilder.setLength(0);
+                    continue;
+                }
+
+                stringBuilder.append(c);
+            }
+
+            if (stringBuilder.length() > 0) {
+                addBreadcrumbJsonRecordIfValid(breadcrumbLogFileData, stringBuilder.toString());
+            }
+        }
+
+        return breadcrumbLogFileData;
+    }
+
+    private static void addBreadcrumbJsonRecordIfValid(List<String> breadcrumbLogFileData, String line) {
+        int braceStart = line.indexOf('{');
+        if (braceStart < 0) {
+            return;
+        }
+
+        String candidate = line.substring(braceStart);
+        try {
+            JSONObject parsed = new JSONObject(candidate);
+            if (parsed.has("timestamp")) {
+                breadcrumbLogFileData.add(candidate);
+            }
+        } catch (JSONException ignored) {
+            // Ignore QueueFile framing bytes and partial rollover fragments.
+        }
+    }
+}
         FileInputStream inputStream = new FileInputStream(breadcrumbLogFile.getAbsolutePath());
 
         StringBuilder stringBuilder = new StringBuilder();

--- a/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/breadcrumbs/BreadcrumbsReader.java
@@ -5,9 +5,24 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.json.JSONException;
+import org.json.JSONObject;
 
+/**
+ * Test helper that extracts breadcrumb JSON records from the on-disk QueueFile log.
+ */
 public class BreadcrumbsReader {
 
+    /**
+     * Reads the breadcrumb log file and returns each breadcrumb as a JSON string.
+     *
+     * <p>Lines are trimmed to their first {@code '{'}} to strip QueueFile framing bytes,
+     * then kept only if they parse as JSON and contain a {@code timestamp} field. This
+     * filters out framing noise and orphaned sub-objects exposed by rollover.</p>
+     *
+     * @param path directory containing the breadcrumb log
+     * @return breadcrumb records in file order
+     */
     public static List<String> readBreadcrumbLogFile(String path) throws IOException {
         BacktraceBreadcrumbs breadcrumbs = new BacktraceBreadcrumbs(path);
         File breadcrumbLogFile = new File(breadcrumbs.getBreadcrumbLogPath());
@@ -15,15 +30,21 @@ public class BreadcrumbsReader {
         List<String> breadcrumbLogFileData = new ArrayList<String>();
         FileInputStream inputStream = new FileInputStream(breadcrumbLogFile.getAbsolutePath());
 
-        // The encoding contains headers for the encoded data
-        // We just throw away lines that don't start with "timestamp
         StringBuilder stringBuilder = new StringBuilder();
         while (inputStream.available() > 0) {
             char c = (char) inputStream.read();
             if (c == '\n') {
                 String line = stringBuilder.toString();
-                if (line.matches(".*timestamp.*")) {
-                    breadcrumbLogFileData.add(line);
+                int braceStart = line.indexOf('{');
+                if (braceStart >= 0) {
+                    String candidate = line.substring(braceStart);
+                    try {
+                        JSONObject parsed = new JSONObject(candidate);
+                        if (parsed.has("timestamp")) {
+                            breadcrumbLogFileData.add(candidate);
+                        }
+                    } catch (JSONException ignored) {
+                    }
                 }
                 stringBuilder = new StringBuilder();
                 continue;

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -436,9 +436,8 @@ public class BacktraceBase implements Client {
      * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should
      *                                  be a power of 2
      * @return true if we successfully enabled breadcrumbs
-     * @note breadcrumbTypesToEnable only affects automatic breadcrumb receivers.
-     *       User created
-     *       breadcrumbs will always be enabled
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers.
+     *       User created breadcrumbs will always be enabled
      */
     public boolean enableBreadcrumbs(Context context, int maxBreadcrumbLogSizeBytes) {
         if (!isBreadcrumbsAvailable()) {
@@ -454,9 +453,8 @@ public class BacktraceBase implements Client {
      * @param breadcrumbTypesToEnable a set containing which breadcrumb types to
      *                                enable
      * @return true if we successfully enabled breadcrumbs
-     * @note breadcrumbTypesToEnable only affects automatic breadcrumb receivers.
-     *       User created
-     *       breadcrumbs will always be enabled
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers.
+     *       User created breadcrumbs will always be enabled
      */
     public boolean enableBreadcrumbs(Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable) {
         if (!isBreadcrumbsAvailable()) {
@@ -474,9 +472,8 @@ public class BacktraceBase implements Client {
      * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should
      *                                  be a power of 2
      * @return true if we successfully enabled breadcrumbs
-     * @note breadcrumbTypesToEnable only affects automatic breadcrumb receivers.
-     *       User created
-     *       breadcrumbs will always be enabled
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers.
+     *       User created breadcrumbs will always be enabled
      */
     public boolean enableBreadcrumbs(
             Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
@@ -484,6 +481,106 @@ public class BacktraceBase implements Client {
             return false;
         }
         return database.getBreadcrumbs().enableBreadcrumbs(context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes);
+    }
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context            context of current state of the application
+     * @param minBreadcrumbLevel the minimum severity level a breadcrumb must
+     *                           have to be recorded. Breadcrumbs with a level
+     *                           below this threshold will be dropped.
+     * @return true if we successfully enabled breadcrumbs
+     */
+    public boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        if (!isBreadcrumbsAvailable()) {
+            return false;
+        }
+        return database.getBreadcrumbs().enableBreadcrumbs(context, minBreadcrumbLevel);
+    }
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                 context of current state of the application
+     * @param breadcrumbTypesToEnable a set containing which breadcrumb types to
+     *                                enable
+     * @param minBreadcrumbLevel      the minimum severity level a breadcrumb
+     *                                must have to be recorded. Breadcrumbs with
+     *                                a level below this threshold will be
+     *                                dropped.
+     * @return true if we successfully enabled breadcrumbs
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers.
+     *       User created breadcrumbs will always be enabled (subject to the minBreadcrumbLevel
+     *       threshold)
+     */
+    public boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        if (!isBreadcrumbsAvailable()) {
+            return false;
+        }
+        return database.getBreadcrumbs().enableBreadcrumbs(context, breadcrumbTypesToEnable, minBreadcrumbLevel);
+    }
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                   context of current state of the application
+     * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should
+     *                                  be a power of 2
+     * @param minBreadcrumbLevel        the minimum severity level a breadcrumb
+     *                                  must have to be recorded. Breadcrumbs
+     *                                  with a level below this threshold will be
+     *                                  dropped.
+     * @return true if we successfully enabled breadcrumbs
+     */
+    public boolean enableBreadcrumbs(
+            Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        if (!isBreadcrumbsAvailable()) {
+            return false;
+        }
+        return database.getBreadcrumbs().enableBreadcrumbs(context, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
+    }
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                   context of current state of the application
+     * @param breadcrumbTypesToEnable   a set containing which breadcrumb types to
+     *                                  enable
+     * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should
+     *                                  be a power of 2
+     * @param minBreadcrumbLevel        the minimum severity level a breadcrumb
+     *                                  must have to be recorded. Breadcrumbs
+     *                                  with a level below this threshold will be
+     *                                  dropped.
+     * @return true if we successfully enabled breadcrumbs
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers.
+     *       User created breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel}
+     *       threshold)
+     */
+    public boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        if (!isBreadcrumbsAvailable()) {
+            return false;
+        }
+        return database.getBreadcrumbs().enableBreadcrumbs(
+                context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
+    }
+
+    /**
+     * Gets the current minimum breadcrumb level threshold. Breadcrumbs with a
+     * level below this value are dropped when the breadcrumb is added.
+     *
+     * @return the current minimum breadcrumb level, or null if breadcrumbs are
+     *         not available
+     */
+    public BacktraceBreadcrumbLevel getMinBreadcrumbLevel() {
+        if (!isBreadcrumbsAvailable()) {
+            return null;
+        }
+        return database.getBreadcrumbs().getMinBreadcrumbLevel();
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -515,7 +515,9 @@ public class BacktraceBase implements Client {
      *       threshold)
      */
     public boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         if (!isBreadcrumbsAvailable()) {
             return false;
         }
@@ -560,13 +562,15 @@ public class BacktraceBase implements Client {
      *       threshold)
      */
     public boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
-            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         if (!isBreadcrumbsAvailable()) {
             return false;
         }
-        return database.getBreadcrumbs().enableBreadcrumbs(
-                context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
+        return database.getBreadcrumbs()
+                .enableBreadcrumbs(context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -212,7 +212,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         }
 
         this.enabledBreadcrumbTypes = breadcrumbTypesToEnable;
-        this.minBreadcrumbLevel = minBreadcrumbLevel;
+        this.minBreadcrumbLevel = minBreadcrumbLevel != null ? minBreadcrumbLevel : BacktraceBreadcrumbLevel.DEBUG;
         registerAutomaticBreadcrumbReceivers();
 
         // We should log all breadcrumb configuration changes in the breadcrumbs
@@ -367,6 +367,9 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         }
         if (!enabledBreadcrumbTypes.contains(type)) {
             return false;
+        }
+        if (level == null) {
+            level = BacktraceBreadcrumbLevel.INFO;
         }
         if (level.ordinal() < minBreadcrumbLevel.ordinal()) {
             return false;

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -371,7 +371,6 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         if (level.ordinal() < minBreadcrumbLevel.ordinal()) {
             return false;
         }
-        System.out.println("adding bc:" + message);
         boolean addResult = backtraceBreadcrumbsLogManager.addBreadcrumb(message, attributes, type, level);
         if (addResult && this.onSuccessfulBreadcrumbAddEventListener != null) {
             this.onSuccessfulBreadcrumbAddEventListener.onSuccessfulAdd(this.getCurrentBreadcrumbId());

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -414,7 +414,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
             attributes.put(enabledType.toString(), state);
         }
 
-        attributes.put("min_breadcrumb_level", minBreadcrumbLevel.toString());
+        attributes.put("breadcrumb.level", minBreadcrumbLevel.toString());
 
         return backtraceBreadcrumbsLogManager.addBreadcrumb(
                 "Breadcrumbs configuration",

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -31,6 +31,13 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     private EnumSet<BacktraceBreadcrumbType> enabledBreadcrumbTypes;
 
     /**
+     * Minimum severity level a breadcrumb must have to be recorded. Breadcrumbs with a level
+     * below this threshold are dropped when the breadcrumb is added. Defaults to
+     * {@link BacktraceBreadcrumbLevel#DEBUG} (records all levels).
+     */
+    private BacktraceBreadcrumbLevel minBreadcrumbLevel = BacktraceBreadcrumbLevel.DEBUG;
+
+    /**
      * The Backtrace BroadcastReceiver instance
      */
     private BacktraceBroadcastReceiver backtraceBroadcastReceiver;
@@ -145,11 +152,35 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     @Override
     public boolean enableBreadcrumbs(
             Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
+        return enableBreadcrumbs(context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel.DEBUG);
+    }
+
+    @Override
+    public boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, BacktraceBreadcrumbType.ALL, DEFAULT_MAX_LOG_SIZE_BYTES, minBreadcrumbLevel);
+    }
+
+    @Override
+    public boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, breadcrumbTypesToEnable, DEFAULT_MAX_LOG_SIZE_BYTES, minBreadcrumbLevel);
+    }
+
+    @Override
+    public boolean enableBreadcrumbs(
+            Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, BacktraceBreadcrumbType.ALL, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
+    }
+
+    @Override
+    public boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         this.context = context;
 
         final long startEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
 
-        final boolean enabled = enableBreadcrumbs(breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes);
+        final boolean enabled = enableBreadcrumbs(breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
 
         final long endEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
 
@@ -161,7 +192,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     }
 
     private boolean enableBreadcrumbs(
-            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         if (backtraceBreadcrumbsLogManager == null) {
             try {
                 backtraceBreadcrumbsLogManager = new BacktraceBreadcrumbsLogManager(
@@ -173,6 +204,7 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         }
 
         this.enabledBreadcrumbTypes = breadcrumbTypesToEnable;
+        this.minBreadcrumbLevel = minBreadcrumbLevel;
         registerAutomaticBreadcrumbReceivers();
 
         // We should log all breadcrumb configuration changes in the breadcrumbs
@@ -183,6 +215,11 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     @Override
     public EnumSet<BacktraceBreadcrumbType> getEnabledBreadcrumbTypes() {
         return this.enabledBreadcrumbTypes;
+    }
+
+    @Override
+    public BacktraceBreadcrumbLevel getMinBreadcrumbLevel() {
+        return this.minBreadcrumbLevel;
     }
 
     @Override
@@ -323,6 +360,10 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
         if (!enabledBreadcrumbTypes.contains(type)) {
             return false;
         }
+        if (level.ordinal() < minBreadcrumbLevel.ordinal()) {
+            return false;
+        }
+        System.out.println("adding bc:" + message);
         boolean addResult = backtraceBreadcrumbsLogManager.addBreadcrumb(message, attributes, type, level);
         if (addResult && this.onSuccessfulBreadcrumbAddEventListener != null) {
             this.onSuccessfulBreadcrumbAddEventListener.onSuccessfulAdd(this.getCurrentBreadcrumbId());
@@ -372,6 +413,8 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
 
             attributes.put(enabledType.toString(), state);
         }
+
+        attributes.put("min_breadcrumb_level", minBreadcrumbLevel.toString());
 
         return backtraceBreadcrumbsLogManager.addBreadcrumb(
                 "Breadcrumbs configuration",

--- a/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/breadcrumbs/BacktraceBreadcrumbs.java
@@ -152,7 +152,8 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     @Override
     public boolean enableBreadcrumbs(
             Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes) {
-        return enableBreadcrumbs(context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel.DEBUG);
+        return enableBreadcrumbs(
+                context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel.DEBUG);
     }
 
     @Override
@@ -162,7 +163,9 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
 
     @Override
     public boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         return enableBreadcrumbs(context, breadcrumbTypesToEnable, DEFAULT_MAX_LOG_SIZE_BYTES, minBreadcrumbLevel);
     }
 
@@ -174,13 +177,16 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
 
     @Override
     public boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
-            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         this.context = context;
 
         final long startEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
 
-        final boolean enabled = enableBreadcrumbs(breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
+        final boolean enabled =
+                enableBreadcrumbs(breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes, minBreadcrumbLevel);
 
         final long endEnablingReportsTime = DebugHelper.getCurrentTimeMillis();
 
@@ -192,7 +198,9 @@ public class BacktraceBreadcrumbs implements Breadcrumbs {
     }
 
     private boolean enableBreadcrumbs(
-            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         if (backtraceBreadcrumbsLogManager == null) {
             try {
                 backtraceBreadcrumbsLogManager = new BacktraceBreadcrumbsLogManager(

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -59,9 +59,6 @@ public interface Breadcrumbs {
      *                           Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      *                           A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
-     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
-     * {@link #enableBreadcrumbs(Context)} to preserve backward compatibility for downstream
-     * implementers. Override to apply the level threshold.
      */
     default boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         return enableBreadcrumbs(context);
@@ -79,9 +76,6 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
-     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
-     * {@link #enableBreadcrumbs(Context, EnumSet)} to preserve backward compatibility for downstream
-     * implementers. Override to apply the level threshold.
      */
     default boolean enableBreadcrumbs(
             Context context,
@@ -100,9 +94,6 @@ public interface Breadcrumbs {
      *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      *                                  A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
-     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
-     * {@link #enableBreadcrumbs(Context, int)} to preserve backward compatibility for downstream
-     * implementers. Override to apply the level threshold.
      */
     default boolean enableBreadcrumbs(
             Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
@@ -122,9 +113,6 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
-     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
-     * {@link #enableBreadcrumbs(Context, EnumSet, int)} to preserve backward compatibility for
-     * downstream implementers. Override to apply the level threshold.
      */
     default boolean enableBreadcrumbs(
             Context context,
@@ -146,9 +134,6 @@ public interface Breadcrumbs {
      * value are dropped when the breadcrumb is added.
      *
      * @return the current minimum breadcrumb level
-     * @implNote The default implementation returns {@link BacktraceBreadcrumbLevel#DEBUG} (record
-     * all levels) to preserve the pre-threshold behavior for downstream implementers. Override to
-     * report the configured threshold.
      */
     default BacktraceBreadcrumbLevel getMinBreadcrumbLevel() {
         return BacktraceBreadcrumbLevel.DEBUG;

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -57,6 +57,7 @@ public interface Breadcrumbs {
      * @param minBreadcrumbLevel the minimum severity level a breadcrumb must have to be recorded.
      *                           Breadcrumbs with a level below this threshold will be dropped.
      *                           Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     *                           A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
      * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
      * {@link #enableBreadcrumbs(Context)} to preserve backward compatibility for downstream
@@ -74,6 +75,7 @@ public interface Breadcrumbs {
      * @param minBreadcrumbLevel      the minimum severity level a breadcrumb must have to be recorded.
      *                                Breadcrumbs with a level below this threshold will be dropped.
      *                                Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     *                                A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
@@ -96,6 +98,7 @@ public interface Breadcrumbs {
      * @param minBreadcrumbLevel        the minimum severity level a breadcrumb must have to be recorded.
      *                                  Breadcrumbs with a level below this threshold will be dropped.
      *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     *                                  A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
      * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
      * {@link #enableBreadcrumbs(Context, int)} to preserve backward compatibility for downstream
@@ -115,6 +118,7 @@ public interface Breadcrumbs {
      * @param minBreadcrumbLevel        the minimum severity level a breadcrumb must have to be recorded.
      *                                  Breadcrumbs with a level below this threshold will be dropped.
      *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     *                                  A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -120,6 +120,11 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     *
+     * <p><strong>Default implementation:</strong> delegates to
+     * {@link #enableBreadcrumbs(Context, EnumSet, int)} to preserve compatibility with existing implementations. 
+     * Implementations must override this method to apply
+     * {@code minBreadcrumbLevel} filtering.</p>
      */
     default boolean enableBreadcrumbs(
             Context context,

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -158,7 +158,7 @@ public interface Breadcrumbs {
      * Add a breadcrumb of type "Manual" and the desired level with the provided message string
      *
      * @param message a message which describes this breadcrumb (1KB max)
-     * @param level   the severity level of this breadcrumb
+     * @param level   the severity level of this breadcrumb ({@code null} is treated as {@link BacktraceBreadcrumbLevel#INFO})
      * @return true if the breadcrumb was successfully added
      */
     boolean addBreadcrumb(String message, BacktraceBreadcrumbLevel level);
@@ -177,7 +177,7 @@ public interface Breadcrumbs {
      *
      * @param message    a message which describes this breadcrumb (1KB max)
      * @param attributes key-value pairs to provide additional information about this breadcrumb (1KB max, including some overhead per key-value pair)
-     * @param level      the severity level of this breadcrumb
+     * @param level      the severity level of this breadcrumb ({@code null} is treated as {@link BacktraceBreadcrumbLevel#INFO})
      * @return true if the breadcrumb was successfully added
      */
     boolean addBreadcrumb(String message, Map<String, Object> attributes, BacktraceBreadcrumbLevel level);
@@ -196,7 +196,7 @@ public interface Breadcrumbs {
      *
      * @param message a message which describes this breadcrumb (1KB max)
      * @param type    broadly describes the category of this breadcrumb
-     * @param level   the severity level of this breadcrumb
+     * @param level   the severity level of this breadcrumb ({@code null} is treated as {@link BacktraceBreadcrumbLevel#INFO})
      * @return true if the breadcrumb was successfully added
      */
     boolean addBreadcrumb(String message, BacktraceBreadcrumbType type, BacktraceBreadcrumbLevel level);
@@ -217,7 +217,7 @@ public interface Breadcrumbs {
      * @param message    a message which describes this breadcrumb (1KB max)
      * @param attributes key-value pairs to provide additional information about this breadcrumb (1KB max, including some overhead per key-value pair)
      * @param type       broadly describes the category of this breadcrumb
-     * @param level      the severity level of this breadcrumb
+     * @param level      the severity level of this breadcrumb ({@code null} is treated as {@link BacktraceBreadcrumbLevel#INFO})
      * @return true if the breadcrumb was successfully added
      */
     boolean addBreadcrumb(

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -79,6 +79,10 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     *
+     * <p><strong>Default implementation:</strong> delegates to
+     * {@link #enableBreadcrumbs(Context, EnumSet)} to preserve compatibility with existing implementations. 
+     * Implementations must override this method to apply {@code minBreadcrumbLevel} filtering.</p>
      */
     default boolean enableBreadcrumbs(
             Context context,

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -23,7 +23,7 @@ public interface Breadcrumbs {
      * @param context                 context of current state of the application
      * @param breadcrumbTypesToEnable a set containing which breadcrumb types to enable
      * @return true if we successfully enabled breadcrumbs
-     * @note breadcrumbTypesToEnable only affects automatic breadcrumb receivers. User created
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled
      */
     boolean enableBreadcrumbs(Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable);
@@ -44,11 +44,67 @@ public interface Breadcrumbs {
      * @param breadcrumbTypesToEnable   a set containing which breadcrumb types to enable
      * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should be a power of 2
      * @return true if we successfully enabled breadcrumbs
-     * @note breadcrumbTypesToEnable only affects automatic breadcrumb receivers. User created
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled
      */
     boolean enableBreadcrumbs(
             Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, int maxBreadcrumbLogSizeBytes);
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context            context of current state of the application
+     * @param minBreadcrumbLevel the minimum severity level a breadcrumb must have to be recorded.
+     *                           Breadcrumbs with a level below this threshold will be dropped.
+     *                           Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     * @return true if we successfully enabled breadcrumbs
+     */
+    boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                 context of current state of the application
+     * @param breadcrumbTypesToEnable a set containing which breadcrumb types to enable
+     * @param minBreadcrumbLevel      the minimum severity level a breadcrumb must have to be recorded.
+     *                                Breadcrumbs with a level below this threshold will be dropped.
+     *                                Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     * @return true if we successfully enabled breadcrumbs
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
+     * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     */
+    boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                   context of current state of the application
+     * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should be a power of 2
+     * @param minBreadcrumbLevel        the minimum severity level a breadcrumb must have to be recorded.
+     *                                  Breadcrumbs with a level below this threshold will be dropped.
+     *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     * @return true if we successfully enabled breadcrumbs
+     */
+    boolean enableBreadcrumbs(
+            Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+
+    /**
+     * Enable logging of breadcrumbs and submission with crash reports
+     *
+     * @param context                   context of current state of the application
+     * @param breadcrumbTypesToEnable   a set containing which breadcrumb types to enable
+     * @param maxBreadcrumbLogSizeBytes breadcrumb log size limit in bytes, should be a power of 2
+     * @param minBreadcrumbLevel        the minimum severity level a breadcrumb must have to be recorded.
+     *                                  Breadcrumbs with a level below this threshold will be dropped.
+     *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
+     * @return true if we successfully enabled breadcrumbs
+     * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
+     * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     */
+    boolean enableBreadcrumbs(
+            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel);
 
     /**
      * Gets the enabled breadcrumb types
@@ -56,6 +112,14 @@ public interface Breadcrumbs {
      * @return enabled breadcrumb types
      */
     EnumSet<BacktraceBreadcrumbType> getEnabledBreadcrumbTypes();
+
+    /**
+     * Gets the current minimum breadcrumb level threshold. Breadcrumbs with a level below this
+     * value are dropped when the breadcrumb is added.
+     *
+     * @return the current minimum breadcrumb level
+     */
+    BacktraceBreadcrumbLevel getMinBreadcrumbLevel();
 
     /**
      * Clear breadcrumb logs

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -101,6 +101,11 @@ public interface Breadcrumbs {
      *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      *                                  A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
+     *
+     * <p><strong>Default implementation:</strong> delegates to
+     * {@link #enableBreadcrumbs(Context, int)} to preserve compatibility with existing implementations. 
+     * Implementations must override this method to apply
+     * {@code minBreadcrumbLevel} filtering.</p>
      */
     default boolean enableBreadcrumbs(
             Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -58,8 +58,13 @@ public interface Breadcrumbs {
      *                           Breadcrumbs with a level below this threshold will be dropped.
      *                           Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      * @return true if we successfully enabled breadcrumbs
+     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
+     * {@link #enableBreadcrumbs(Context)} to preserve backward compatibility for downstream
+     * implementers. Override to apply the level threshold.
      */
-    boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+    default boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context);
+    }
 
     /**
      * Enable logging of breadcrumbs and submission with crash reports
@@ -72,11 +77,16 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
+     * {@link #enableBreadcrumbs(Context, EnumSet)} to preserve backward compatibility for downstream
+     * implementers. Override to apply the level threshold.
      */
-    boolean enableBreadcrumbs(
+    default boolean enableBreadcrumbs(
             Context context,
             EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
-            BacktraceBreadcrumbLevel minBreadcrumbLevel);
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, breadcrumbTypesToEnable);
+    }
 
     /**
      * Enable logging of breadcrumbs and submission with crash reports
@@ -87,9 +97,14 @@ public interface Breadcrumbs {
      *                                  Breadcrumbs with a level below this threshold will be dropped.
      *                                  Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      * @return true if we successfully enabled breadcrumbs
+     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
+     * {@link #enableBreadcrumbs(Context, int)} to preserve backward compatibility for downstream
+     * implementers. Override to apply the level threshold.
      */
-    boolean enableBreadcrumbs(
-            Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+    default boolean enableBreadcrumbs(
+            Context context, int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, maxBreadcrumbLogSizeBytes);
+    }
 
     /**
      * Enable logging of breadcrumbs and submission with crash reports
@@ -103,12 +118,17 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      * @note {@code breadcrumbTypesToEnable} only affects automatic breadcrumb receivers. User created
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
+     * @implNote The default implementation ignores {@code minBreadcrumbLevel} and delegates to
+     * {@link #enableBreadcrumbs(Context, EnumSet, int)} to preserve backward compatibility for
+     * downstream implementers. Override to apply the level threshold.
      */
-    boolean enableBreadcrumbs(
+    default boolean enableBreadcrumbs(
             Context context,
             EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
             int maxBreadcrumbLogSizeBytes,
-            BacktraceBreadcrumbLevel minBreadcrumbLevel);
+            BacktraceBreadcrumbLevel minBreadcrumbLevel) {
+        return enableBreadcrumbs(context, breadcrumbTypesToEnable, maxBreadcrumbLogSizeBytes);
+    }
 
     /**
      * Gets the enabled breadcrumb types
@@ -122,8 +142,13 @@ public interface Breadcrumbs {
      * value are dropped when the breadcrumb is added.
      *
      * @return the current minimum breadcrumb level
+     * @implNote The default implementation returns {@link BacktraceBreadcrumbLevel#DEBUG} (record
+     * all levels) to preserve the pre-threshold behavior for downstream implementers. Override to
+     * report the configured threshold.
      */
-    BacktraceBreadcrumbLevel getMinBreadcrumbLevel();
+    default BacktraceBreadcrumbLevel getMinBreadcrumbLevel() {
+        return BacktraceBreadcrumbLevel.DEBUG;
+    }
 
     /**
      * Clear breadcrumb logs

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -74,7 +74,9 @@ public interface Breadcrumbs {
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
      */
     boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel);
 
     /**
      * Enable logging of breadcrumbs and submission with crash reports
@@ -103,8 +105,10 @@ public interface Breadcrumbs {
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
      */
     boolean enableBreadcrumbs(
-            Context context, EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
-            int maxBreadcrumbLogSizeBytes, BacktraceBreadcrumbLevel minBreadcrumbLevel);
+            Context context,
+            EnumSet<BacktraceBreadcrumbType> breadcrumbTypesToEnable,
+            int maxBreadcrumbLogSizeBytes,
+            BacktraceBreadcrumbLevel minBreadcrumbLevel);
 
     /**
      * Gets the enabled breadcrumb types

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -62,7 +62,7 @@ public interface Breadcrumbs {
      *
      * <p><strong>Default implementation:</strong> delegates to {@link #enableBreadcrumbs(Context)}
      * to preserve compatibility with existing implementations. Implementations must override this method to apply {@code minBreadcrumbLevel} filtering.</p>
-     */ 
+     */
     default boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         return enableBreadcrumbs(context);
     }
@@ -81,7 +81,7 @@ public interface Breadcrumbs {
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
      *
      * <p><strong>Default implementation:</strong> delegates to
-     * {@link #enableBreadcrumbs(Context, EnumSet)} to preserve compatibility with existing implementations. 
+     * {@link #enableBreadcrumbs(Context, EnumSet)} to preserve compatibility with existing implementations.
      * Implementations must override this method to apply {@code minBreadcrumbLevel} filtering.</p>
      */
     default boolean enableBreadcrumbs(
@@ -103,7 +103,7 @@ public interface Breadcrumbs {
      * @return true if we successfully enabled breadcrumbs
      *
      * <p><strong>Default implementation:</strong> delegates to
-     * {@link #enableBreadcrumbs(Context, int)} to preserve compatibility with existing implementations. 
+     * {@link #enableBreadcrumbs(Context, int)} to preserve compatibility with existing implementations.
      * Implementations must override this method to apply
      * {@code minBreadcrumbLevel} filtering.</p>
      */
@@ -127,7 +127,7 @@ public interface Breadcrumbs {
      * breadcrumbs will always be enabled (subject to the {@code minBreadcrumbLevel} threshold)
      *
      * <p><strong>Default implementation:</strong> delegates to
-     * {@link #enableBreadcrumbs(Context, EnumSet, int)} to preserve compatibility with existing implementations. 
+     * {@link #enableBreadcrumbs(Context, EnumSet, int)} to preserve compatibility with existing implementations.
      * Implementations must override this method to apply
      * {@code minBreadcrumbLevel} filtering.</p>
      */

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -59,7 +59,10 @@ public interface Breadcrumbs {
      *                           Use {@link BacktraceBreadcrumbLevel#DEBUG} to record all levels.
      *                           A {@code null} value is treated as {@link BacktraceBreadcrumbLevel#DEBUG}.
      * @return true if we successfully enabled breadcrumbs
-     */
+     *
+     * <p><strong>Default implementation:</strong> delegates to {@link #enableBreadcrumbs(Context)}
+     * to preserve compatibility with existing implementations. Implementations must override this method to apply {@code minBreadcrumbLevel} filtering.</p>
+     */ 
     default boolean enableBreadcrumbs(Context context, BacktraceBreadcrumbLevel minBreadcrumbLevel) {
         return enableBreadcrumbs(context);
     }

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Breadcrumbs.java
@@ -134,6 +134,9 @@ public interface Breadcrumbs {
      * value are dropped when the breadcrumb is added.
      *
      * @return the current minimum breadcrumb level
+     *
+     * <p><strong>Default implementation:</strong> returns {@link BacktraceBreadcrumbLevel#DEBUG},
+     * which preserves the existing behavior of recording all breadcrumb levels.</p>
      */
     default BacktraceBreadcrumbLevel getMinBreadcrumbLevel() {
         return BacktraceBreadcrumbLevel.DEBUG;

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -187,6 +187,7 @@ public class MainActivity extends AppCompatActivity {
             throw new Exception("App context is null");
         }
 
+        // NOTE: Minimum breadcrumb level set to INFO (DEBUG breadcrumbs will be filtered out)
         backtraceClient.enableBreadcrumbs(view.getContext().getApplicationContext(), BacktraceBreadcrumbLevel.INFO);
         registerNativeBreadcrumbs(backtraceClient); // Order should not matter
     }
@@ -206,11 +207,11 @@ public class MainActivity extends AppCompatActivity {
             }
         };
         backtraceClient.addBreadcrumb("About to send Backtrace report", attributes, BacktraceBreadcrumbType.LOG);
-        backtraceClient.addBreadcrumb("sending dbg bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.DEBUG);
-        backtraceClient.addBreadcrumb("sending info bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.INFO);
-        backtraceClient.addBreadcrumb("sending warn bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.WARNING);
-        backtraceClient.addBreadcrumb("sending err bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.ERROR);
-        backtraceClient.addBreadcrumb("sending fatal bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.FATAL);
+        backtraceClient.addBreadcrumb("Debug breadcrumb (< INFO, filtered)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.DEBUG);
+        backtraceClient.addBreadcrumb("Info breadcrumb (== INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.INFO);
+        backtraceClient.addBreadcrumb("Warning breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.WARNING);
+        backtraceClient.addBreadcrumb("Error breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.ERROR);
+        backtraceClient.addBreadcrumb("Fatal breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.FATAL);
         addNativeBreadcrumb();
         addNativeBreadcrumbUserError();
         BacktraceReport report = new BacktraceReport("Test");

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -11,6 +11,7 @@ import backtraceio.library.BacktraceClient;
 import backtraceio.library.BacktraceCredentials;
 import backtraceio.library.BacktraceDatabase;
 import backtraceio.library.base.BacktraceBase;
+import backtraceio.library.enums.BacktraceBreadcrumbLevel;
 import backtraceio.library.enums.BacktraceBreadcrumbType;
 import backtraceio.library.enums.database.RetryBehavior;
 import backtraceio.library.enums.database.RetryOrder;
@@ -186,7 +187,7 @@ public class MainActivity extends AppCompatActivity {
             throw new Exception("App context is null");
         }
 
-        backtraceClient.enableBreadcrumbs(view.getContext().getApplicationContext());
+        backtraceClient.enableBreadcrumbs(view.getContext().getApplicationContext(), BacktraceBreadcrumbLevel.INFO);
         registerNativeBreadcrumbs(backtraceClient); // Order should not matter
     }
 
@@ -205,6 +206,11 @@ public class MainActivity extends AppCompatActivity {
             }
         };
         backtraceClient.addBreadcrumb("About to send Backtrace report", attributes, BacktraceBreadcrumbType.LOG);
+        backtraceClient.addBreadcrumb("sending dbg bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.DEBUG);
+        backtraceClient.addBreadcrumb("sending info bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.INFO);
+        backtraceClient.addBreadcrumb("sending warn bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.WARNING);
+        backtraceClient.addBreadcrumb("sending err bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.ERROR);
+        backtraceClient.addBreadcrumb("sending fatal bc", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.FATAL);
         addNativeBreadcrumb();
         addNativeBreadcrumbUserError();
         BacktraceReport report = new BacktraceReport("Test");

--- a/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
+++ b/example-app/src/main/java/backtraceio/backtraceio/MainActivity.java
@@ -207,11 +207,22 @@ public class MainActivity extends AppCompatActivity {
             }
         };
         backtraceClient.addBreadcrumb("About to send Backtrace report", attributes, BacktraceBreadcrumbType.LOG);
-        backtraceClient.addBreadcrumb("Debug breadcrumb (< INFO, filtered)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.DEBUG);
-        backtraceClient.addBreadcrumb("Info breadcrumb (== INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.INFO);
-        backtraceClient.addBreadcrumb("Warning breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.WARNING);
-        backtraceClient.addBreadcrumb("Error breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.ERROR);
-        backtraceClient.addBreadcrumb("Fatal breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.FATAL);
+        backtraceClient.addBreadcrumb(
+                "Debug breadcrumb (< INFO, filtered)",
+                attributes,
+                BacktraceBreadcrumbType.LOG,
+                BacktraceBreadcrumbLevel.DEBUG);
+        backtraceClient.addBreadcrumb(
+                "Info breadcrumb (== INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.INFO);
+        backtraceClient.addBreadcrumb(
+                "Warning breadcrumb (> INFO)",
+                attributes,
+                BacktraceBreadcrumbType.LOG,
+                BacktraceBreadcrumbLevel.WARNING);
+        backtraceClient.addBreadcrumb(
+                "Error breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.ERROR);
+        backtraceClient.addBreadcrumb(
+                "Fatal breadcrumb (> INFO)", attributes, BacktraceBreadcrumbType.LOG, BacktraceBreadcrumbLevel.FATAL);
         addNativeBreadcrumb();
         addNativeBreadcrumbUserError();
         BacktraceReport report = new BacktraceReport("Test");


### PR DESCRIPTION
## Summary

Adds a way to set the global minimum breadcrumb level while enabling breadcrumbs, which allows filtering the breadcrumbs from being added, when below the minimum level.

## Changes

- **Breadcrumbs.java**: 4 new `enableBreadcrumbs` backward-compatible overloads with `minBreadcrumbLevel` argument, plus `getMinBreadcrumbLevel()`.
- **BacktraceBreadcrumbs.java**: stores the `minBreadcrumbLevel` threshold, default `DEBUG` level, drops below-threshold breadcrumbs during `addBreadcrumb`, logs the level in the configuration breadcrumb.
- **BacktraceBase.java**: forwards the new overloads and getter to the breadcrumb implementation.
- **BacktraceBreadcrumbsTest.java**: 5 tests covering below/at/above threshold, default level, re-enable update level, new `breadcrumb.level` attribute in config.
- **MainActivity.java**: example app sets min level to `INFO` and emits one breadcrumb per level in `sendReport` to showcase the filter.
- **BreadcrumbsReader.java**: included JSON-parse check with existing substring `timestamp` match; issue exposed by the new `breadcrumb.level` attribute shifting QueueFile byte alignment.

ref: BT-6699