### PR TITLE
feature: support more than 64 native attributes

### DIFF
--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -61,12 +61,25 @@ namespace {
     }
 
     // Stores attributes as crashpad StringAnnotations, replacing the 64-entry
-    // simple_annotations dictionary. The snapshot reader reads at most
-    // crashpad::kMaxNumberOfAnnotations per module, so SetAnnotation drops new
-    // keys past that. Annotations and name buffers are allocated once and never
+    // simple_annotations dictionary. The crashpad snapshot reader reads at most
+    // crashpad::kMaxNumberOfAnnotations annotation objects per module, so
+    // SetAnnotation drops new user keys past that limit (internal keys keep
+    // reserved slots). Annotations and name buffers are allocated once and never
     // freed (the global list references them for the process lifetime).
     constexpr crashpad::Annotation::ValueSizeType kAnnotationValueMaxSize = 4096;
     using DynamicAnnotation = crashpad::StringAnnotation<kAnnotationValueMaxSize>;
+
+    // Reserve slots for internal, per-report annotations so they are never
+    // crowded out by user attributes near the read limit.
+    constexpr size_t kReservedAnnotationSlots = 2; // error.message, _mod_faulting_tid
+
+    bool IsValidAnnotationKey(const char* rawKey) {
+        return rawKey != nullptr && rawKey[0] != '\0';
+    }
+
+    bool IsReservedAnnotationKey(const std::string& key) {
+        return key == "error.message" || key == "_mod_faulting_tid";
+    }
 
     std::unordered_map<std::string, DynamicAnnotation*> g_annotations;
 
@@ -84,14 +97,18 @@ namespace {
     }
 
     void SetAnnotation(const char* rawKey, const char* rawValue) {
-        if (rawKey == nullptr || rawKey[0] == '\0') {
+        if (!IsValidAnnotationKey(rawKey)) {
             return;
         }
         const std::lock_guard<std::mutex> lock(attribute_synchronization);
         std::string key(rawKey);
-        // Drop new keys past the read limit; updates to existing keys are fine.
-        if (g_annotations.find(key) == g_annotations.end()
-                && g_annotations.size() >= crashpad::kMaxNumberOfAnnotations) {
+        const bool isNewKey = g_annotations.find(key) == g_annotations.end();
+        // Cap user keys below the read limit so the reserved internal keys can
+        // always be registered; updates to existing keys are always allowed.
+        const size_t userAnnotationLimit =
+                crashpad::kMaxNumberOfAnnotations - kReservedAnnotationSlots;
+        if (isNewKey && !IsReservedAnnotationKey(key)
+                && g_annotations.size() >= userAnnotationLimit) {
             __android_log_print(
                     ANDROID_LOG_WARN,
                     "Backtrace-Android",

--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -3,6 +3,7 @@
 #include "handler/crash_report_upload_thread.h"
 #include "backtrace-native.h"
 #include "client/annotation.h"
+#include "snapshot/snapshot_constants.h"
 #include <jni.h>
 #include <libgen.h>
 #include <cstring>
@@ -59,11 +60,11 @@ namespace {
                 "Started Crashpad upload thread for offline native reports");
     }
 
-    // Stores each attribute as a crashpad StringAnnotation in the global
-    // AnnotationList (unbounded), replacing the legacy simple_annotations
-    // dictionary that was limited to 64 entries. Once set, an annotation is
-    // permanently referenced by crashpad's global list, so annotations and
-    // their name buffers are allocated once and never freed.
+    // Stores attributes as crashpad StringAnnotations, replacing the 64-entry
+    // simple_annotations dictionary. The snapshot reader reads at most
+    // crashpad::kMaxNumberOfAnnotations per module, so SetAnnotation drops new
+    // keys past that. Annotations and name buffers are allocated once and never
+    // freed (the global list references them for the process lifetime).
     constexpr crashpad::Annotation::ValueSizeType kAnnotationValueMaxSize = 4096;
     using DynamicAnnotation = crashpad::StringAnnotation<kAnnotationValueMaxSize>;
 
@@ -87,7 +88,18 @@ namespace {
             return;
         }
         const std::lock_guard<std::mutex> lock(attribute_synchronization);
-        DynamicAnnotation* annotation = GetOrCreateAnnotation(std::string(rawKey));
+        std::string key(rawKey);
+        // Drop new keys past the read limit; updates to existing keys are fine.
+        if (g_annotations.find(key) == g_annotations.end()
+                && g_annotations.size() >= crashpad::kMaxNumberOfAnnotations) {
+            __android_log_print(
+                    ANDROID_LOG_WARN,
+                    "Backtrace-Android",
+                    "Dropping native attribute '%s': reached crashpad's annotation read limit",
+                    rawKey);
+            return;
+        }
+        DynamicAnnotation* annotation = GetOrCreateAnnotation(key);
         // Set(const char*) uses strncpy; the StringPiece overload uses std::copy.
         annotation->Set(base::StringPiece(rawValue != nullptr ? rawValue : ""));
     }

--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -2,8 +2,11 @@
 #include "handler/handler_main.h"
 #include "handler/crash_report_upload_thread.h"
 #include "backtrace-native.h"
+#include "client/annotation.h"
 #include <jni.h>
 #include <libgen.h>
+#include <cstring>
+#include <unordered_map>
 
 extern std::string thread_id;
 extern std::atomic_bool initialized;
@@ -54,6 +57,50 @@ namespace {
                 ANDROID_LOG_INFO,
                 "Backtrace-Android",
                 "Started Crashpad upload thread for offline native reports");
+    }
+
+    // Stores each attribute as a crashpad StringAnnotation in the global
+    // AnnotationList (unbounded), replacing the legacy simple_annotations
+    // dictionary that was limited to 64 entries. Once set, an annotation is
+    // permanently referenced by crashpad's global list, so annotations and
+    // their name buffers are allocated once and never freed.
+    constexpr crashpad::Annotation::ValueSizeType kAnnotationValueMaxSize = 4096;
+    using DynamicAnnotation = crashpad::StringAnnotation<kAnnotationValueMaxSize>;
+
+    std::unordered_map<std::string, DynamicAnnotation*> g_annotations;
+
+    // Caller must hold attribute_synchronization.
+    DynamicAnnotation* GetOrCreateAnnotation(const std::string& key) {
+        auto it = g_annotations.find(key);
+        if (it != g_annotations.end()) {
+            return it->second;
+        }
+        char* nameCopy = new char[key.size() + 1];
+        std::memcpy(nameCopy, key.c_str(), key.size() + 1);
+        DynamicAnnotation* annotation = new DynamicAnnotation(nameCopy);
+        g_annotations.emplace(key, annotation);
+        return annotation;
+    }
+
+    void SetAnnotation(const char* rawKey, const char* rawValue) {
+        if (rawKey == nullptr || rawKey[0] == '\0') {
+            return;
+        }
+        const std::lock_guard<std::mutex> lock(attribute_synchronization);
+        DynamicAnnotation* annotation = GetOrCreateAnnotation(std::string(rawKey));
+        // Set(const char*) uses strncpy; the StringPiece overload uses std::copy.
+        annotation->Set(base::StringPiece(rawValue != nullptr ? rawValue : ""));
+    }
+
+    void ClearAnnotation(const char* rawKey) {
+        if (rawKey == nullptr || rawKey[0] == '\0') {
+            return;
+        }
+        const std::lock_guard<std::mutex> lock(attribute_synchronization);
+        auto it = g_annotations.find(std::string(rawKey));
+        if (it != g_annotations.end()) {
+            it->second->Clear();
+        }
     }
 
 } // namespace
@@ -325,23 +372,14 @@ void DumpWithoutCrashCrashpad(jstring message, jboolean set_main_thread_as_fault
     crashpad::CaptureContext(&context);
 
     // set dump message for single report
-    crashpad::SimpleStringDictionary *annotations = NULL;
-
     if (message != NULL || set_main_thread_as_faulting_thread == true) {
         JNIEnv *env = GetJniEnv();
         if (env == nullptr) {
             __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android", "Cannot initialize JNIEnv");
             return;
         }
-        const std::lock_guard<std::mutex> lock(attribute_synchronization);
-        crashpad::CrashpadInfo *info = crashpad::CrashpadInfo::GetCrashpadInfo();
-        annotations = info->simple_annotations();
-        if (!annotations) {
-            annotations = new crashpad::SimpleStringDictionary();
-            info->set_simple_annotations(annotations);
-        }
         if (set_main_thread_as_faulting_thread == true) {
-            annotations->SetKeyValue("_mod_faulting_tid", thread_id);
+            SetAnnotation("_mod_faulting_tid", thread_id.c_str());
         }
         if (message != NULL) {
             // user can't override error.message - exception message that Crashpad/crash-reporting tool
@@ -349,14 +387,14 @@ void DumpWithoutCrashCrashpad(jstring message, jboolean set_main_thread_as_fault
             // report and after creating a dump, method will clean up this attribute.
             jboolean isCopy;
             const char *rawMessage = env->GetStringUTFChars(message, &isCopy);
-            annotations->SetKeyValue("error.message", rawMessage);
+            SetAnnotation("error.message", rawMessage);
             env->ReleaseStringUTFChars(message, rawMessage);
         }
     }
     client->DumpWithoutCrash(&context);
 
-    if (annotations != NULL) {
-        annotations->RemoveKey("error.message");
+    if (message != NULL) {
+        ClearAnnotation("error.message");
     }
 }
 
@@ -372,22 +410,13 @@ void AddAttributeCrashpad(jstring key, jstring value) {
         return;
     }
 
-    const std::lock_guard<std::mutex> lock(attribute_synchronization);
-    crashpad::CrashpadInfo *info = crashpad::CrashpadInfo::GetCrashpadInfo();
-    crashpad::SimpleStringDictionary *annotations = info->simple_annotations();
-    if (!annotations) {
-        annotations = new crashpad::SimpleStringDictionary();
-        info->set_simple_annotations(annotations);
-    }
-
     jboolean isCopy;
     const char *crashpadKey = env->GetStringUTFChars(key, &isCopy);
     const char *crashpadValue = env->GetStringUTFChars(value, &isCopy);
-    if (crashpadKey && crashpadValue)
-        annotations->SetKeyValue(crashpadKey, crashpadValue);
+    SetAnnotation(crashpadKey, crashpadValue);
 
-    env->ReleaseStringUTFChars(key, crashpadKey);
-    env->ReleaseStringUTFChars(value, crashpadValue);
+    if (crashpadKey) env->ReleaseStringUTFChars(key, crashpadKey);
+    if (crashpadValue) env->ReleaseStringUTFChars(value, crashpadValue);
 }
 
 void AddAttachmentCrashpad(jstring jattachment) {

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -357,6 +357,9 @@ public class BacktraceBase implements Client {
      * - is not an object (the attribute value is primitive type like String, or
      * Int)
      *
+     * Note: native crash reports omit attributes with an empty-string value
+     * (managed/JVM reports are unaffected).
+     *
      * @param key   attribute name
      * @param value attribute value.
      */

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -358,7 +358,7 @@ public class BacktraceBase implements Client {
      * Int)
      *
      * Note: native crash reports omit attributes with an empty-string value
-     * (managed/JVM reports are unaffected).
+     * (managed reports are unaffected).
      *
      * @param key   attribute name
      * @param value attribute value.

--- a/backtrace-library/src/main/java/backtraceio/library/interfaces/Client.java
+++ b/backtrace-library/src/main/java/backtraceio/library/interfaces/Client.java
@@ -23,6 +23,8 @@ public interface Client {
      * Adds new attributes to the client.
      * If the native integration is available and attributes are primitive type,
      * they will be added to the native reports.
+     * Note: native crash reports omit attributes with an empty-string value
+     * (managed reports are unaffected).
      * @param attributes client Attributes
      */
     void addAttribute(Map<String, Object> attributes);
@@ -31,6 +33,8 @@ public interface Client {
      * Adds new attribute to the client.
      * If the native integration is available and attributes are primitive type,
      * they will be added to the native reports.
+     * Note: native crash reports omit attributes with an empty-string value
+     * (managed reports are unaffected).
      * @param key attribute key
      * @param value attribute value
      */


### PR DESCRIPTION
## Summary

Removes the 64-entry limit on native (Crashpad) attributes.

Previously, a simple dictionary was used for storing attributes, which limits the total count to 64 entries. They are now stored in Crashpad's global `AnnotationList`.

The attribute count is limited by Crashpad's internal limit, `kMaxNumberOfAnnotations`. `SetAnnotation` will refuse to add keys beyond the limit, providing feedback with a warning.

## Changes

- Removes use of `SimpleStringDictionary`, and replaces it with `AnnotationList`. This data is dynamically allocated.
- Native crash reports omit attributes with an empty-string value (this was allowed previously). Managed/JVM reports are unaffected, documented in`addAttribute`.

ref: BT-6868