### PR TITLE
Native crash-handler test coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,39 +6,69 @@ on:
   pull_request:
   schedule:
     - cron: "0 0 * * *"
+  workflow_dispatch:
+    inputs:
+      hardware_abi:
+        description: "ABI for the self-hosted hardware release gate"
+        required: false
+        default: "arm64-v8a"
+      hardware_page_size:
+        description: "Expected device page size (4096 or 16384); empty skips the check"
+        required: false
+        default: ""
 
 permissions:
   contents: read
 
+# Trust model: fork and Dependabot pull_request runs never receive repository secrets, so they run
+# the secretless lanes only (source quality, legacy API 21/22, AAB resolver + fresh-process
+# safety). Credentialed lanes (Sauce, AAB ingestion, 16 KB runtime) run only for trusted commits
+# and fail fast when credentials are missing. PR code is never executed with secrets via
+# pull_request_target.
 jobs:
-  build:
+  policy:
     runs-on: ubuntu-latest
+    outputs:
+      trusted: ${{ steps.classify.outputs.trusted }}
+    steps:
+      - id: classify
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPOSITORY: ${{ github.event.pull_request.head.repo.full_name }}
+          REPOSITORY: ${{ github.repository }}
+          ACTOR: ${{ github.actor }}
+        run: |
+          set -euo pipefail
+          trusted=false
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            trusted=true
+          elif [ "$HEAD_REPOSITORY" = "$REPOSITORY" ] && [ "$ACTOR" != "dependabot[bot]" ]; then
+            trusted=true
+          fi
+          echo "trusted=$trusted" >> "$GITHUB_OUTPUT"
 
+  # Secretless: guard suite, formatting, lint, baseline scope, CI policy, build, ELF alignment.
+  source-quality:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
         with:
           fetch-depth: 2
           submodules: recursive
-          token: ${{ secrets.ACCESS_TOKEN }}
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
         with:
-          java-version: 17.0.10
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
         with:
           cache-read-only: true
-
-      - name: Write to local.properties
-        run: |
-          echo BACKTRACE_SUBMISSION_URL=\"${{ secrets.BACKTRACE_SUBMISSION_URL }}\" >> ./local.properties
-          echo BACKTRACE_CORONER_URL=\"${{ secrets.BACKTRACE_CORONER_URL }}\" >> ./local.properties
-          echo BACKTRACE_CORONER_TOKEN=\"${{ secrets.BACKTRACE_CORONER_TOKEN }}\" >> ./local.properties
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -51,6 +81,12 @@ jobs:
 
       - name: Verify the APK ZIP guard rejects every forbidden archive-reader form
         run: scripts/check_no_native_init_apk_zip_scan_selftest.sh
+
+      - name: CI policy self-test
+        run: scripts/check_native_ci_policy_selftest.sh
+
+      - name: CI policy
+        run: scripts/check_native_ci_policy.sh .github/workflows/test.yml
 
       - name: Formatting
         run: ./gradlew spotlessCheck
@@ -76,14 +112,6 @@ jobs:
       - name: Build and check
         run: ./gradlew assembleDebugAndroidTest build --profile
 
-      - name: Upload build profile
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: gradle-build-profile
-          path: build/reports/profile/
-          if-no-files-found: ignore
-
       - name: Alignment script executable
         run: chmod +x scripts/check_elf_alignment.sh
 
@@ -92,153 +120,94 @@ jobs:
           scripts/check_elf_alignment.sh \
             example-app/build/outputs/apk/debug/example-app-debug.apk
 
-      - name: Upload symbols.zip
-        uses: actions/upload-artifact@v4
+      - name: Upload build and test reports
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: native-debug-symbols.zip
-          path: example-app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+          name: source-quality-reports
+          retention-days: 7
+          path: |
+            build/reports/profile/
+            **/build/test-results/**/*.xml
+            **/build/reports/lint-results-*.xml
+          if-no-files-found: ignore
 
-      - name: Upload example-app APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: example-app-debug.apk
-          path: example-app/build/outputs/apk/debug/example-app-debug.apk
-
-      - name: Upload example-app Test APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: example-app-debug-androidTest.apk
-          path: example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk
-
-      - name: Upload backtrace-library AAR
-        uses: actions/upload-artifact@v4
-        with:
-          name: backtrace-library-debug.aar
-          path: backtrace-library/build/outputs/aar/backtrace-library-debug.aar
-
-      - name: Upload backtrace-library Test APK
-        uses: actions/upload-artifact@v4
-        with:
-          name: backtrace-library-debug-androidTest.apk
-          path: backtrace-library/build/outputs/apk/androidTest/debug/backtrace-library-debug-androidTest.apk
-
-  test:
+  # Secretless: API 21/22 verifier, resolver, and clean-process safety on the oldest supported
+  # runtimes.
+  legacy-api:
     runs-on: ubuntu-latest
-    needs: build
-
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        test-apk:
-          [
-            example-app-debug-androidTest.apk,
-            backtrace-library-debug-androidTest.apk,
-          ]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Download APK
-        uses: actions/download-artifact@v4
-        with:
-          name: example-app-debug.apk
-
-      - name: Download Test APK
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ matrix.test-apk }}
-
-      - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@v4
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          skip-run: true
-
-      - name: Run saucectl
-        env:
-          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-          TEST_APP: ${{ matrix.test-apk }}
-        run: |
-          saucectl configure --username "$SAUCE_USERNAME" --accessKey "$SAUCE_ACCESS_KEY"
-          conc=$(curl -s -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" "https://api.eu-central-1.saucelabs.com/rest/v1.2/users/$SAUCE_USERNAME/concurrency")
-          ccy=$(printf '%s' "$conc" | jq -r '[.concurrency.organization.allowed.rds, .concurrency.organization.allowed.vms] | map(select(type=="number")) | min // 1' 2>/dev/null)
-          case "$ccy" in ''|*[!0-9]*) ccy=1 ;; esac
-          echo "Using --ccy $ccy"
-          saucectl run --ccy "$ccy" --retries 2
-
-      # The legacy uncorrelated `morgue ... || true` step was removed: it could never fail the
-      # workflow, and ingestion is now gated by the UUID-correlated AAB handler test. Fatal-crash
-      # correlation is tracked as a separate release gate.
-
-#        runs-on: macos-latest # necessary for reactivecircus/android-emulator-runner@v2
-#     - name: Emulator test
-#       uses: reactivecircus/android-emulator-runner@v2
-#       with:
-#         target: google_apis
-#         api-level: ${{ matrix.api-level }}
-#         arch: x86_64
-#         script: ./gradlew connectedCheck
-
-#     - name: Code coverage
-#       run: bash <(curl -s https://codecov.io/bash)
-
-  # Play-style AAB qualification: install a device-specific APK set generated by bundletool and
-  # prove the production resolver returns the installed ABI configuration split.
-  aab-split-install:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-
+        api-level: [21, 22]
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
         with:
-          fetch-depth: 2
           submodules: recursive
-          token: ${{ secrets.ACCESS_TOKEN }}
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
         with:
-          java-version: 17.0.10
-          distribution: "adopt"
+          java-version: "17"
+          distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
-      # Explicit trust policy: fork and Dependabot runs never receive secrets, so they run the
-      # resolver gate only (REQUIRE_INGESTION=0) and the test's credentials skip stays reachable.
-      # Trusted runs must have all three credentials and gate on ingestion; a trusted run with
-      # missing credentials fails immediately instead of silently weakening the gate.
-      - name: Determine AAB ingestion mode
-        id: aab-mode
-        env:
-          IS_FORK: >-
-            ${{ github.event_name == 'pull_request' &&
-                github.event.pull_request.head.repo.full_name != github.repository }}
-          IS_DEPENDABOT: ${{ github.actor == 'dependabot[bot]' }}
-          SUBMISSION_URL: ${{ secrets.BACKTRACE_SUBMISSION_URL }}
-          CORONER_URL: ${{ secrets.BACKTRACE_CORONER_URL }}
-          CORONER_TOKEN: ${{ secrets.BACKTRACE_CORONER_TOKEN }}
+      - name: Accept Android SDK licences
+        run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+      - name: Build app and instrumentation APKs
+        run: ./gradlew :example-app:assembleDebug :example-app:assembleDebugAndroidTest
+
+      - name: Enable KVM group permissions
         run: |
-          set -euo pipefail
-          if [ "$IS_FORK" = "true" ] || [ "$IS_DEPENDABOT" = "true" ]; then
-            echo "require_ingestion=0" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [ -z "$SUBMISSION_URL" ] || [ -z "$CORONER_URL" ] || [ -z "$CORONER_TOKEN" ]; then
-            echo "Trusted AAB ingestion run is missing credentials." >&2
-            exit 1
-          fi
-          printf '%s\n' \
-            "BACKTRACE_SUBMISSION_URL=\"$SUBMISSION_URL\"" \
-            "BACKTRACE_CORONER_URL=\"$CORONER_URL\"" \
-            "BACKTRACE_CORONER_TOKEN=\"$CORONER_TOKEN\"" \
-            >> ./local.properties
-          echo "require_ingestion=1" >> "$GITHUB_OUTPUT"
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Legacy compatibility tests (API ${{ matrix.api-level }})
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: ${{ matrix.api-level }}
+          arch: x86_64
+          target: default
+          script: ./scripts/run_legacy_native_compatibility_test.sh
+
+      - name: Upload legacy lane results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: legacy-api-${{ matrix.api-level }}-results
+          retention-days: 7
+          path: |
+            **/build/outputs/androidTest-results/**
+            **/build/reports/androidTests/**
+          if-no-files-found: ignore
+
+  # Secretless: real split install, production resolver, and fresh-process failure safety. Runs
+  # for every PR, including forks; ingestion is excluded by policy, not by a silent failure.
+  aab-resolver-and-safety:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout submodules
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: set up JDK 17
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Set up Gradle (caching)
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -249,9 +218,6 @@ jobs:
             "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
           echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
 
-      # Create the debug keystore before Gradle runs so the instrumentation APK and the
-      # bundletool-signed split APKs share one certificate; instrumentation requires the test and
-      # target packages to be signed identically.
       - name: Ensure Android debug keystore
         run: |
           mkdir -p "$HOME/.android"
@@ -270,25 +236,425 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
 
-      # NOTE: android-emulator-runner executes each script line as an independent `sh -c`, so the
-      # whole flow lives in one committed script invoked as a single line.
-      - name: Split-install resolver and handler tests
+      - name: Split resolver and fresh-process safety tests
         uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
         with:
           api-level: 30
           arch: x86_64
           target: google_apis
-          script: REQUIRE_INGESTION=${{ steps.aab-mode.outputs.require_ingestion }} ./scripts/run_split_install_test.sh
+          script: REQUIRE_INGESTION=0 RUN_FATAL=0 ./scripts/run_split_install_test.sh
 
-      - name: Upload split-install diagnostics
+      - name: Upload resolver and safety diagnostics
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: aab-split-install-diagnostics
+          name: aab-resolver-safety-diagnostics
           retention-days: 7
           path: |
             installed-package-paths.txt
+            device-facts.txt
             split-resolver-output.txt
-            split-native-output.txt
+            fresh-process-safety-output.txt
+            native-report-evidence.json
+            split-install-logcat.txt
+          if-no-files-found: ignore
+
+  # Trusted only: builds the Sauce artifacts with validated credentials baked into BuildConfig.
+  trusted-device-build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: policy
+    if: needs.policy.outputs.trusted == 'true'
+    steps:
+      - name: Checkout submodules
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: set up JDK 17
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Set up Gradle (caching)
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+
+      - name: Validate and write trusted credentials
+        env:
+          BACKTRACE_SUBMISSION_URL: ${{ secrets.BACKTRACE_SUBMISSION_URL }}
+          BACKTRACE_CORONER_URL: ${{ secrets.BACKTRACE_CORONER_URL }}
+          BACKTRACE_CORONER_TOKEN: ${{ secrets.BACKTRACE_CORONER_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          keys = (
+              "BACKTRACE_SUBMISSION_URL",
+              "BACKTRACE_CORONER_URL",
+              "BACKTRACE_CORONER_TOKEN",
+          )
+          missing = [key for key in keys if not os.environ.get(key)]
+          if missing:
+              raise SystemExit("Missing trusted CI credentials: " + ", ".join(missing))
+
+          Path("local.properties").write_text(
+              "".join(f"{key}={json.dumps(os.environ[key])}\n" for key in keys),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Accept Android SDK licences
+        run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+      - name: Build device-test artifacts
+        run: ./gradlew assembleDebugAndroidTest assembleDebug
+
+      - name: Upload symbols.zip
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: native-debug-symbols.zip
+          path: example-app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
+          if-no-files-found: ignore
+
+      - name: Upload example-app APK
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: example-app-debug.apk
+          path: example-app/build/outputs/apk/debug/example-app-debug.apk
+
+      - name: Upload example-app Test APK
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: example-app-debug-androidTest.apk
+          path: example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk
+
+      - name: Upload backtrace-library AAR
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: backtrace-library-debug.aar
+          path: backtrace-library/build/outputs/aar/backtrace-library-debug.aar
+
+      - name: Upload backtrace-library Test APK
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: backtrace-library-debug-androidTest.apk
+          path: backtrace-library/build/outputs/apk/androidTest/debug/backtrace-library-debug-androidTest.apk
+
+  sauce-instrumentation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: [policy, trusted-device-build]
+    if: needs.policy.outputs.trusted == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test-apk:
+          [
+            example-app-debug-androidTest.apk,
+            backtrace-library-debug-androidTest.apk,
+          ]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          persist-credentials: false
+
+      - name: Download APK
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        with:
+          name: example-app-debug.apk
+
+      - name: Download Test APK
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        with:
+          name: ${{ matrix.test-apk }}
+
+      - name: Install saucectl
+        uses: saucelabs/saucectl-run-action@bc81720eb01738d9c664b07fe42621bd0014283f # v4
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          skip-run: true
+          saucectl-version: 0.213.0
+
+      - name: Run saucectl
+        env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          TEST_APP: ${{ matrix.test-apk }}
+        run: |
+          saucectl configure --username "$SAUCE_USERNAME" --accessKey "$SAUCE_ACCESS_KEY"
+          conc=$(curl -s -u "$SAUCE_USERNAME:$SAUCE_ACCESS_KEY" "https://api.eu-central-1.saucelabs.com/rest/v1.2/users/$SAUCE_USERNAME/concurrency")
+          ccy=$(printf '%s' "$conc" | jq -r '[.concurrency.organization.allowed.rds, .concurrency.organization.allowed.vms] | map(select(type=="number")) | min // 1' 2>/dev/null)
+          case "$ccy" in ''|*[!0-9]*) ccy=1 ;; esac
+          echo "Using --ccy $ccy"
+          saucectl run --ccy "$ccy" --retries 2
+
+  # Trusted only: full split-install qualification — resolver, fresh-process safety, nonfatal,
+  # fatal + restart-assisted recovery, and disable/re-enable lifecycle, all GUID-correlated.
+  aab-native-full:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: policy
+    if: needs.policy.outputs.trusted == 'true'
+    steps:
+      - name: Checkout submodules
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: set up JDK 17
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Set up Gradle (caching)
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+
+      - name: Validate and write trusted credentials
+        env:
+          BACKTRACE_SUBMISSION_URL: ${{ secrets.BACKTRACE_SUBMISSION_URL }}
+          BACKTRACE_CORONER_URL: ${{ secrets.BACKTRACE_CORONER_URL }}
+          BACKTRACE_CORONER_TOKEN: ${{ secrets.BACKTRACE_CORONER_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          keys = (
+              "BACKTRACE_SUBMISSION_URL",
+              "BACKTRACE_CORONER_URL",
+              "BACKTRACE_CORONER_TOKEN",
+          )
+          missing = [key for key in keys if not os.environ.get(key)]
+          if missing:
+              raise SystemExit("Missing trusted CI credentials: " + ", ".join(missing))
+
+          Path("local.properties").write_text(
+              "".join(f"{key}={json.dumps(os.environ[key])}\n" for key in keys),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Accept Android SDK licences
+        run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+      - name: Download bundletool (pinned)
+        run: |
+          curl -sL -o bundletool.jar \
+            "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
+          echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
+
+      - name: Ensure Android debug keystore
+        run: |
+          mkdir -p "$HOME/.android"
+          if [ ! -f "$HOME/.android/debug.keystore" ]; then
+            keytool -genkeypair -keystore "$HOME/.android/debug.keystore" -storepass android \
+              -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
+
+      - name: Build AAB and instrumentation APK
+        run: ./gradlew :example-app:bundleDebug :example-app:assembleDebugAndroidTest
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Full split-install qualification
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 30
+          arch: x86_64
+          target: google_apis
+          script: REQUIRE_INGESTION=1 RUN_FATAL=1 ./scripts/run_split_install_test.sh
+
+      - name: Upload full qualification diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: aab-native-full-diagnostics
+          retention-days: 7
+          path: |
+            installed-package-paths.txt
+            device-facts.txt
+            split-resolver-output.txt
+            fresh-process-safety-output.txt
+            split-nonfatal-output.txt
+            split-fatal-output.txt
+            split-lifecycle-output.txt
+            native-report-evidence.json
+            split-install-logcat.txt
+          if-no-files-found: ignore
+
+  # Trusted only: the same full qualification on an official 16 KB-page-size emulator image. ELF
+  # alignment (checked in source-quality) is necessary but not a runtime test; this is.
+  aab-native-16kb:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    needs: policy
+    if: needs.policy.outputs.trusted == 'true'
+    steps:
+      - name: Checkout submodules
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: set up JDK 17
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        with:
+          java-version: "17"
+          distribution: "temurin"
+
+      - name: Set up Gradle (caching)
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+
+      - name: Validate and write trusted credentials
+        env:
+          BACKTRACE_SUBMISSION_URL: ${{ secrets.BACKTRACE_SUBMISSION_URL }}
+          BACKTRACE_CORONER_URL: ${{ secrets.BACKTRACE_CORONER_URL }}
+          BACKTRACE_CORONER_TOKEN: ${{ secrets.BACKTRACE_CORONER_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          keys = (
+              "BACKTRACE_SUBMISSION_URL",
+              "BACKTRACE_CORONER_URL",
+              "BACKTRACE_CORONER_TOKEN",
+          )
+          missing = [key for key in keys if not os.environ.get(key)]
+          if missing:
+              raise SystemExit("Missing trusted CI credentials: " + ", ".join(missing))
+
+          Path("local.properties").write_text(
+              "".join(f"{key}={json.dumps(os.environ[key])}\n" for key in keys),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Accept Android SDK licences
+        run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
+
+      - name: Download bundletool (pinned)
+        run: |
+          curl -sL -o bundletool.jar \
+            "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
+          echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
+
+      - name: Ensure Android debug keystore
+        run: |
+          mkdir -p "$HOME/.android"
+          if [ ! -f "$HOME/.android/debug.keystore" ]; then
+            keytool -genkeypair -keystore "$HOME/.android/debug.keystore" -storepass android \
+              -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
+
+      - name: Build AAB, debug APK, and instrumentation APK
+        run: ./gradlew :example-app:bundleDebug :example-app:assembleDebug :example-app:assembleDebugAndroidTest
+
+      - name: Enable KVM group permissions
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: 16 KB runtime qualification
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        with:
+          api-level: 35
+          arch: x86_64
+          target: google_apis_ps16k
+          script: ./scripts/run_16kb_native_qualification.sh
+
+      - name: Upload 16 KB qualification diagnostics
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: aab-native-16kb-diagnostics
+          retention-days: 7
+          path: |
+            installed-package-paths.txt
+            device-facts.txt
+            split-resolver-output.txt
+            fresh-process-safety-output.txt
+            split-nonfatal-output.txt
+            split-fatal-output.txt
+            split-lifecycle-output.txt
+            native-report-evidence.json
+            split-install-logcat.txt
+          if-no-files-found: ignore
+
+  # Manual hardware gate: allocated arm64 / mixed-bitness devices on a self-hosted runner. Fails
+  # clearly when no device is attached; never silently passes.
+  hardware-release-gate:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: [self-hosted, android-device, arm64]
+    timeout-minutes: 90
+    steps:
+      - name: Checkout submodules
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        with:
+          submodules: recursive
+          persist-credentials: false
+
+      - name: Validate and write trusted credentials
+        env:
+          BACKTRACE_SUBMISSION_URL: ${{ secrets.BACKTRACE_SUBMISSION_URL }}
+          BACKTRACE_CORONER_URL: ${{ secrets.BACKTRACE_CORONER_URL }}
+          BACKTRACE_CORONER_TOKEN: ${{ secrets.BACKTRACE_CORONER_TOKEN }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          keys = (
+              "BACKTRACE_SUBMISSION_URL",
+              "BACKTRACE_CORONER_URL",
+              "BACKTRACE_CORONER_TOKEN",
+          )
+          missing = [key for key in keys if not os.environ.get(key)]
+          if missing:
+              raise SystemExit("Missing trusted CI credentials: " + ", ".join(missing))
+
+          Path("local.properties").write_text(
+              "".join(f"{key}={json.dumps(os.environ[key])}\n" for key in keys),
+              encoding="utf-8",
+          )
+          PY
+
+      - name: Hardware release gate
+        run: |
+          ./scripts/run_native_release_device_gate.sh \
+            --abi "${{ github.event.inputs.hardware_abi }}" \
+            --require-device-64-bit true \
+            --require-process-64-bit true \
+            --require-page-size "${{ github.event.inputs.hardware_page_size }}" \
+            --require-ingestion true
+
+      - name: Upload hardware gate evidence
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: hardware-release-gate-evidence
+          retention-days: 30
+          path: |
+            native-report-evidence.json
+            device-facts.txt
+            installed-package-paths.txt
             split-install-logcat.txt
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -192,6 +192,8 @@ jobs:
   # for every PR, including forks; ingestion is excluded by policy, not by a silent failure.
   aab-resolver-and-safety:
     runs-on: ubuntu-latest
+    env:
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     timeout-minutes: 45
     steps:
       - name: Checkout submodules
@@ -255,6 +257,7 @@ jobs:
             device-facts.txt
             split-resolver-output.txt
             fresh-process-safety-output.txt
+            assertion-sabotage-output.txt
             native-report-evidence.json
             split-install-logcat.txt
           if-no-files-found: ignore
@@ -398,6 +401,8 @@ jobs:
   # fatal + restart-assisted recovery, and disable/re-enable lifecycle, all GUID-correlated.
   aab-native-full:
     runs-on: ubuntu-latest
+    env:
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     timeout-minutes: 60
     needs: policy
     if: needs.policy.outputs.trusted == 'true'
@@ -489,6 +494,7 @@ jobs:
             device-facts.txt
             split-resolver-output.txt
             fresh-process-safety-output.txt
+            assertion-sabotage-output.txt
             split-nonfatal-output.txt
             split-fatal-output.txt
             split-lifecycle-output.txt
@@ -500,6 +506,8 @@ jobs:
   # alignment (checked in source-quality) is necessary but not a runtime test; this is.
   aab-native-16kb:
     runs-on: ubuntu-latest
+    env:
+      PR_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
     timeout-minutes: 60
     needs: policy
     if: needs.policy.outputs.trusted == 'true'
@@ -596,6 +604,7 @@ jobs:
             device-facts.txt
             split-resolver-output.txt
             fresh-process-safety-output.txt
+            assertion-sabotage-output.txt
             split-nonfatal-output.txt
             split-fatal-output.txt
             split-lifecycle-output.txt
@@ -604,17 +613,36 @@ jobs:
           if-no-files-found: ignore
 
   # Manual hardware gate: allocated arm64 / mixed-bitness devices on a self-hosted runner. Fails
-  # clearly when no device is attached; never silently passes.
+  # clearly when no device is attached or a prerequisite is missing; never silently passes. The
+  # gate script derives process bitness from the ABI (arm64-v8a = 64-bit, armeabi-v7a = 32-bit),
+  # so the 32-bit-on-64-bit-hardware scenario is dispatched with hardware_abi=armeabi-v7a.
   hardware-release-gate:
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, android-device, arm64]
     timeout-minutes: 90
+    env:
+      PR_HEAD_SHA: ${{ github.sha }}
     steps:
       - name: Checkout submodules
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
         with:
           submodules: recursive
           persist-credentials: false
+
+      - name: Download bundletool (pinned)
+        run: |
+          curl -sL -o bundletool.jar \
+            "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
+          echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
+
+      - name: Ensure Android debug keystore
+        run: |
+          mkdir -p "$HOME/.android"
+          if [ ! -f "$HOME/.android/debug.keystore" ]; then
+            keytool -genkeypair -keystore "$HOME/.android/debug.keystore" -storepass android \
+              -alias androiddebugkey -keypass android -keyalg RSA -keysize 2048 -validity 10000 \
+              -dname "CN=Android Debug,O=Android,C=US"
+          fi
 
       - name: Validate and write trusted credentials
         env:
@@ -647,7 +675,6 @@ jobs:
           ./scripts/run_native_release_device_gate.sh \
             --abi "${{ github.event.inputs.hardware_abi }}" \
             --require-device-64-bit true \
-            --require-process-64-bit true \
             --require-page-size "${{ github.event.inputs.hardware_page_size }}" \
             --require-ingestion true
 
@@ -661,5 +688,11 @@ jobs:
             native-report-evidence.json
             device-facts.txt
             installed-package-paths.txt
+            split-resolver-output.txt
+            fresh-process-safety-output.txt
+            assertion-sabotage-output.txt
+            split-nonfatal-output.txt
+            split-fatal-output.txt
+            split-lifecycle-output.txt
             split-install-logcat.txt
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -578,6 +578,11 @@ jobs:
           api-level: 35
           arch: x86_64
           target: google_apis_ps16k
+          # The ps16k google_apis image thrashes under the default AVD RAM: 16 KB pages inflate
+          # every process, and system-wide mem-pressure kills reaped the test service process
+          # (alongside the launcher and GMS) seconds after boot.
+          ram-size: 6144M
+          heap-size: 576M
           script: ./scripts/run_16kb_native_qualification.sh
 
       - name: Upload 16 KB qualification diagnostics

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "backtrace-library/src/main/cpp/libbun"]
 	path = backtrace-library/src/main/cpp/libbun
-	url = git@github.com:backtrace-labs/libbun.git
+	url = https://github.com/backtrace-labs/libbun.git
 [submodule "backtrace-library/src/main/cpp/crashpad"]
 	path = backtrace-library/src/main/cpp/crashpad
-	url = git@github.com:backtrace-labs/crashpad.git
+	url = https://github.com/backtrace-labs/crashpad.git

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,14 @@
 # Backtrace Android Release Notes
 
 ## Next version
-Bugfixes
-- Fixed a native-integration cold-start ANR in large APK/AAB applications by removing SDK-owned APK ZIP central-directory parsing (`ZipFile$Source.initCEN`) from crash-handler path resolution. The SDK now prefers the path selected by Android's native linker, with extracted-library and installed-split metadata fallbacks.
-- Hardened optional native setup, disable, and dump calls so failures remain nonfatal and managed reporting continues; `tryEnableNativeIntegration()` exposes the setup result while `enableNativeIntegration()` stays `void` for compatibility.
-- Prevented crash-handler/setup diagnostics from logging credentials, argument values, or resolved paths; failures log a stable stage code and exception class only.
-- Corrected process-ABI selection by preferring the ABI reported for the running process. On API 23 and later, malformed primary ABI metadata falls back to process-bitness-specific ABI lists; API 21-22 retain the device-ordered fallback.
-- Added Play-style split-install, fatal-process, disable/re-enable lifecycle, API 21/22, and 16 KB runtime qualification. Hardware and affected-customer validation are tracked in the release qualification document before full production sign-off.
+
+### Bug fixes
+
+- Improved native-integration startup in large APK and Android App Bundle applications by removing synchronous SDK-owned APK ZIP central-directory parsing from crash-handler path resolution. The SDK now prefers the path selected by Android's native linker, with extracted-library and installed-split metadata fallbacks.
+- Hardened optional native setup, disable, and dump operations so failures remain nonfatal and managed reporting continues.
+- Added `tryEnableNativeIntegration(...)` methods that report whether native crash-handler registration succeeded while preserving existing `void enableNativeIntegration(...)` APIs.
+- Corrected process-ABI selection for native-library fallback resolution.
+- Prevented native setup and crash-handler diagnostics from logging credentials, argument values, application-provided annotations, attachment paths, or resolved native-library paths.
 
 ## Version 3.13.0
 Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Next version
 Bugfixes
-- Removed synchronous base- and split-APK ZIP central-directory inspection from native crash-handler library resolution. That scan was the identified cause of customer-reported cold-start ANRs showing `ZipFile$Source.initCEN`. The SDK now prefers the path selected by Android's native linker, with extracted-library and installed-split metadata fallbacks. Production qualification for fatal crash capture and legacy or mixed-bitness devices is tracked separately.
-- Native-integration path-resolution and JNI-bridge failures now disable native integration and return `false` rather than propagating those failures to the host application.
-- Corrected process-ABI selection by preferring the ABI reported for the running process. On API 23 and later, malformed primary ABI metadata falls back to process-bitness-specific ABI lists. API 21-22 retain the device-ordered fallback when primary process ABI metadata is unavailable.
+- Fixed a native-integration cold-start ANR in large APK/AAB applications by removing SDK-owned APK ZIP central-directory parsing (`ZipFile$Source.initCEN`) from crash-handler path resolution. The SDK now prefers the path selected by Android's native linker, with extracted-library and installed-split metadata fallbacks.
+- Hardened optional native setup, disable, and dump calls so failures remain nonfatal and managed reporting continues; `tryEnableNativeIntegration()` exposes the setup result while `enableNativeIntegration()` stays `void` for compatibility.
+- Prevented crash-handler/setup diagnostics from logging credentials, argument values, or resolved paths; failures log a stable stage code and exception class only.
+- Corrected process-ABI selection by preferring the ABI reported for the running process. On API 23 and later, malformed primary ABI metadata falls back to process-bitness-specific ABI lists; API 21-22 retain the device-ordered fallback.
+- Added Play-style split-install, fatal-process, disable/re-enable lifecycle, API 21/22, and 16 KB runtime qualification. Hardware and affected-customer validation are tracked in the release qualification document before full production sign-off.
 
 ## Version 3.13.0
 Improvements

--- a/README.md
+++ b/README.md
@@ -73,9 +73,7 @@ For more information about the Android SDK, including installation, usage, and c
 
 ## Native crash integration startup
 
-Native crash capture requires a writable `BacktraceDatabase`. Configure initial attributes,
-attachments, and breadcrumbs before enabling the integration, then call
-`enableNativeIntegration()` as early as practical:
+Native crash capture requires a writable `BacktraceDatabase`. Configure initial attributes, attachments, and breadcrumbs before enabling the integration, then call `enableNativeIntegration()` as early as practical:
 
 ```java
 BacktraceDatabase database = new BacktraceDatabase(context, databaseSettings);
@@ -85,12 +83,20 @@ BacktraceExceptionHandler.enable(client);
 client.enableNativeIntegration();
 ```
 
-`enableNativeIntegration()` is synchronous. Keeping it in the normal startup sequence provides the
-earliest native-crash coverage. It can be invoked from one background thread, but native crashes
-that occur before initialization completes cannot be captured.
+`enableNativeIntegration()` is synchronous and remains `void` for compatibility;
+a contained setup failure is logged and the call returns normally. To observe the actual setup status, use `tryEnableNativeIntegration()`:
 
-The SDK resolves its native crash-handler library from the path already selected by Android's
-linker. Backtrace does not open or parse the host application's base or split APK while resolving
-the crash-handler library.
-See [Native integration startup and threading](docs/native-integration-startup.md) for operational
-guidance and failure modes.
+```java
+boolean nativeEnabled = client.tryEnableNativeIntegration();
+if (!nativeEnabled) {
+    // Native crash capture is unavailable. Managed reporting remains available.
+}
+```
+
+Keeping initialization in the normal startup sequence provides the earliest native-crash coverage.
+It can be invoked from one background thread, but native crashes that occur before initialization completes cannot be captured.
+Do not invoke enable concurrently or race it with `disableNativeIntegration()`. `dumpWithoutCrash()` is a safe no-op while native integration is unavailable or disabled.
+
+The SDK resolves its native crash-handler library from the path already selected by Android's linker.
+Backtrace does not open or parse the host application's base or split APK while resolving the crash-handler library.
+See [Native integration startup and threading](docs/native-integration-startup.md) for operational guidance and failure modes.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,9 @@ BacktraceExceptionHandler.enable(client);
 client.enableNativeIntegration();
 ```
 
-`enableNativeIntegration()` is synchronous and remains `void` for compatibility;
-a contained setup failure is logged and the call returns normally. To observe the actual setup status, use `tryEnableNativeIntegration()`:
+`enableNativeIntegration()` is synchronous and remains `void` for compatibility. A contained setup
+failure is logged and the call returns normally. To observe the actual setup status, use
+`tryEnableNativeIntegration()`:
 
 ```java
 boolean nativeEnabled = client.tryEnableNativeIntegration();
@@ -94,9 +95,13 @@ if (!nativeEnabled) {
 ```
 
 Keeping initialization in the normal startup sequence provides the earliest native-crash coverage.
-It can be invoked from one background thread, but native crashes that occur before initialization completes cannot be captured.
-Do not invoke enable concurrently or race it with `disableNativeIntegration()`. `dumpWithoutCrash()` is a safe no-op while native integration is unavailable or disabled.
+It can be invoked from one application-controlled background thread, but native crashes that occur
+before initialization completes cannot be captured. Make one initial registration attempt per
+process; after a successful registration, disable/re-enable is supported. Do not call enable
+concurrently or race it with `disableNativeIntegration()`. `dumpWithoutCrash()` is a safe no-op
+while native integration is unavailable or disabled.
 
 The SDK resolves its native crash-handler library from the path already selected by Android's linker.
 Backtrace does not open or parse the host application's base or split APK while resolving the crash-handler library.
-See [Native integration startup and threading](docs/native-integration-startup.md) for operational guidance and failure modes.
+See [Native integration startup and threading](docs/native-integration-startup.md) for lifecycle,
+compatibility, and diagnostic details.

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceBaseNativeIntegrationApiTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceBaseNativeIntegrationApiTest.java
@@ -1,0 +1,73 @@
+package backtraceio.library;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import backtraceio.library.base.BacktraceBase;
+import backtraceio.library.enums.UnwindingMode;
+import backtraceio.library.interfaces.Database;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/** Verifies the result-returning native-integration overloads preserve every caller option. */
+@RunWith(AndroidJUnit4.class)
+public class BacktraceBaseNativeIntegrationApiTest {
+
+    private Context context;
+    private BacktraceCredentials credentials;
+
+    @Before
+    public void setUp() {
+        this.context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        this.credentials = new BacktraceCredentials("https://test.sp.backtrace.io", "1231231231231");
+    }
+
+    @Test
+    public void resultReturningOverloadDelegatesUnwindingOptions() {
+        Database database = mock(Database.class);
+        when(database.setupNativeIntegration(
+                        any(BacktraceBase.class),
+                        same(this.credentials),
+                        eq(true),
+                        eq(UnwindingMode.LOCAL_DUMPWITHOUTCRASH)))
+                .thenReturn(true);
+        BacktraceClient client = new BacktraceClient(this.context, this.credentials, database);
+
+        assertTrue(client.tryEnableNativeIntegration(true, UnwindingMode.LOCAL_DUMPWITHOUTCRASH));
+
+        verify(database)
+                .setupNativeIntegration(
+                        same(client), same(this.credentials), eq(true), eq(UnwindingMode.LOCAL_DUMPWITHOUTCRASH));
+    }
+
+    @Test
+    public void voidBooleanOverloadDelegatesToMatchingDatabaseOperation() {
+        Database database = mock(Database.class);
+        BacktraceClient client = new BacktraceClient(this.context, this.credentials, database);
+
+        client.enableNativeIntegration(false);
+
+        verify(database).setupNativeIntegration(same(client), same(this.credentials), eq(false));
+    }
+
+    @Test
+    public void voidUnwindingOverloadDelegatesEveryOption() {
+        Database database = mock(Database.class);
+        BacktraceClient client = new BacktraceClient(this.context, this.credentials, database);
+
+        client.enableNativeIntegration(true, UnwindingMode.REMOTE_DUMPWITHOUTCRASH);
+
+        verify(database)
+                .setupNativeIntegration(
+                        same(client), same(this.credentials), eq(true), eq(UnwindingMode.REMOTE_DUMPWITHOUTCRASH));
+    }
+}

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceDatabaseSanitizedLoggingTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceDatabaseSanitizedLoggingTest.java
@@ -1,0 +1,194 @@
+package backtraceio.library;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import backtraceio.library.logger.BacktraceInternalLogger;
+import backtraceio.library.logger.BacktraceLogger;
+import backtraceio.library.logger.LogLevel;
+import backtraceio.library.logger.Logger;
+import backtraceio.library.models.nativeHandler.CrashHandlerConfiguration;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Native-integration failure diagnostics must never carry credentials or paths: a custom
+ * credential provider or an {@link UnsatisfiedLinkError} can embed a submission URL, token, or
+ * filesystem path in its exception message. These tests throw failures whose messages contain
+ * every sensitive sentinel and prove the sanitized logging contract: no sentinel in any message,
+ * no {@code Throwable} passed to the logger, and a stable stage code plus exception class present.
+ */
+@RunWith(AndroidJUnit4.class)
+public class BacktraceDatabaseSanitizedLoggingTest {
+
+    private static final String ALL_SENTINELS = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL"
+            + " --annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL"
+            + " /data/data/customer/files/crashpad"
+            + " /data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so"
+            + " /customer/attachment/medical-record.txt";
+
+    private static final class RecordingGlobalLogger implements Logger {
+        final List<String> messages = new ArrayList<>();
+        int throwableOverloadCalls;
+
+        @Override
+        public int d(String tag, String message) {
+            messages.add(message);
+            return 0;
+        }
+
+        @Override
+        public int w(String tag, String message) {
+            messages.add(message);
+            return 0;
+        }
+
+        @Override
+        public int e(String tag, String message) {
+            messages.add(message);
+            return 0;
+        }
+
+        @Override
+        public int e(String tag, String message, Throwable tr) {
+            throwableOverloadCalls++;
+            messages.add(message);
+            if (tr != null && tr.getMessage() != null) {
+                messages.add(tr.getMessage());
+            }
+            return 0;
+        }
+
+        boolean anyMessageContains(String needle) {
+            for (String message : messages) {
+                if (message != null && message.contains(needle)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        void assertSanitized(String expectedCode, String expectedFailureClass) {
+            assertFalse("SENTINEL leaked into diagnostics", anyMessageContains("SENTINEL"));
+            assertFalse("token= leaked into diagnostics", anyMessageContains("token="));
+            assertFalse("crashpad path leaked into diagnostics", anyMessageContains("/files/crashpad"));
+            assertFalse("library path leaked into diagnostics", anyMessageContains("libbacktrace-native.so"));
+            assertEquals("Throwable must never reach the logger on native paths", 0, throwableOverloadCalls);
+            assertTrue("missing stable code " + expectedCode, anyMessageContains(expectedCode));
+            if (expectedFailureClass != null) {
+                assertTrue("missing failure class " + expectedFailureClass, anyMessageContains(expectedFailureClass));
+            }
+        }
+    }
+
+    private Context context;
+    private RecordingGlobalLogger recordingLogger;
+    private BacktraceDatabase database;
+    private BacktraceClient client;
+    private BacktraceCredentials credentials;
+
+    @Before
+    public void setUp() {
+        this.context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File databaseDirectory = new File(this.context.getFilesDir(), "sanitized-logging-test-" + System.nanoTime());
+        assertTrue(databaseDirectory.mkdirs());
+        this.database = new BacktraceDatabase(this.context, databaseDirectory.getAbsolutePath());
+        this.credentials = new BacktraceCredentials("https://test.sp.backtrace.io", "1231231231231");
+        this.client = new BacktraceClient(this.context, this.credentials);
+        this.database.start();
+
+        this.recordingLogger = new RecordingGlobalLogger();
+        BacktraceLogger.setLogger(this.recordingLogger);
+    }
+
+    @After
+    public void tearDown() {
+        // Restore the global logger even when an assertion failed mid-test.
+        BacktraceLogger.setLogger(new BacktraceInternalLogger(LogLevel.OFF));
+    }
+
+    @Test
+    public void preparationFailureWithSentinelMessageIsSanitized() {
+        this.database.useCrashHandlerConfiguration(new CrashHandlerConfiguration() {
+            @Override
+            public List<String> getCrashHandlerEnvironmentVariables(ApplicationInfo applicationInfo) {
+                throw new IllegalStateException("preparation failed: " + ALL_SENTINELS);
+            }
+        });
+
+        assertEquals(false, this.database.setupNativeIntegration(this.client, this.credentials));
+        this.recordingLogger.assertSanitized("BT_NATIVE_PREPARE_FAILURE", "java.lang.IllegalStateException");
+    }
+
+    @Test
+    public void credentialFailureWithSentinelMessageIsSanitized() {
+        BacktraceCredentials throwingCredentials = new BacktraceCredentials("https://test.sp.backtrace.io", "token") {
+            @Override
+            public android.net.Uri getMinidumpSubmissionUrl() {
+                throw new IllegalStateException("credential resolution failed: " + ALL_SENTINELS);
+            }
+        };
+
+        assertEquals(false, this.database.setupNativeIntegration(this.client, throwingCredentials));
+        this.recordingLogger.assertSanitized("BT_NATIVE_PREPARE_FAILURE", "java.lang.IllegalStateException");
+    }
+
+    @Test
+    public void bridgeFailureWithSentinelMessageIsSanitized() {
+        this.database.useNativeCommunication(new backtraceio.library.interfaces.NativeCommunication() {
+            @Override
+            public boolean handleCrash(String[] args) {
+                return false;
+            }
+
+            @Override
+            public boolean initializeJavaCrashHandler(
+                    String url,
+                    String databasePath,
+                    String classPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    String[] environmentVariables) {
+                throw new UnsatisfiedLinkError("bridge failed: " + ALL_SENTINELS);
+            }
+
+            @Override
+            public boolean initializeCrashHandler(
+                    String url,
+                    String databasePath,
+                    String handlerPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    boolean enableClientSideUnwinding,
+                    backtraceio.library.enums.UnwindingMode unwindingMode) {
+                return false;
+            }
+        });
+
+        assertEquals(false, this.database.setupNativeIntegration(this.client, this.credentials));
+        this.recordingLogger.assertSanitized("BT_NATIVE_BRIDGE_FAILURE", "java.lang.UnsatisfiedLinkError");
+    }
+
+    @Test
+    public void disableFailureWithSentinelMessageIsSanitized() {
+        this.database.useNativeDisableAction(() -> {
+            throw new UnsatisfiedLinkError("disable failed: " + ALL_SENTINELS);
+        });
+
+        this.database.disableNativeIntegration();
+        this.recordingLogger.assertSanitized("BT_NATIVE_DISABLE_FAILURE", "java.lang.UnsatisfiedLinkError");
+        assertFalse(this.database.addNativeAttribute("key", "value"));
+    }
+}

--- a/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceDatabaseSanitizedLoggingTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/BacktraceDatabaseSanitizedLoggingTest.java
@@ -8,9 +8,7 @@ import android.content.Context;
 import android.content.pm.ApplicationInfo;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.platform.app.InstrumentationRegistry;
-import backtraceio.library.logger.BacktraceInternalLogger;
 import backtraceio.library.logger.BacktraceLogger;
-import backtraceio.library.logger.LogLevel;
 import backtraceio.library.logger.Logger;
 import backtraceio.library.models.nativeHandler.CrashHandlerConfiguration;
 import java.io.File;
@@ -32,10 +30,10 @@ import org.junit.runner.RunWith;
 public class BacktraceDatabaseSanitizedLoggingTest {
 
     private static final String ALL_SENTINELS = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL"
-            + " --annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL"
-            + " /data/data/customer/files/crashpad"
+            + " --annotation=private.application.value=SENSITIVE_ATTRIBUTE_SENTINEL"
+            + " /data/user/0/example.application/files/crashpad"
             + " /data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so"
-            + " /customer/attachment/medical-record.txt";
+            + " /data/user/0/example.application/files/attachment.txt";
 
     private static final class RecordingGlobalLogger implements Logger {
         final List<String> messages = new ArrayList<>();
@@ -92,6 +90,7 @@ public class BacktraceDatabaseSanitizedLoggingTest {
     }
 
     private Context context;
+    private Logger previousLogger;
     private RecordingGlobalLogger recordingLogger;
     private BacktraceDatabase database;
     private BacktraceClient client;
@@ -99,6 +98,7 @@ public class BacktraceDatabaseSanitizedLoggingTest {
 
     @Before
     public void setUp() {
+        this.previousLogger = BacktraceLogger.getLogger();
         this.context = InstrumentationRegistry.getInstrumentation().getTargetContext();
         File databaseDirectory = new File(this.context.getFilesDir(), "sanitized-logging-test-" + System.nanoTime());
         assertTrue(databaseDirectory.mkdirs());
@@ -114,7 +114,7 @@ public class BacktraceDatabaseSanitizedLoggingTest {
     @After
     public void tearDown() {
         // Restore the global logger even when an assertion failed mid-test.
-        BacktraceLogger.setLogger(new BacktraceInternalLogger(LogLevel.OFF));
+        BacktraceLogger.setLogger(this.previousLogger);
     }
 
     @Test
@@ -179,6 +179,44 @@ public class BacktraceDatabaseSanitizedLoggingTest {
 
         assertEquals(false, this.database.setupNativeIntegration(this.client, this.credentials));
         this.recordingLogger.assertSanitized("BT_NATIVE_BRIDGE_FAILURE", "java.lang.UnsatisfiedLinkError");
+    }
+
+    @Test
+    public void bridgeReturnedFalseUsesStableDiagnosticCode() {
+        this.database.useNativeCommunication(new backtraceio.library.interfaces.NativeCommunication() {
+            @Override
+            public boolean handleCrash(String[] args) {
+                return false;
+            }
+
+            @Override
+            public boolean initializeJavaCrashHandler(
+                    String url,
+                    String databasePath,
+                    String classPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    String[] environmentVariables) {
+                return false;
+            }
+
+            @Override
+            public boolean initializeCrashHandler(
+                    String url,
+                    String databasePath,
+                    String handlerPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    boolean enableClientSideUnwinding,
+                    backtraceio.library.enums.UnwindingMode unwindingMode) {
+                return false;
+            }
+        });
+
+        assertEquals(false, this.database.setupNativeIntegration(this.client, this.credentials));
+        this.recordingLogger.assertSanitized("BT_NATIVE_BRIDGE_FAILURE", null);
     }
 
     @Test

--- a/backtrace-library/src/androidTest/java/backtraceio/library/services/BacktraceCrashHandlerRunnerLoggingTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/services/BacktraceCrashHandlerRunnerLoggingTest.java
@@ -18,22 +18,23 @@ import org.junit.runner.RunWith;
 import org.mockito.junit.MockitoJUnitRunner;
 
 /**
- * Crashpad passes the submission URL (which can carry the minidump token) and every customer
- * annotation on the handler argument vector, and exception messages commonly embed rejected
- * library paths; runner logs end up in Logcat and CI artifacts. These tests throw failures whose
- * <em>messages contain every sensitive sentinel</em> and prove that no logged message leaks them:
- * the logger contract carries no {@link Throwable}, and messages hold only a stable stage code and
- * the failure class name.
+ * Crashpad passes the submission URL (which can carry the minidump token) and every
+ * application-provided annotation on the handler argument vector, and exception messages commonly
+ * embed rejected library paths; runner logs end up in Logcat and CI artifacts. These tests throw
+ * failures whose <em>messages contain every sensitive sentinel</em> and prove that no logged
+ * message leaks them: the logger contract carries no {@link Throwable}, and messages hold only a
+ * stable stage code and the failure class name.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class BacktraceCrashHandlerRunnerLoggingTest {
 
     private static final String URL_SENTINEL = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL";
-    private static final String ANNOTATION_SENTINEL = "--annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL";
-    private static final String DATABASE_SENTINEL = "/data/data/customer/files/crashpad";
+    private static final String ANNOTATION_SENTINEL =
+            "--annotation=private.application.value=SENSITIVE_ATTRIBUTE_SENTINEL";
+    private static final String DATABASE_SENTINEL = "/data/user/0/example.application/files/crashpad";
     private static final String LIBRARY_SENTINEL =
             "/data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so";
-    private static final String ATTACHMENT_SENTINEL = "/customer/attachment/medical-record.txt";
+    private static final String ATTACHMENT_SENTINEL = "/data/user/0/example.application/files/attachment.txt";
     private static final String ALL_SENTINELS = URL_SENTINEL + " " + ANNOTATION_SENTINEL + " " + DATABASE_SENTINEL + " "
             + LIBRARY_SENTINEL + " " + ATTACHMENT_SENTINEL;
     private static final String[] SENSITIVE_ARGS =
@@ -64,8 +65,8 @@ public class BacktraceCrashHandlerRunnerLoggingTest {
         void assertNoSentinelLeaked() {
             for (String sentinel : new String[] {
                 "SECRET_URL_TOKEN_SENTINEL",
-                "PRIVATE_CUSTOMER_SENTINEL",
-                "private.customer.value",
+                "SENSITIVE_ATTRIBUTE_SENTINEL",
+                "private.application.value",
                 DATABASE_SENTINEL,
                 LIBRARY_SENTINEL,
                 ATTACHMENT_SENTINEL,

--- a/backtrace-library/src/androidTest/java/backtraceio/library/services/BacktraceCrashHandlerRunnerLoggingTest.java
+++ b/backtrace-library/src/androidTest/java/backtraceio/library/services/BacktraceCrashHandlerRunnerLoggingTest.java
@@ -19,29 +19,32 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 /**
  * Crashpad passes the submission URL (which can carry the minidump token) and every customer
- * annotation on the handler argument vector, and runner logs end up in Logcat and CI artifacts.
- * These tests prove no diagnostic message leaks that data on any failure stage.
+ * annotation on the handler argument vector, and exception messages commonly embed rejected
+ * library paths; runner logs end up in Logcat and CI artifacts. These tests throw failures whose
+ * <em>messages contain every sensitive sentinel</em> and prove that no logged message leaks them:
+ * the logger contract carries no {@link Throwable}, and messages hold only a stable stage code and
+ * the failure class name.
  */
 @RunWith(MockitoJUnitRunner.class)
 public class BacktraceCrashHandlerRunnerLoggingTest {
 
-    private static final String URL_SENTINEL = "SECRET_URL_TOKEN_SENTINEL";
-    private static final String ANNOTATION_SENTINEL = "PRIVATE_CUSTOMER_VALUE_SENTINEL";
-    private static final String[] SENSITIVE_ARGS = new String[] {
-        "--url=https://example.invalid/minidump?token=" + URL_SENTINEL,
-        "--annotation=private.customer.value=" + ANNOTATION_SENTINEL,
-        "--database=/data/data/example/files/crashpad"
-    };
+    private static final String URL_SENTINEL = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL";
+    private static final String ANNOTATION_SENTINEL = "--annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL";
+    private static final String DATABASE_SENTINEL = "/data/data/customer/files/crashpad";
+    private static final String LIBRARY_SENTINEL =
+            "/data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so";
+    private static final String ATTACHMENT_SENTINEL = "/customer/attachment/medical-record.txt";
+    private static final String ALL_SENTINELS = URL_SENTINEL + " " + ANNOTATION_SENTINEL + " " + DATABASE_SENTINEL + " "
+            + LIBRARY_SENTINEL + " " + ATTACHMENT_SENTINEL;
+    private static final String[] SENSITIVE_ARGS =
+            new String[] {"--url=" + URL_SENTINEL, ANNOTATION_SENTINEL, "--database=" + DATABASE_SENTINEL};
 
     private static final class RecordingLogger implements BacktraceCrashHandlerRunner.RunnerLogger {
         final List<String> messages = new ArrayList<>();
 
         @Override
-        public void error(String message, Throwable throwable) {
+        public void error(String message) {
             messages.add(message);
-            if (throwable != null) {
-                messages.add(String.valueOf(throwable.getMessage()));
-            }
         }
 
         @Override
@@ -57,16 +60,63 @@ public class BacktraceCrashHandlerRunnerLoggingTest {
             }
             return false;
         }
+
+        void assertNoSentinelLeaked() {
+            for (String sentinel : new String[] {
+                "SECRET_URL_TOKEN_SENTINEL",
+                "PRIVATE_CUSTOMER_SENTINEL",
+                "private.customer.value",
+                DATABASE_SENTINEL,
+                LIBRARY_SENTINEL,
+                ATTACHMENT_SENTINEL,
+                "token="
+            }) {
+                assertFalse("Sensitive value leaked into runner log: " + sentinel, anyMessageContains(sentinel));
+            }
+        }
     }
 
     private static HashMap<String, String> environmentWithHandlerPath() {
         HashMap<String, String> environment = new HashMap<>();
-        environment.put(CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER, "path/to/lib");
+        environment.put(CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER, LIBRARY_SENTINEL);
         return environment;
     }
 
     @Test
-    public void handlerFailureDoesNotLogArguments() {
+    public void loadFailureWithSentinelMessageLeaksNothing() {
+        SystemLoader loader = mock(SystemLoader.class);
+        doThrow(new UnsatisfiedLinkError("dlopen failed: " + ALL_SENTINELS))
+                .when(loader)
+                .loadLibrary(any());
+        RecordingLogger logger = new RecordingLogger();
+
+        BacktraceCrashHandlerRunner runner =
+                new BacktraceCrashHandlerRunner(mock(BacktraceCrashHandlerWrapper.class), loader, logger);
+
+        assertFalse(runner.run(SENSITIVE_ARGS, environmentWithHandlerPath()));
+        logger.assertNoSentinelLeaked();
+        assertTrue(logger.anyMessageContains("BT_HANDLER_LOAD_FAILURE"));
+        assertTrue(logger.anyMessageContains("java.lang.UnsatisfiedLinkError"));
+    }
+
+    @Test
+    public void dispatchFailureWithSentinelMessageLeaksNothing() {
+        BacktraceCrashHandlerWrapper crashHandler = mock(BacktraceCrashHandlerWrapper.class);
+        when(crashHandler.handleCrash(any(String[].class)))
+                .thenThrow(new IllegalStateException("dispatch failed: " + ALL_SENTINELS));
+        RecordingLogger logger = new RecordingLogger();
+
+        BacktraceCrashHandlerRunner runner =
+                new BacktraceCrashHandlerRunner(crashHandler, mock(SystemLoader.class), logger);
+
+        assertFalse(runner.run(SENSITIVE_ARGS, environmentWithHandlerPath()));
+        logger.assertNoSentinelLeaked();
+        assertTrue(logger.anyMessageContains("BT_HANDLER_DISPATCH_FAILURE"));
+        assertTrue(logger.anyMessageContains("java.lang.IllegalStateException"));
+    }
+
+    @Test
+    public void handlerReturnedFailureLeaksNothing() {
         BacktraceCrashHandlerWrapper crashHandler = mock(BacktraceCrashHandlerWrapper.class);
         when(crashHandler.handleCrash(any(String[].class))).thenReturn(false);
         RecordingLogger logger = new RecordingLogger();
@@ -75,39 +125,8 @@ public class BacktraceCrashHandlerRunnerLoggingTest {
                 new BacktraceCrashHandlerRunner(crashHandler, mock(SystemLoader.class), logger);
 
         assertFalse(runner.run(SENSITIVE_ARGS, environmentWithHandlerPath()));
-        assertFalse(logger.anyMessageContains(URL_SENTINEL));
-        assertFalse(logger.anyMessageContains(ANNOTATION_SENTINEL));
-        assertFalse(logger.anyMessageContains("private.customer.value"));
-    }
-
-    @Test
-    public void handlerDispatchExceptionDoesNotLogArguments() {
-        BacktraceCrashHandlerWrapper crashHandler = mock(BacktraceCrashHandlerWrapper.class);
-        when(crashHandler.handleCrash(any(String[].class))).thenThrow(new IllegalStateException("dispatch failed"));
-        RecordingLogger logger = new RecordingLogger();
-
-        BacktraceCrashHandlerRunner runner =
-                new BacktraceCrashHandlerRunner(crashHandler, mock(SystemLoader.class), logger);
-
-        assertFalse(runner.run(SENSITIVE_ARGS, environmentWithHandlerPath()));
-        assertFalse(logger.anyMessageContains(URL_SENTINEL));
-        assertFalse(logger.anyMessageContains(ANNOTATION_SENTINEL));
-        assertTrue(logger.anyMessageContains("Cannot execute the native crash handler."));
-    }
-
-    @Test
-    public void loadFailureDoesNotLogLibraryPathOrArguments() {
-        SystemLoader loader = mock(SystemLoader.class);
-        doThrow(new UnsatisfiedLinkError("dlopen failed")).when(loader).loadLibrary(any());
-        RecordingLogger logger = new RecordingLogger();
-
-        BacktraceCrashHandlerRunner runner =
-                new BacktraceCrashHandlerRunner(mock(BacktraceCrashHandlerWrapper.class), loader, logger);
-
-        assertFalse(runner.run(SENSITIVE_ARGS, environmentWithHandlerPath()));
-        assertFalse(logger.anyMessageContains(URL_SENTINEL));
-        assertFalse(logger.anyMessageContains("path/to/lib"));
-        assertTrue(logger.anyMessageContains("Cannot load the native crash-handler library."));
+        logger.assertNoSentinelLeaked();
+        assertTrue(logger.anyMessageContains("BT_HANDLER_RETURNED_FAILURE"));
     }
 
     @Test
@@ -124,10 +143,26 @@ public class BacktraceCrashHandlerRunnerLoggingTest {
         new BacktraceCrashHandlerRunner(failingHandler, mock(SystemLoader.class), dispatchLogger)
                 .run(new String[] {}, environmentWithHandlerPath());
 
-        assertTrue(loadLogger.anyMessageContains("Cannot load the native crash-handler library."));
-        assertFalse(loadLogger.anyMessageContains("Cannot execute the native crash handler."));
-        assertTrue(dispatchLogger.anyMessageContains("Cannot execute the native crash handler."));
-        assertFalse(dispatchLogger.anyMessageContains("Cannot load the native crash-handler library."));
+        assertTrue(loadLogger.anyMessageContains("BT_HANDLER_LOAD_FAILURE"));
+        assertFalse(loadLogger.anyMessageContains("BT_HANDLER_DISPATCH_FAILURE"));
+        assertTrue(dispatchLogger.anyMessageContains("BT_HANDLER_DISPATCH_FAILURE"));
+        assertFalse(dispatchLogger.anyMessageContains("BT_HANDLER_LOAD_FAILURE"));
+    }
+
+    @Test
+    public void missingEnvironmentAndBlankPathUseStageCodes() {
+        RecordingLogger logger = new RecordingLogger();
+        BacktraceCrashHandlerRunner runner = new BacktraceCrashHandlerRunner(
+                mock(BacktraceCrashHandlerWrapper.class), mock(SystemLoader.class), logger);
+
+        assertFalse(runner.run(new String[] {}, null));
+        assertTrue(logger.anyMessageContains("BT_HANDLER_ENV_UNAVAILABLE"));
+
+        HashMap<String, String> blankPath = new HashMap<>();
+        blankPath.put(CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER, "   ");
+        assertFalse(runner.run(new String[] {}, blankPath));
+        assertTrue(logger.anyMessageContains("BT_HANDLER_PATH_UNAVAILABLE"));
+        logger.assertNoSentinelLeaked();
     }
 
     @Test

--- a/backtrace-library/src/main/cpp/backends/backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/backend.cpp
@@ -102,7 +102,8 @@ void DumpWithoutCrash(jstring message, jboolean set_main_thread_as_faulting_thre
     // crash the host application that setup containment just protected.
     if (!initialized.load(std::memory_order_acquire) || disabled.load(std::memory_order_acquire)) {
         __android_log_print(ANDROID_LOG_WARN, "Backtrace-Android",
-                            "Cannot create a native dump because native integration is not enabled.");
+                            "BT_NATIVE_DUMP_UNAVAILABLE: Cannot create a native dump because "
+                            "native integration is not enabled.");
         return;
     }
 #ifdef CRASHPAD_BACKEND

--- a/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
+++ b/backtrace-library/src/main/cpp/backends/crashpad-backend.cpp
@@ -400,7 +400,8 @@ void DumpWithoutCrashCrashpad(jstring message, jboolean set_main_thread_as_fault
     // Defense in depth behind the backend-level initialized/disabled guard.
     if (client == nullptr) {
         __android_log_print(ANDROID_LOG_ERROR, "Backtrace-Android",
-                            "Cannot create a native dump because the Crashpad client is unavailable.");
+                            "BT_NATIVE_DUMP_UNAVAILABLE: Cannot create a native dump because "
+                            "the Crashpad client is unavailable.");
         return;
     }
 

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -54,7 +54,7 @@ public class BacktraceDatabase implements Database {
     private boolean _enable = false;
     private Breadcrumbs breadcrumbs;
     private CrashHandlerConfiguration crashHandlerConfiguration;
-    private boolean _enabledNativeIntegration = false;
+    private volatile boolean _enabledNativeIntegration = false;
     private NativeCommunication nativeCommunication = new BacktraceCrashHandlerWrapper();
 
     /**
@@ -209,17 +209,17 @@ public class BacktraceDatabase implements Database {
         // Validate public inputs before performing any side effects; enabling the optional native
         // integration must never terminate the host application.
         if (client == null) {
-            BacktraceLogger.e(LOG_TAG, "Native integration requires a Backtrace client.");
+            BacktraceLogger.e(LOG_TAG, "BT_NATIVE_PREPARE_FAILURE: Native integration requires a Backtrace client.");
             this._enabledNativeIntegration = false;
             return false;
         }
         if (credentials == null) {
-            BacktraceLogger.e(LOG_TAG, "Native integration requires Backtrace credentials.");
+            BacktraceLogger.e(LOG_TAG, "BT_NATIVE_PREPARE_FAILURE: Native integration requires Backtrace credentials.");
             this._enabledNativeIntegration = false;
             return false;
         }
         if (nativeCommunication == null || crashHandlerConfiguration == null) {
-            BacktraceLogger.e(LOG_TAG, "Native integration dependencies are unavailable.");
+            BacktraceLogger.e(LOG_TAG, "BT_NATIVE_PREPARE_FAILURE: Native integration dependencies are unavailable.");
             this._enabledNativeIntegration = false;
             return false;
         }
@@ -240,7 +240,8 @@ public class BacktraceDatabase implements Database {
         try {
             Uri minidumpUri = credentials.getMinidumpSubmissionUrl();
             if (minidumpUri == null || minidumpUri.toString().trim().isEmpty()) {
-                BacktraceLogger.e(LOG_TAG, "Native integration requires a minidump submission URL.");
+                BacktraceLogger.e(
+                        LOG_TAG, "BT_NATIVE_PREPARE_FAILURE: Native integration requires a minidump submission URL.");
                 this._enabledNativeIntegration = false;
                 return false;
             }
@@ -301,7 +302,7 @@ public class BacktraceDatabase implements Database {
         }
 
         if (!_enabledNativeIntegration) {
-            BacktraceLogger.e(LOG_TAG, "Native integration was not enabled by the native initialization bridge.");
+            BacktraceLogger.e(LOG_TAG, "BT_NATIVE_BRIDGE_FAILURE: The native initialization bridge returned false.");
         }
 
         if (_enabledNativeIntegration && this.breadcrumbs.isEnabled()) {

--- a/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/BacktraceDatabase.java
@@ -132,6 +132,19 @@ public class BacktraceDatabase implements Database {
     }
 
     /**
+     * Sanitized failure description for optional-native-integration diagnostics: exception
+     * messages can carry submission URLs, tokens, or filesystem paths (for example from a custom
+     * credential implementation or an UnsatisfiedLinkError), so these paths log only the class.
+     */
+    private static String failureType(Throwable failure) {
+        if (failure == null) {
+            return "unknown";
+        }
+        String type = failure.getClass().getName();
+        return type == null || type.trim().isEmpty() ? "unknown" : type;
+    }
+
+    /**
      * Setup native crash handler
      *
      * @param client      Backtrace client
@@ -262,8 +275,9 @@ public class BacktraceDatabase implements Database {
             this._enabledNativeIntegration = false;
             BacktraceLogger.e(
                     LOG_TAG,
-                    "Native integration was not enabled because its configuration could not be" + " prepared.",
-                    failure);
+                    "BT_NATIVE_PREPARE_FAILURE: Native integration configuration could not be"
+                            + " prepared. Failure type: "
+                            + failureType(failure));
             return false;
         }
 
@@ -280,8 +294,9 @@ public class BacktraceDatabase implements Database {
             this._enabledNativeIntegration = false;
             BacktraceLogger.e(
                     LOG_TAG,
-                    "Native integration was not enabled because the native initialization bridge" + " failed.",
-                    failure);
+                    "BT_NATIVE_BRIDGE_FAILURE: Native integration was not enabled because the"
+                            + " native initialization bridge failed. Failure type: "
+                            + failureType(failure));
             return false;
         }
 
@@ -299,9 +314,10 @@ public class BacktraceDatabase implements Database {
             } catch (RuntimeException failure) {
                 BacktraceLogger.e(
                         LOG_TAG,
-                        "Native integration is enabled, but the breadcrumb synchronization hook"
-                                + " could not be installed.",
-                        failure);
+                        "BT_NATIVE_BREADCRUMB_HOOK_FAILURE: Native integration is enabled, but the"
+                                + " breadcrumb synchronization hook could not be installed."
+                                + " Failure type: "
+                                + failureType(failure));
             }
         }
 
@@ -335,7 +351,11 @@ public class BacktraceDatabase implements Database {
         try {
             nativeDisableAction.run();
         } catch (RuntimeException | LinkageError failure) {
-            BacktraceLogger.e(LOG_TAG, "Native integration could not be disabled through the native bridge.", failure);
+            BacktraceLogger.e(
+                    LOG_TAG,
+                    "BT_NATIVE_DISABLE_FAILURE: Native integration could not be disabled through"
+                            + " the native bridge. Failure type: "
+                            + failureType(failure));
         } finally {
             this._enabledNativeIntegration = false;
         }

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -294,7 +294,7 @@ public class BacktraceBase implements Client {
      * control normally, leaving managed crash reporting operational.
      *
      * <p>See {@code docs/native-integration-startup.md} for resolution precedence, failure
-     * semantics, threading, and release qualification boundaries.
+     * semantics, threading, lifecycle, and compatibility details.
      */
     public void enableNativeIntegration() {
         tryEnableNativeIntegration();
@@ -320,6 +320,19 @@ public class BacktraceBase implements Client {
     public boolean tryEnableNativeIntegration(boolean enableClientSideUnwinding) {
         return Boolean.TRUE.equals(
                 this.database.setupNativeIntegration(this, this.credentials, enableClientSideUnwinding));
+    }
+
+    /**
+     * Same as {@link #enableNativeIntegration(boolean, UnwindingMode)}, but reports whether the
+     * native crash handler was actually installed.
+     *
+     * @param enableClientSideUnwinding Enable client side unwinding
+     * @param unwindingMode             Unwinding mode to use for client side unwinding
+     * @return {@code true} when native integration is enabled
+     */
+    public boolean tryEnableNativeIntegration(boolean enableClientSideUnwinding, UnwindingMode unwindingMode) {
+        return Boolean.TRUE.equals(
+                this.database.setupNativeIntegration(this, this.credentials, enableClientSideUnwinding, unwindingMode));
     }
 
     /**

--- a/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
+++ b/backtrace-library/src/main/java/backtraceio/library/base/BacktraceBase.java
@@ -798,8 +798,19 @@ public class BacktraceBase implements Client {
             dumpWithoutCrashNative(message, setMainThreadAsFaultingThread);
         } catch (RuntimeException | LinkageError failure) {
             BacktraceLogger.e(
-                    LOG_TAG, "Cannot create a native dump because native integration is unavailable.", failure);
+                    LOG_TAG,
+                    "BT_NATIVE_DUMP_UNAVAILABLE: Cannot create a native dump because native"
+                            + " integration is unavailable. Failure type: "
+                            + failureType(failure));
         }
+    }
+
+    private static String failureType(Throwable failure) {
+        if (failure == null) {
+            return "unknown";
+        }
+        String type = failure.getClass().getName();
+        return type == null || type.trim().isEmpty() ? "unknown" : type;
     }
 
     private native void dumpWithoutCrashNative(String message, boolean setMainThreadAsFaultingThread);

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceCrashHandlerRunner.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceCrashHandlerRunner.java
@@ -12,21 +12,21 @@ public class BacktraceCrashHandlerRunner {
     private final SystemLoader loader;
     private final RunnerLogger logger;
 
-    /** Logging seam so tests can prove no message carries handler arguments or credentials. */
+    /**
+     * Logging seam without a {@link Throwable} overload: exception messages commonly carry the
+     * rejected library path ({@code UnsatisfiedLinkError}) or credential-bearing URLs, and this
+     * process's Logcat is collected into CI artifacts. Tests use it to prove no message leaks.
+     */
     interface RunnerLogger {
-        void error(String message, Throwable throwable);
+        void error(String message);
 
         void info(String message);
     }
 
     private static final class LogcatRunnerLogger implements RunnerLogger {
         @Override
-        public void error(String message, Throwable throwable) {
-            if (throwable == null) {
-                Log.e(LOG_TAG, message);
-            } else {
-                Log.e(LOG_TAG, message, throwable);
-            }
+        public void error(String message) {
+            Log.e(LOG_TAG, message);
         }
 
         @Override
@@ -59,30 +59,28 @@ public class BacktraceCrashHandlerRunner {
     }
 
     /**
-     * Runs the crash handler. Diagnostics never include the handler arguments, the environment, or
-     * the resolved library path: Crashpad passes the submission URL (which can carry the minidump
-     * token) and every customer annotation on the argument vector, and this log ends up in Logcat
-     * and CI artifacts.
+     * Runs the crash handler. Diagnostics carry only a stable stage code and the failure class
+     * name — never the handler arguments, environment, resolved library path, exception message,
+     * or stack trace: Crashpad passes the submission URL (which can carry the minidump token) and
+     * every customer annotation on the argument vector, and exception messages embed paths.
      */
     public boolean run(String[] args, Map<String, String> environmentVariables) {
         if (environmentVariables == null) {
-            logger.error("Cannot capture crash dump. Environment is unavailable.", null);
+            logger.error("BT_HANDLER_ENV_UNAVAILABLE: Cannot capture crash dump. Environment is unavailable.");
             return false;
         }
 
         String crashHandlerLibrary = environmentVariables.get(CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER);
         if (crashHandlerLibrary == null || crashHandlerLibrary.trim().isEmpty()) {
-            logger.error("Cannot capture crash dump. Crash-handler path is unavailable.", null);
+            logger.error("BT_HANDLER_PATH_UNAVAILABLE: Cannot capture crash dump. Crash-handler path is unavailable.");
             return false;
         }
 
-        // The library path was resolved in the application process; loading it here can still fail
-        // (for example an APK-backed path the linker of this process cannot use). Contain both the
-        // load and the dispatch separately so diagnostics distinguish the failure stages.
         try {
             loader.loadLibrary(crashHandlerLibrary);
         } catch (RuntimeException | LinkageError failure) {
-            logger.error("Cannot load the native crash-handler library.", failure);
+            logger.error("BT_HANDLER_LOAD_FAILURE: Cannot load the native crash-handler library. Failure type: "
+                    + failureType(failure));
             return false;
         }
 
@@ -90,16 +88,25 @@ public class BacktraceCrashHandlerRunner {
         try {
             result = crashHandler.handleCrash(args == null ? new String[0] : args);
         } catch (RuntimeException | LinkageError failure) {
-            logger.error("Cannot execute the native crash handler.", failure);
+            logger.error("BT_HANDLER_DISPATCH_FAILURE: Cannot execute the native crash handler. Failure type: "
+                    + failureType(failure));
             return false;
         }
 
         if (!result) {
-            logger.error("Native crash-handler invocation returned failure.", null);
+            logger.error("BT_HANDLER_RETURNED_FAILURE: Native crash-handler invocation returned failure.");
             return false;
         }
 
         logger.info("Successfully ran crash handler code.");
         return true;
+    }
+
+    private static String failureType(Throwable failure) {
+        if (failure == null) {
+            return "unknown";
+        }
+        String type = failure.getClass().getName();
+        return type == null || type.trim().isEmpty() ? "unknown" : type;
     }
 }

--- a/backtrace-library/src/main/java/backtraceio/library/services/BacktraceCrashHandlerRunner.java
+++ b/backtrace-library/src/main/java/backtraceio/library/services/BacktraceCrashHandlerRunner.java
@@ -62,7 +62,8 @@ public class BacktraceCrashHandlerRunner {
      * Runs the crash handler. Diagnostics carry only a stable stage code and the failure class
      * name — never the handler arguments, environment, resolved library path, exception message,
      * or stack trace: Crashpad passes the submission URL (which can carry the minidump token) and
-     * every customer annotation on the argument vector, and exception messages embed paths.
+     * every application-provided annotation on the argument vector, and exception messages embed
+     * paths.
      */
     public boolean run(String[] args, Map<String, String> environmentVariables) {
         if (environmentVariables == null) {

--- a/coroner-client/src/main/java/backtraceio/coroner/CoronerClient.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/CoronerClient.java
@@ -56,6 +56,26 @@ public class CoronerClient {
         return makeRequest(coronerQuery);
     }
 
+    /**
+     * GUID-correlated query returning up to {@code limit} reports. Use a limit larger than the
+     * expected report count (qualification tests use 10); otherwise duplicate detection is
+     * impossible.
+     */
+    public CoronerResponse guidTimestampFilter(
+            final String guid,
+            final String timestampLeast,
+            final String timestampMost,
+            final List<String> customAttributes,
+            final int limit)
+            throws CoronerResponseException, IOException, CoronerHttpException {
+        final List<String> attributes = concatAttributes(customAttributes);
+
+        final JsonObject coronerQuery =
+                this.coronerQueries.filterByGuidAndTimestamp(guid, timestampLeast, timestampMost, attributes, limit);
+
+        return makeRequest(coronerQuery);
+    }
+
     private List<String> concatAttributes(final List<String> customAttributes) {
         final List<String> result = new ArrayList<>(customAttributes);
         result.addAll(DEFAULT_ATTRIBUTES);

--- a/coroner-client/src/main/java/backtraceio/coroner/CoronerClient.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/CoronerClient.java
@@ -76,6 +76,27 @@ public class CoronerClient {
         return makeRequest(coronerQuery);
     }
 
+    /**
+     * GUID plus exact {@code error.message} query returning up to {@code limit} reports. Use this
+     * to prove a specific message was ingested exactly once even when the backend collapses a
+     * GUID-wide grouped query into a single wildcard group.
+     */
+    public CoronerResponse guidMessageTimestampFilter(
+            final String guid,
+            final String errorMessage,
+            final String timestampLeast,
+            final String timestampMost,
+            final List<String> customAttributes,
+            final int limit)
+            throws CoronerResponseException, IOException, CoronerHttpException {
+        final List<String> attributes = concatAttributes(customAttributes);
+
+        final JsonObject coronerQuery = this.coronerQueries.filterByGuidMessageAndTimestamp(
+                guid, errorMessage, timestampLeast, timestampMost, attributes, limit);
+
+        return makeRequest(coronerQuery);
+    }
+
     private List<String> concatAttributes(final List<String> customAttributes) {
         final List<String> result = new ArrayList<>(customAttributes);
         result.addAll(DEFAULT_ATTRIBUTES);

--- a/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueries.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueries.java
@@ -57,4 +57,33 @@ public class CoronerQueries {
 
         return this.builder.buildRxIdGroup(filtersBuilder.getJson(), attributes, limit);
     }
+
+    /**
+     * GUID plus exact {@code error.message} query. Grouped results can collapse into a single
+     * wildcard group exposing one head value per fold, so proving that a specific message was
+     * ingested exactly once requires filtering on the message itself rather than inspecting head
+     * values of a GUID-wide query.
+     */
+    public JsonObject filterByGuidMessageAndTimestamp(
+            final String guid,
+            final String errorMessage,
+            final String timestampLeast,
+            final String timestampMost,
+            final List<String> attributes,
+            final int limit) {
+        if (guid == null || guid.trim().isEmpty()) {
+            throw new IllegalArgumentException("guid cannot be null or blank");
+        }
+        if (errorMessage == null || errorMessage.trim().isEmpty()) {
+            throw new IllegalArgumentException("errorMessage cannot be null or blank");
+        }
+
+        final CoronerFiltersBuilder filtersBuilder = new CoronerFiltersBuilder();
+        filtersBuilder.addFilter(CoronerQueryFields.GUID, FilterOperator.EQUAL, guid);
+        filtersBuilder.addFilter(CoronerQueryFields.ERROR_MESSAGE, FilterOperator.EQUAL, errorMessage);
+        filtersBuilder.addFilter(CoronerQueryFields.TIMESTAMP, FilterOperator.AT_LEAST, timestampLeast + ".");
+        filtersBuilder.addFilter(CoronerQueryFields.TIMESTAMP, FilterOperator.AT_MOST, timestampMost + ".");
+
+        return this.builder.buildRxIdGroup(filtersBuilder.getJson(), attributes, limit);
+    }
 }

--- a/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueries.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueries.java
@@ -34,4 +34,27 @@ public class CoronerQueries {
 
         return this.builder.buildRxIdGroup(filtersBuilder.getJson(), attributes);
     }
+
+    /**
+     * GUID-correlated query with a caller-chosen result limit. GUID is the primary correlation key
+     * for qualification reports (fatal reports carry no controllable {@code error.message}), and
+     * the limit must exceed the expected count for duplicate detection to be possible.
+     */
+    public JsonObject filterByGuidAndTimestamp(
+            final String guid,
+            final String timestampLeast,
+            final String timestampMost,
+            final List<String> attributes,
+            final int limit) {
+        if (guid == null || guid.trim().isEmpty()) {
+            throw new IllegalArgumentException("guid cannot be null or blank");
+        }
+
+        final CoronerFiltersBuilder filtersBuilder = new CoronerFiltersBuilder();
+        filtersBuilder.addFilter(CoronerQueryFields.GUID, FilterOperator.EQUAL, guid);
+        filtersBuilder.addFilter(CoronerQueryFields.TIMESTAMP, FilterOperator.AT_LEAST, timestampLeast + ".");
+        filtersBuilder.addFilter(CoronerQueryFields.TIMESTAMP, FilterOperator.AT_MOST, timestampMost + ".");
+
+        return this.builder.buildRxIdGroup(filtersBuilder.getJson(), attributes, limit);
+    }
 }

--- a/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueryBuilder.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueryBuilder.java
@@ -6,15 +6,30 @@ import com.google.gson.JsonPrimitive;
 import java.util.List;
 
 class CoronerQueryBuilder {
-    private final String FOLD_HEAD = "head";
-    private final int OFFSET = 0;
-    private final int LIMIT = 1;
+    private static final String FOLD_HEAD = "head";
+    private static final int OFFSET = 0;
+    private static final int DEFAULT_LIMIT = 1;
+    static final int MAX_LIMIT = 100;
 
     public JsonObject buildRxIdGroup(final JsonArray filters, final List<String> headFolds) {
-        return this.build(CoronerQueryFields.RXID, filters, headFolds);
+        return this.buildRxIdGroup(filters, headFolds, DEFAULT_LIMIT);
     }
 
-    private JsonObject build(final String groupName, final JsonArray filters, final List<String> headFolds) {
+    /**
+     * Builds an {@code _rxid}-grouped query returning up to {@code limit} result groups. Duplicate
+     * detection requires a limit larger than the expected report count: with the historical
+     * hard-coded limit of one, a query could never return more than one report, so an
+     * "exactly one" assertion could not fail on duplicates.
+     */
+    public JsonObject buildRxIdGroup(final JsonArray filters, final List<String> headFolds, final int limit) {
+        if (limit < 1 || limit > MAX_LIMIT) {
+            throw new IllegalArgumentException("limit must be between 1 and " + MAX_LIMIT);
+        }
+        return this.build(CoronerQueryFields.RXID, filters, headFolds, limit);
+    }
+
+    private JsonObject build(
+            final String groupName, final JsonArray filters, final List<String> headFolds, final int limit) {
         final JsonObject folds = joinHeadFolds(headFolds);
 
         final JsonObject result = new JsonObject();
@@ -28,7 +43,7 @@ class CoronerQueryBuilder {
         result.add(Constants.FOLD, folds);
         result.add(Constants.GROUP, group);
         result.add(Constants.OFFSET, new JsonPrimitive(OFFSET));
-        result.add(Constants.LIMIT, new JsonPrimitive(LIMIT));
+        result.add(Constants.LIMIT, new JsonPrimitive(limit));
         result.add(Constants.FILTER, filters);
 
         return result;

--- a/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueryFields.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/query/CoronerQueryFields.java
@@ -3,8 +3,12 @@ package backtraceio.coroner.query;
 public class CoronerQueryFields {
     public static final String FOLD_CALLSTACK = "callstack";
     public static final String FOLD_CLASSIFIERS = "classifiers";
-    public static final String FOLD_GUID = "guid";
+
+    public static final String GUID = "guid";
+    public static final String FOLD_GUID = GUID;
+
     public static final String RXID = "_rxid";
     public static final String ERROR_TYPE = "error.type";
+    public static final String ERROR_MESSAGE = "error.message";
     public static final String TIMESTAMP = "timestamp";
 }

--- a/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponse.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponse.java
@@ -30,11 +30,17 @@ public class CoronerResponse {
         if (this.values == null) {
             throw new CoronerResponseProcessingException("Values property from response is null");
         }
-        if (elementIndex < 0 || elementIndex > this.values.size()) {
+        if (elementIndex < 0 || elementIndex >= this.values.size()) {
             throw new CoronerResponseProcessingException(
-                    "Incorrect element index, value should be between 0 and " + this.values.size());
+                    "Incorrect element index; value must be between 0 and " + (this.values.size() - 1));
         }
         final CoronerResponseGroup responseGroup = values.get(elementIndex);
+        if (responseGroup == null) {
+            throw new CoronerResponseProcessingException("Response group is null for element index: " + elementIndex);
+        }
+        if (this.columnsDesc == null) {
+            throw new CoronerResponseProcessingException("Columns description property from response is null");
+        }
 
         final int attributeIndex = getAttributeIndex(name);
         try {
@@ -53,7 +59,8 @@ public class CoronerResponse {
 
     private int getAttributeIndex(final String attributeName) throws CoronerResponseProcessingException {
         for (int index = 0; index < this.columnsDesc.size(); index++) {
-            if (this.columnsDesc.get(index).name.equals(attributeName)) {
+            final ColumnDescElement columnDesc = this.columnsDesc.get(index);
+            if (columnDesc != null && columnDesc.name != null && columnDesc.name.equals(attributeName)) {
                 return index;
             }
         }

--- a/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponseGroup.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponseGroup.java
@@ -5,10 +5,11 @@ import java.util.List;
 public class CoronerResponseGroup {
     private static final Integer EXPECTED_NUMBER_OF_ELEMENTS = 3;
 
-    @SuppressWarnings("unused")
     private final String groupIdentifier;
 
     private final List<Object> values;
+
+    private final int groupRowCount;
 
     public CoronerResponseGroup(final List<Object> obj) throws IllegalArgumentException {
         if (obj == null || obj.size() != EXPECTED_NUMBER_OF_ELEMENTS) {
@@ -18,9 +19,31 @@ public class CoronerResponseGroup {
 
         this.groupIdentifier = obj.get(0).toString();
         this.values = (List<Object>) obj.get(1);
+        this.groupRowCount = parseRowCount(obj.get(2));
+    }
+
+    private static int parseRowCount(final Object countElement) {
+        if (countElement instanceof Number) {
+            return Math.max(1, ((Number) countElement).intValue());
+        }
+        return 1;
     }
 
     public Object getAttribute(final int index) {
         return values.get(index);
+    }
+
+    /** The grouped identifier for this result row; for {@code _rxid}-grouped queries, the RXID. */
+    public String getGroupIdentifier() {
+        return groupIdentifier;
+    }
+
+    /**
+     * The number of underlying rows folded into this group. Coroner can collapse a grouped query
+     * into a single {@code "*"} group whose count carries the real match total, so callers
+     * counting reports must sum row counts rather than counting groups.
+     */
+    public int getGroupRowCount() {
+        return groupRowCount;
     }
 }

--- a/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponseGroup.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/response/CoronerResponseGroup.java
@@ -1,5 +1,6 @@
 package backtraceio.coroner.response;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 public class CoronerResponseGroup {
@@ -23,10 +24,20 @@ public class CoronerResponseGroup {
     }
 
     private static int parseRowCount(final Object countElement) {
-        if (countElement instanceof Number) {
-            return Math.max(1, ((Number) countElement).intValue());
+        if (!(countElement instanceof Number)) {
+            throw new IllegalArgumentException("Coroner group row count is not numeric");
         }
-        return 1;
+
+        final int rowCount;
+        try {
+            rowCount = new BigDecimal(countElement.toString()).intValueExact();
+        } catch (NumberFormatException | ArithmeticException failure) {
+            throw new IllegalArgumentException("Coroner group row count must be an exact 32-bit integer", failure);
+        }
+        if (rowCount <= 0) {
+            throw new IllegalArgumentException("Coroner group row count must be positive");
+        }
+        return rowCount;
     }
 
     public Object getAttribute(final int index) {

--- a/coroner-client/src/main/java/backtraceio/coroner/serialization/CoronerResponseGroupDeserializer.java
+++ b/coroner-client/src/main/java/backtraceio/coroner/serialization/CoronerResponseGroupDeserializer.java
@@ -9,24 +9,18 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import java.lang.reflect.Type;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class CoronerResponseGroupDeserializer implements JsonDeserializer<CoronerResponseGroup> {
-    private static final Logger LOGGER = Logger.getLogger(CoronerResponseGroupDeserializer.class.getName());
-
     @Override
     public CoronerResponseGroup deserialize(
             final JsonElement json, final Type typeOfT, final JsonDeserializationContext context)
             throws JsonParseException {
-        final JsonArray jsonArray = json.getAsJsonArray();
-        final List<Object> obj = new Gson().fromJson(jsonArray, (Type) Object.class);
         try {
+            final JsonArray jsonArray = json.getAsJsonArray();
+            final List<Object> obj = new Gson().fromJson(jsonArray, (Type) Object.class);
             return new CoronerResponseGroup(obj);
-        } catch (Exception e) {
-            LOGGER.log(Level.SEVERE, "Coroner response deserialization exception ", e);
-            e.printStackTrace();
-            return null;
+        } catch (RuntimeException failure) {
+            throw new JsonParseException("Unable to deserialize Coroner response group", failure);
         }
     }
 }

--- a/coroner-client/src/test/java/backtraceio/coroner/CoronerClientTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/CoronerClientTest.java
@@ -1,9 +1,11 @@
 package backtraceio.coroner;
 
+import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_GUID_MESSAGE_TIMESTAMP;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_GUID_TIMESTAMP;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_RXID_123;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_RXID_123_ATTR_ERR_MSG;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_TIMESTAMP_ERR_TYPE;
+import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_GUID_MESSAGE_ONE_RESULT_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_GUID_TWO_RESULTS_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_OPERATION_ERROR_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_RX_FILTER_CORONER_JSON;
@@ -162,6 +164,43 @@ public class CoronerClientTest {
         assertEquals(guid, result.getAttribute(0, "guid", String.class));
         assertEquals(guid, result.getAttribute(1, "guid", String.class));
         assertEquals("duplicate-report", result.getAttribute(1, "error.message", String.class));
+    }
+
+    /**
+     * The GUID+message query proves a specific message was ingested exactly once even when a
+     * GUID-wide grouped query collapses into a single wildcard group.
+     */
+    @Test
+    public void guidMessageTimestampFilterReturnsTheMatchingReport()
+            throws CoronerResponseException, IOException, CoronerHttpException, CoronerResponseProcessingException {
+        // GIVEN
+        final String guid = "11111111-2222-3333-4444-555555555555";
+        final String message = "before-disable-11111111";
+        final String expectedJsonQuery = readResourceFile(QUERY_CORONER_GUID_MESSAGE_TIMESTAMP);
+        final String jsonResponse = readResourceFile(RESPONSE_GUID_MESSAGE_ONE_RESULT_JSON);
+        final CoronerApiResponse expectedResponse = GsonWrapper.fromJson(jsonResponse, CoronerApiResponse.class);
+
+        // MOCK
+        when(mockHttpClient.get(argThat(JsonMatchers.jsonEquals(expectedJsonQuery))))
+                .thenReturn(expectedResponse);
+
+        // WHEN
+        final CoronerResponse result = client.guidMessageTimestampFilter(
+                guid, message, "1680000000", "1680000600", Arrays.asList("error.type", "error.message"), 10);
+
+        // THEN
+        assertNotNull(result);
+        assertEquals(1, result.getResultsNumber());
+        assertEquals(guid, result.getAttribute(0, "guid", String.class));
+        assertEquals(message, result.getAttribute(0, "error.message", String.class));
+    }
+
+    @Test
+    public void guidMessageTimestampFilterRejectsBlankMessage() {
+        Mockito.verifyNoInteractions(mockHttpClient);
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> client.guidMessageTimestampFilter("guid", " ", "1", "2", Arrays.asList("error.type"), 10));
     }
 
     @Test

--- a/coroner-client/src/test/java/backtraceio/coroner/CoronerClientTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/CoronerClientTest.java
@@ -1,8 +1,10 @@
 package backtraceio.coroner;
 
+import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_GUID_TIMESTAMP;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_RXID_123;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_RXID_123_ATTR_ERR_MSG;
 import static backtraceio.coroner.utils.ResourceUtils.QUERY_CORONER_TIMESTAMP_ERR_TYPE;
+import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_GUID_TWO_RESULTS_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_OPERATION_ERROR_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_RX_FILTER_CORONER_JSON;
 import static backtraceio.coroner.utils.ResourceUtils.RESPONSE_TIMESTAMP_ERR_TYPE_CORONER_JSON;
@@ -131,5 +133,45 @@ public class CoronerClientTest {
             assertEquals(errorMessage, exception.getCoronerError().getMessage());
             assertEquals(32769, exception.getCoronerError().getCode());
         }
+    }
+
+    /**
+     * A bounded GUID query can return more than one report; the historical hard-coded limit of one
+     * made duplicate detection impossible because a response could never carry two results.
+     */
+    @Test
+    public void guidTimestampFilterReturnsMultipleResults()
+            throws CoronerResponseException, IOException, CoronerHttpException, CoronerResponseProcessingException {
+        // GIVEN
+        final String guid = "11111111-2222-3333-4444-555555555555";
+        final String expectedJsonQuery = readResourceFile(QUERY_CORONER_GUID_TIMESTAMP);
+        final String jsonResponse = readResourceFile(RESPONSE_GUID_TWO_RESULTS_JSON);
+        final CoronerApiResponse expectedResponse = GsonWrapper.fromJson(jsonResponse, CoronerApiResponse.class);
+
+        // MOCK
+        when(mockHttpClient.get(argThat(JsonMatchers.jsonEquals(expectedJsonQuery))))
+                .thenReturn(expectedResponse);
+
+        // WHEN
+        final CoronerResponse result = client.guidTimestampFilter(
+                guid, "1680000000", "1680000600", Arrays.asList("error.type", "error.message"), 10);
+
+        // THEN
+        assertNotNull(result);
+        assertEquals(2, result.getResultsNumber());
+        assertEquals(guid, result.getAttribute(0, "guid", String.class));
+        assertEquals(guid, result.getAttribute(1, "guid", String.class));
+        assertEquals("duplicate-report", result.getAttribute(1, "error.message", String.class));
+    }
+
+    @Test
+    public void guidTimestampFilterRejectsInvalidLimit() {
+        Mockito.verifyNoInteractions(mockHttpClient);
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> client.guidTimestampFilter("guid", "1", "2", Arrays.asList("error.type"), 0));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> client.guidTimestampFilter("guid", "1", "2", Arrays.asList("error.type"), 101));
     }
 }

--- a/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueriesTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueriesTest.java
@@ -47,6 +47,47 @@ public class CoronerQueriesTest {
     }
 
     @Test
+    public void filterByGuidAndTimestampTest() {
+        // GIVEN
+        final String guid = "1f4a2b3c-0000-4f0a-fd08-00000000dead";
+        final String timestampStart = "1680943692";
+        final String timestampEnd = "1681943692";
+        final List<String> attributes = Arrays.asList("error.type", "error.message");
+
+        // WHEN
+        JsonObject result = coronerQueries.filterByGuidAndTimestamp(guid, timestampStart, timestampEnd, attributes, 10);
+
+        // THEN
+        String expectedResult = "{\"fold\":{\"error.type\":[[\"head\"]],\"error.message\":[[\"head\"]]},"
+                + "\"group\":[[\"_rxid\"]],\"offset\":0,\"limit\":10,"
+                + "\"filter\":[{\"guid\":[[\"equal\",\"1f4a2b3c-0000-4f0a-fd08-00000000dead\"]],"
+                + "\"timestamp\":[[\"at-least\",\"1680943692.\"],[\"at-most\",\"1681943692.\"]]}]}";
+        assertEquals(expectedResult, StringUtils.normalizeSpace(result.toString()));
+    }
+
+    @Test
+    public void filterByGuidEscapesJsonSpecialCharacters() {
+        // A GUID is validated as non-blank only; prove special characters cannot break the JSON.
+        JsonObject result =
+                coronerQueries.filterByGuidAndTimestamp("we\"ird\\guid", "1", "2", Arrays.asList("error.type"), 10);
+
+        String serialized = result.toString();
+        org.junit.Assert.assertTrue(serialized.contains("we\\\"ird\\\\guid"));
+        // Round-trips through the parser without corruption.
+        com.google.gson.JsonParser.parseString(serialized);
+    }
+
+    @Test
+    public void filterByGuidRejectsBlankGuid() {
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueries.filterByGuidAndTimestamp(null, "1", "2", Arrays.asList("a"), 10));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueries.filterByGuidAndTimestamp("  ", "1", "2", Arrays.asList("a"), 10));
+    }
+
+    @Test
     public void filterByErrorTypeAndTimestampTest() {
         // GIVEN
         final List<String> attributes = Arrays.asList("error.message", "example-attribute");

--- a/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueriesTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueriesTest.java
@@ -88,6 +88,40 @@ public class CoronerQueriesTest {
     }
 
     @Test
+    public void filterByGuidMessageAndTimestampTest() {
+        // GIVEN
+        final String guid = "1f4a2b3c-0000-4f0a-fd08-00000000dead";
+        final String message = "before-disable-1f4a2b3c";
+        final List<String> attributes = Arrays.asList("error.type", "error.message");
+
+        // WHEN
+        JsonObject result = coronerQueries.filterByGuidMessageAndTimestamp(
+                guid, message, "1680943692", "1681943692", attributes, 10);
+
+        // THEN
+        String expectedResult = "{\"fold\":{\"error.type\":[[\"head\"]],\"error.message\":[[\"head\"]]},"
+                + "\"group\":[[\"_rxid\"]],\"offset\":0,\"limit\":10,"
+                + "\"filter\":[{\"guid\":[[\"equal\",\"1f4a2b3c-0000-4f0a-fd08-00000000dead\"]],"
+                + "\"error.message\":[[\"equal\",\"before-disable-1f4a2b3c\"]],"
+                + "\"timestamp\":[[\"at-least\",\"1680943692.\"],[\"at-most\",\"1681943692.\"]]}]}";
+        assertEquals(expectedResult, StringUtils.normalizeSpace(result.toString()));
+    }
+
+    @Test
+    public void filterByGuidMessageRejectsBlankInputs() {
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueries.filterByGuidMessageAndTimestamp(
+                        "  ", "message", "1", "2", Arrays.asList("a"), 10));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueries.filterByGuidMessageAndTimestamp("guid", null, "1", "2", Arrays.asList("a"), 10));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueries.filterByGuidMessageAndTimestamp("guid", " ", "1", "2", Arrays.asList("a"), 10));
+    }
+
+    @Test
     public void filterByErrorTypeAndTimestampTest() {
         // GIVEN
         final List<String> attributes = Arrays.asList("error.message", "example-attribute");

--- a/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueryBuilderTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/query/CoronerQueryBuilderTest.java
@@ -28,4 +28,40 @@ public class CoronerQueryBuilderTest {
                 "{\"fold\":{\"error.type\":[[\"head\"]],\"callstack\":[[\"head\"]]},\"group\":[[\"_rxid\"]],\"offset\":0,\"limit\":1,\"filter\":[{\"_rxid\":[[\"equal\",\"03000000-4f0a-fd08-0000-000000000000\"]]}]}";
         assertEquals(expectedResult, StringUtils.normalizeSpace(result.toString()));
     }
+
+    /** The no-limit overload must keep emitting {@code limit: 1} for existing callers. */
+    @Test
+    public void defaultOverloadKeepsLimitOne() {
+        final CoronerQueryBuilder coronerQueryBuilder = new CoronerQueryBuilder();
+        final JsonArray filters = GsonWrapper.fromJson("[{\"guid\":[[\"equal\",\"abc\"]]}]", JsonArray.class);
+
+        final JsonObject result = coronerQueryBuilder.buildRxIdGroup(filters, Arrays.asList("error.type"));
+
+        assertEquals(1, result.get("limit").getAsInt());
+    }
+
+    @Test
+    public void explicitLimitIsEmitted() {
+        final CoronerQueryBuilder coronerQueryBuilder = new CoronerQueryBuilder();
+        final JsonArray filters = GsonWrapper.fromJson("[{\"guid\":[[\"equal\",\"abc\"]]}]", JsonArray.class);
+
+        final JsonObject result = coronerQueryBuilder.buildRxIdGroup(filters, Arrays.asList("error.type"), 10);
+
+        assertEquals(10, result.get("limit").getAsInt());
+    }
+
+    @Test
+    public void invalidLimitsThrow() {
+        final CoronerQueryBuilder coronerQueryBuilder = new CoronerQueryBuilder();
+        final JsonArray filters = GsonWrapper.fromJson("[{\"guid\":[[\"equal\",\"abc\"]]}]", JsonArray.class);
+        final List<String> headFolds = Arrays.asList("error.type");
+
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class, () -> coronerQueryBuilder.buildRxIdGroup(filters, headFolds, 0));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class, () -> coronerQueryBuilder.buildRxIdGroup(filters, headFolds, -1));
+        org.junit.Assert.assertThrows(
+                IllegalArgumentException.class,
+                () -> coronerQueryBuilder.buildRxIdGroup(filters, headFolds, CoronerQueryBuilder.MAX_LIMIT + 1));
+    }
 }

--- a/coroner-client/src/test/java/backtraceio/coroner/response/CoronerResponseGroupTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/response/CoronerResponseGroupTest.java
@@ -1,0 +1,50 @@
+package backtraceio.coroner.response;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class CoronerResponseGroupTest {
+
+    @Test
+    public void positiveNumericRowCountIsAccepted() {
+        final CoronerResponseGroup responseGroup = createResponseGroup(2);
+
+        assertEquals(2, responseGroup.getGroupRowCount());
+    }
+
+    @Test
+    public void nonNumericRowCountIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> createResponseGroup("1"));
+    }
+
+    @Test
+    public void zeroRowCountIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> createResponseGroup(0));
+    }
+
+    @Test
+    public void negativeRowCountIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> createResponseGroup(-1));
+    }
+
+    @Test
+    public void fractionalRowCountIsRejected() {
+        assertThrows(IllegalArgumentException.class, () -> createResponseGroup(1.5));
+    }
+
+    @Test
+    public void overflowingRowCountIsRejected() {
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> createResponseGroup(BigInteger.valueOf(Integer.MAX_VALUE).add(BigInteger.ONE)));
+    }
+
+    private static CoronerResponseGroup createResponseGroup(final Object rowCount) {
+        return new CoronerResponseGroup(Arrays.asList("*", Collections.emptyList(), rowCount));
+    }
+}

--- a/coroner-client/src/test/java/backtraceio/coroner/response/CoronerResponseTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/response/CoronerResponseTest.java
@@ -1,0 +1,49 @@
+package backtraceio.coroner.response;
+
+import static org.junit.Assert.assertThrows;
+
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+
+public class CoronerResponseTest {
+
+    @Test
+    public void elementIndexEqualToResultCountIsRejected() {
+        final CoronerResponse response = createResponse(
+                Collections.singletonList(createColumn("guid")),
+                Collections.singletonList(createResponseGroup("guid-value")));
+
+        assertThrows(CoronerResponseProcessingException.class, () -> response.getAttribute(1, "guid", String.class));
+    }
+
+    @Test
+    public void nullColumnsDescriptionIsRejected() {
+        final CoronerResponse response =
+                createResponse(null, Collections.singletonList(createResponseGroup("guid-value")));
+
+        assertThrows(CoronerResponseProcessingException.class, () -> response.getAttribute(0, "guid", String.class));
+    }
+
+    @Test
+    public void nullSelectedResponseGroupIsRejected() {
+        final CoronerResponse response =
+                createResponse(Collections.singletonList(createColumn("guid")), Collections.singletonList(null));
+
+        assertThrows(CoronerResponseProcessingException.class, () -> response.getAttribute(0, "guid", String.class));
+    }
+
+    private static CoronerResponse createResponse(
+            final java.util.List<ColumnDescElement> columnsDesc, final java.util.List<CoronerResponseGroup> values) {
+        return new CoronerResponse(columnsDesc, values);
+    }
+
+    private static ColumnDescElement createColumn(final String name) {
+        return new ColumnDescElement(name, null, null, null);
+    }
+
+    private static CoronerResponseGroup createResponseGroup(final Object attribute) {
+        return new CoronerResponseGroup(
+                Arrays.asList("*", Collections.singletonList(Collections.singletonList(attribute)), 1));
+    }
+}

--- a/coroner-client/src/test/java/backtraceio/coroner/serialization/CoronerResponseGroupDeserializerTest.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/serialization/CoronerResponseGroupDeserializerTest.java
@@ -1,9 +1,10 @@
 package backtraceio.coroner.serialization;
 
-import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 import backtraceio.coroner.response.CoronerResponseGroup;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import com.google.gson.JsonParser;
 import org.junit.Test;
 
@@ -15,10 +16,9 @@ public class CoronerResponseGroupDeserializerTest {
         final CoronerResponseGroupDeserializer deserializer = new CoronerResponseGroupDeserializer();
         final JsonElement jsonElement = JsonParser.parseString("[]").getAsJsonArray();
 
-        // WHEN
-        final CoronerResponseGroup result = deserializer.deserialize(jsonElement, CoronerResponseGroup.class, null);
-
-        // THEN
-        assertNull(result);
+        // WHEN / THEN
+        assertThrows(
+                JsonParseException.class,
+                () -> deserializer.deserialize(jsonElement, CoronerResponseGroup.class, null));
     }
 }

--- a/coroner-client/src/test/java/backtraceio/coroner/utils/ResourceUtils.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/utils/ResourceUtils.java
@@ -16,6 +16,8 @@ public class ResourceUtils {
             MAIN_PATH + "/responses/timestamp-err-type-filter.json";
 
     public static final String RESPONSE_OPERATION_ERROR_JSON = MAIN_PATH + "/responses/operation-error.json";
+    public static final String QUERY_CORONER_GUID_TIMESTAMP = MAIN_PATH + "/queries/guid-timestamp-filter.json";
+    public static final String RESPONSE_GUID_TWO_RESULTS_JSON = MAIN_PATH + "/responses/guid-two-results.json";
 
     public static String readResourceFile(String path) throws IOException {
         byte[] bytes = Files.readAllBytes(Paths.get(path));

--- a/coroner-client/src/test/java/backtraceio/coroner/utils/ResourceUtils.java
+++ b/coroner-client/src/test/java/backtraceio/coroner/utils/ResourceUtils.java
@@ -18,6 +18,10 @@ public class ResourceUtils {
     public static final String RESPONSE_OPERATION_ERROR_JSON = MAIN_PATH + "/responses/operation-error.json";
     public static final String QUERY_CORONER_GUID_TIMESTAMP = MAIN_PATH + "/queries/guid-timestamp-filter.json";
     public static final String RESPONSE_GUID_TWO_RESULTS_JSON = MAIN_PATH + "/responses/guid-two-results.json";
+    public static final String QUERY_CORONER_GUID_MESSAGE_TIMESTAMP =
+            MAIN_PATH + "/queries/guid-message-timestamp-filter.json";
+    public static final String RESPONSE_GUID_MESSAGE_ONE_RESULT_JSON =
+            MAIN_PATH + "/responses/guid-message-one-result.json";
 
     public static String readResourceFile(String path) throws IOException {
         byte[] bytes = Files.readAllBytes(Paths.get(path));

--- a/coroner-client/src/test/resources/backtraceio/coroner/queries/guid-message-timestamp-filter.json
+++ b/coroner-client/src/test/resources/backtraceio/coroner/queries/guid-message-timestamp-filter.json
@@ -1,0 +1,32 @@
+{
+    "filter": [{
+        "error.message": [[
+            "equal",
+            "before-disable-11111111"
+        ]],
+        "guid": [[
+            "equal",
+            "11111111-2222-3333-4444-555555555555"
+        ]],
+        "timestamp": [
+            [
+                "at-least",
+                "1680000000."
+            ],
+            [
+                "at-most",
+                "1680000600."
+            ]
+        ]
+    }],
+    "fold": {
+        "error.type": [["head"]],
+        "error.message": [["head"]],
+        "classifiers": [["head"]],
+        "guid": [["head"]],
+        "callstack": [["head"]]
+    },
+    "offset": 0,
+    "limit": 10,
+    "group": [["_rxid"]]
+}

--- a/coroner-client/src/test/resources/backtraceio/coroner/queries/guid-timestamp-filter.json
+++ b/coroner-client/src/test/resources/backtraceio/coroner/queries/guid-timestamp-filter.json
@@ -1,0 +1,28 @@
+{
+    "filter": [{
+        "guid": [[
+            "equal",
+            "11111111-2222-3333-4444-555555555555"
+        ]],
+        "timestamp": [
+            [
+                "at-least",
+                "1680000000."
+            ],
+            [
+                "at-most",
+                "1680000600."
+            ]
+        ]
+    }],
+    "fold": {
+        "error.type": [["head"]],
+        "error.message": [["head"]],
+        "classifiers": [["head"]],
+        "guid": [["head"]],
+        "callstack": [["head"]]
+    },
+    "offset": 0,
+    "limit": 10,
+    "group": [["_rxid"]]
+}

--- a/coroner-client/src/test/resources/backtraceio/coroner/responses/guid-message-one-result.json
+++ b/coroner-client/src/test/resources/backtraceio/coroner/responses/guid-message-one-result.json
@@ -1,0 +1,74 @@
+{
+    "response": {
+        "columns_desc": [
+            {
+                "op": "head",
+                "name": "error.type",
+                "format": "",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "error.message",
+                "format": "",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "callstack",
+                "format": "callstack",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "guid",
+                "format": "uuid",
+                "type": "uuid"
+            },
+            {
+                "op": "head",
+                "name": "classifiers",
+                "format": "labels",
+                "type": "dictionary"
+            }
+        ],
+        "pagination": {
+            "offset": 0,
+            "limit": 10
+        },
+        "columns": [
+            [
+                "head(error.type)",
+                ""
+            ],
+            [
+                "head(error.message)",
+                ""
+            ],
+            [
+                "head(callstack)",
+                "callstack"
+            ],
+            [
+                "head(guid)",
+                "uuid"
+            ],
+            [
+                "head(classifiers)",
+                "labels"
+            ]
+        ],
+        "values": [[
+            "rxid-before",
+            [
+                ["Crash"],
+                ["before-disable-11111111"],
+                ["{\"frame\":[\"libbacktrace-native.so\"]}"],
+                ["11111111-2222-3333-4444-555555555555"],
+                ["native"]
+            ],
+            1
+        ]]
+    },
+    "error": null
+}

--- a/coroner-client/src/test/resources/backtraceio/coroner/responses/guid-two-results.json
+++ b/coroner-client/src/test/resources/backtraceio/coroner/responses/guid-two-results.json
@@ -1,0 +1,87 @@
+{
+    "response": {
+        "columns_desc": [
+            {
+                "op": "head",
+                "name": "error.type",
+                "format": "",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "error.message",
+                "format": "",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "callstack",
+                "format": "callstack",
+                "type": "dictionary"
+            },
+            {
+                "op": "head",
+                "name": "guid",
+                "format": "uuid",
+                "type": "uuid"
+            },
+            {
+                "op": "head",
+                "name": "classifiers",
+                "format": "labels",
+                "type": "dictionary"
+            }
+        ],
+        "pagination": {
+            "offset": 0,
+            "limit": 10
+        },
+        "columns": [
+            [
+                "head(error.type)",
+                ""
+            ],
+            [
+                "head(error.message)",
+                ""
+            ],
+            [
+                "head(callstack)",
+                "callstack"
+            ],
+            [
+                "head(guid)",
+                "uuid"
+            ],
+            [
+                "head(classifiers)",
+                "labels"
+            ]
+        ],
+        "values": [
+            [
+                "rxid-first",
+                [
+                    ["Crash"],
+                    ["duplicate-report"],
+                    ["{\"frame\":[\"libbacktrace-native.so\"]}"],
+                    ["11111111-2222-3333-4444-555555555555"],
+                    ["native"]
+                ],
+                1
+            ],
+            [
+                "rxid-second",
+                [
+                    ["Crash"],
+                    ["duplicate-report"],
+                    ["{\"frame\":[\"libbacktrace-native.so\"]}"],
+                    ["11111111-2222-3333-4444-555555555555"],
+                    ["native"]
+                ],
+                1
+            ]
+        ]
+    },
+    "error": null
+}

--- a/docs/native-integration-startup.md
+++ b/docs/native-integration-startup.md
@@ -2,13 +2,14 @@
 
 ## Scope
 
-`BacktraceClient.enableNativeIntegration()` installs Crashpad for NDK/JNI crashes. Managed Java
-exception handling and Backtrace ANR monitoring are separate integrations.
+`BacktraceClient.enableNativeIntegration()` installs Crashpad for NDK/JNI crashes and requires a
+writable `BacktraceDatabase`. Managed Java exception handling and Backtrace ANR monitoring operate
+independently of native crash-handler registration.
 
 ## Recommended initialization order
 
 1. Create `BacktraceDatabase` with a writable application-private directory.
-2. Create `BacktraceClient`.
+2. Create `BacktraceClient` with its credentials.
 3. Configure initial attributes, attachments, breadcrumbs, metrics, and the managed exception
    handler.
 4. Call `enableNativeIntegration()` once, as early as practical.
@@ -36,86 +37,106 @@ BacktraceExceptionHandler.enable(client)
 client.enableNativeIntegration()
 ```
 
-## Main-thread behavior
+## Synchronous startup behavior
 
 Native initialization is synchronous because crash coverage begins only after Crashpad is
-installed. Backtrace does not read the base APK or split APK ZIP central directory during this
-call; Android's own linker may still access the installed APK when loading an unextracted native
-library.
-It obtains the exact `libbacktrace-native.so` path from Android's already-loaded module metadata and
-uses path-only application metadata as a fallback.
+installed. `enableNativeIntegration()` preserves its existing `void` API and returns normally when
+an optional native setup failure is contained. Use `tryEnableNativeIntegration()`,
+`tryEnableNativeIntegration(boolean)`, or
+`tryEnableNativeIntegration(boolean, UnwindingMode)` when the application needs to know whether
+registration succeeded.
 
-The resolver performs O(number of split metadata entries) filesystem metadata checks — private and
-public split arrays are scanned before deduplication, and none of the work scales with APK ZIP
-central-directory size — and it does not open or parse APK ZIP contents. The remaining work consists of Crashpad database setup, native
-attribute/attachment transfer, and Crashpad handler registration.
+Backtrace does not read or parse the base APK or split APK ZIP central directory during
+initialization. The SDK obtains the exact `libbacktrace-native.so` path from Android's already-loaded
+module metadata and uses path-only application metadata as a fallback. Android's linker may still
+access an installed APK when it loads an unextracted native library.
+
+Path resolution performs a bounded number of filesystem metadata checks based on the installed
+split entries. Its work does not scale with the number of files in an APK.
 
 ## Background-thread use
 
-Calling `enableNativeIntegration()` from a single application-owned worker thread is supported. Do
+Calling `enableNativeIntegration()` from one application-controlled worker thread is supported. Do
 not invoke it concurrently from multiple threads or race it with `disableNativeIntegration()`.
 
-Asynchronous initialization creates a coverage window: a native fault before initialization
+Background initialization creates a coverage window: a native fault before initialization
 finishes cannot be handled by Backtrace. Managed exceptions remain independently covered when
 `BacktraceExceptionHandler.enable(client)` has already been registered.
 
-## Split APK and AAB installs
+## Split APK and Android App Bundle installs
 
-Resolution order is:
+Crash-handler library resolution uses this order:
 
-1. Exact filesystem or APK-backed path reported by Android's native linker.
-2. Extracted `nativeLibraryDir/libbacktrace-native.so`, when present.
-3. An ABI split identified by `splitSourceDirs`, `splitPublicSourceDirs`, and `splitNames`.
-4. The historical base-APK path shape as a compatibility fallback.
+1. The exact filesystem or APK-backed path reported by Android's native linker.
+2. An existing extracted `nativeLibraryDir/libbacktrace-native.so`.
+3. An ABI split identified by installed split metadata.
+4. The base-APK path shape as a compatibility fallback.
 
-The linker-reported path is authoritative and is validated structurally — it is accepted whenever it
-names `lib/<abi>/libbacktrace-native.so` inside an existing container, and is deliberately *not*
-compared against an ABI inferred in Java. Android has already resolved which module the process
-loaded, so rejecting it on an ABI guess would break 32-bit processes on 64-bit devices and
-native-bridge translation.
+The linker-reported path is authoritative and is not compared against an ABI inferred in Java.
+Android has already selected the module loaded by the current process, so this behavior supports
+32-bit processes on 64-bit devices and native-bridge translation.
 
-An inferred ABI is used only to construct steps 3 and 4 — the linker path and an existing extracted
-library are both directly loadable without ABI inference, so the handler initializes from either
-even when process ABI metadata is malformed or unavailable. That inferred value comes from `Build.CPU_ABI`, which
-Android adjusts for the current process bitness, rather than `Build.SUPPORTED_ABIS[0]`, which
-describes the device. On API 23 and later the defensive fallback for an empty `CPU_ABI` preserves
-process bitness via `Process.is64Bit()`; API 21-22 can only fall back to the device-ordered list.
+ABI inference is used only to construct split and base-APK fallback paths. It prefers
+`Build.CPU_ABI`, which Android adjusts for the current process. On API 23 and later, an empty or
+malformed primary ABI falls back according to the process bitness reported by `Process.is64Bit()`.
+API 21 and 22 use the device-ordered ABI list when the primary value is unavailable.
 
-No fallback opens an APK. Split candidates from `splitSourceDirs` and `splitPublicSourceDirs` are
-compared globally: selection prefers an exact `config.<abi>` split name, then an exact
-`split_config.<abi>.apk` filename. A low-confidence filename token match is accepted only when
-split-name metadata is globally unavailable (pre-API-26 installs) and the match is unique; two
-equal-confidence candidates fall back to the base APK instead of being guessed by array order. ABI
-matching treats `x86` and `x86_64` as distinct tokens and ignores language and density splits.
+No fallback opens an APK. Split matching keeps `x86` and `x86_64` distinct and does not select an
+ambiguous split candidate.
 
 ## Failure behavior
 
-- Crash-handler registration is optional and failure-contained. The packaged Backtrace native
-  library is currently loaded when `BacktraceBase` is initialized.
-- `BacktraceClient.enableNativeIntegration()` returns normally and logs a contained failure; use
-  `tryEnableNativeIntegration()` to observe the result, or
-  `BacktraceDatabase.setupNativeIntegration()`, which returns `false`. Managed crash reporting
-  stays operational either way.
-- `dumpWithoutCrash()` is a safe no-op while native integration is uninitialized or disabled.
-- The known-unsupported `x86` native backend remains skipped.
-- An ABI that cannot be determined is not treated as known-unsupported, because a valid
-  linker-reported path and an extracted library do not require ABI inference.
-- In the crash-handler process, a library-load failure exits nonzero with a logged cause instead of
-  appearing successful; that exit status is diagnostic and is not currently consumed by Crashpad.
+- Native crash-handler registration is optional. A contained registration failure leaves managed
+  crash reporting operational.
+- `enableNativeIntegration()` returns normally after a contained failure. Use
+  `tryEnableNativeIntegration()` to observe the registration result.
+- `BacktraceDatabase.setupNativeIntegration()` returns `false` when native registration does not
+  succeed.
+- `dumpWithoutCrash()` is a safe no-op while native integration is unavailable or disabled.
+- A crash-handler process that cannot load or invoke the handler exits with a nonzero status.
 
-## Validation
+## Retry and process lifecycle
 
-For release qualification, verify:
+Native handler initialization is process-scoped. Applications should configure native attributes,
+attachments, breadcrumbs, and credentials before initialization and make at most one initial
+registration attempt per process.
 
-- monolithic APK with extracted native libraries;
-- AAB/Google Play install with compressed native libraries in an ABI split, including the
-  crash-handler process loading the split-backed path and a correlated report reaching Backtrace;
-- cold-start main-thread trace contains no `ZipFile$Source.initCEN` under Backtrace initialization;
-- native crash generated immediately after initialization is uploaded and symbolicated;
-- API 21-22 devices (class loading, resolver construction, environment construction);
-- a real 32-bit process on a 64-bit-capable device;
-- Android 15/16 devices using 16 KB pages;
-- all supported ABIs other than the intentionally unsupported `x86` native crash backend.
+A Java-side validation or preparation failure is contained and returns `false` from
+`tryEnableNativeIntegration()`. A native initialization attempt is protected by a process-global
+once-only initialization boundary, so applications should not repeatedly retry native
+initialization in a loop. Continue using managed reporting and correct the configuration before the
+next application process start.
 
-These qualification gates are independent of the source-level fix: the resolver performs bounded
-filesystem metadata checks and no host APK ZIP central-directory parsing.
+After a successful initial registration, `disableNativeIntegration()` disables native uploads for
+the current process. A later enable call restarts the Crashpad upload thread.
+
+## Compatibility and limitations
+
+- Android API 21 is the minimum supported API level.
+- Monolithic APK and Android App Bundle/split APK installations are supported.
+- The native-linker path is authoritative when available.
+- An existing extracted native library can be used without ABI inference.
+- The `x86` native crash backend is unsupported.
+- `x86_64`, `armeabi-v7a`, and `arm64-v8a` native crash backends are supported.
+- Managed exception reporting and ANR monitoring remain available independently of native
+  crash-handler registration.
+- `arm64-v8a` and `x86_64` support flexible 16 KB page sizes.
+
+## Native integration diagnostic codes
+
+Optional native failures omit exception messages and stack traces because they may contain
+credentials, application-provided data, or filesystem paths. Log entries use a stable diagnostic
+code and, where an exception was caught, its class name.
+
+| Code | Meaning |
+| --- | --- |
+| `BT_NATIVE_PREPARE_FAILURE` | Native configuration or environment preparation failed. |
+| `BT_NATIVE_BRIDGE_FAILURE` | The JNI/native initialization bridge failed. |
+| `BT_NATIVE_BREADCRUMB_HOOK_FAILURE` | The breadcrumb synchronization hook could not be installed. Native integration remains enabled. |
+| `BT_NATIVE_DISABLE_FAILURE` | The native disable bridge failed. Java-side enabled state is still cleared. |
+| `BT_NATIVE_DUMP_UNAVAILABLE` | A dump was requested while native integration was unavailable. |
+| `BT_HANDLER_ENV_UNAVAILABLE` | The crash-handler process environment was unavailable. |
+| `BT_HANDLER_PATH_UNAVAILABLE` | The crash-handler native-library path was unavailable. |
+| `BT_HANDLER_LOAD_FAILURE` | The crash-handler native library could not be loaded. |
+| `BT_HANDLER_DISPATCH_FAILURE` | Dispatch to the native crash handler failed. |
+| `BT_HANDLER_RETURNED_FAILURE` | The native crash handler returned a failure result. |

--- a/example-app/build.gradle
+++ b/example-app/build.gradle
@@ -11,9 +11,29 @@ android {
         versionName "1.0"
         testInstrumentationRunner 'androidx.test.runner.AndroidJUnitRunner'
         ndk {
-            abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+            // -PqualificationAbi=<abi> builds a single-ABI qualification app for the hardware
+            // release gate (for example a 32-bit-only install on a 64-bit device). The library's
+            // published ABI set is unaffected.
+            def qualificationAbi = project.findProperty("qualificationAbi")
+            if (qualificationAbi) {
+                abiFilters qualificationAbi.toString()
+            } else {
+                abiFilters 'x86', 'x86_64', 'armeabi-v7a', 'arm64-v8a'
+            }
         }
     }
+    // Debug-only startup-qualification fixture: -PnativeStartupFixtureAssets=<dir> adds a
+    // generated large-entry-count asset directory (never committed) to the debug APK so a trace
+    // can prove initialization cost does not scale with ZIP central-directory size.
+    def nativeStartupFixtureAssets = project.findProperty("nativeStartupFixtureAssets")
+    if (nativeStartupFixtureAssets) {
+        sourceSets {
+            debug {
+                assets.srcDirs += nativeStartupFixtureAssets.toString()
+            }
+        }
+    }
+
     buildTypes {
         release {
             minifyEnabled false

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertions.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertions.java
@@ -9,6 +9,7 @@ import backtraceio.coroner.query.CoronerQueryFields;
 import backtraceio.coroner.response.CoronerResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -17,35 +18,40 @@ import java.util.Set;
  * GUID-correlated ingestion assertions for native qualification. GUID is the primary correlation
  * key (fatal reports carry no controllable {@code error.message}); the query limit exceeds every
  * expected count, so duplicate reports are detectable — with the historical limit of one they were
- * not. The count policy is injectable so a sabotage test can prove the exactly-N assertion rejects
- * duplicates.
+ * not. The count policy sums group row counts because Coroner can collapse an {@code _rxid}-grouped
+ * query into a single {@code "*"} group whose row count carries the real match total. A collapsed
+ * group exposes only one head value per fold, so it can never prove an expected message set: when
+ * specific messages must be proven, callers use {@link #awaitExactlyOneWithMessage}, which filters
+ * on the message itself. The report source is injectable so sabotage tests can prove every policy
+ * rejects its failure case.
  */
 final class CoronerNativeReportAssertions {
 
+    static final String CRASH_ERROR_TYPE = "Crash";
     static final long POLL_DEADLINE_MS = 90_000;
     static final long POLL_INTERVAL_MS = 2_000;
     static final long STABILITY_WINDOW_MS = 10_000;
     static final int QUERY_LIMIT = 10;
 
     /**
-     * Immutable test-only view of one result group. Coroner can collapse an {@code _rxid}-grouped
-     * query into a single {@code "*"} group whose row count carries the real match total, so the
-     * count policy sums {@code rowCount} instead of counting groups.
+     * Immutable test-only view of one result group. {@code groupId} is the RXID when the backend
+     * returns per-report groups and the literal {@code "*"} when it collapses the grouping;
+     * {@code rowCount} is the number of underlying reports folded into the group.
      */
     static final class NativeReport {
         final String guid;
-        final String rxid;
+        final String groupId;
         final String errorType;
         final String errorMessage;
         final int rowCount;
 
-        NativeReport(String guid, String rxid, String errorType, String errorMessage) {
-            this(guid, rxid, errorType, errorMessage, 1);
+        NativeReport(String guid, String groupId, String errorType, String errorMessage) {
+            this(guid, groupId, errorType, errorMessage, 1);
         }
 
-        NativeReport(String guid, String rxid, String errorType, String errorMessage, int rowCount) {
+        NativeReport(String guid, String groupId, String errorType, String errorMessage, int rowCount) {
             this.guid = guid;
-            this.rxid = rxid;
+            this.groupId = groupId;
             this.errorType = errorType;
             this.errorMessage = errorMessage;
             this.rowCount = rowCount;
@@ -58,25 +64,36 @@ final class CoronerNativeReportAssertions {
     }
 
     static ReportSource coronerSource(final CoronerClient client) {
-        return (guid, timestampStartSeconds) -> {
-            CoronerResponse response = client.guidTimestampFilter(
-                    guid,
-                    Long.toString(timestampStartSeconds),
-                    Long.toString(System.currentTimeMillis() / 1000L),
-                    Arrays.asList(CoronerQueryFields.ERROR_TYPE, CoronerQueryFields.ERROR_MESSAGE),
-                    QUERY_LIMIT);
+        return (guid, timestampStartSeconds) -> toReports(client.guidTimestampFilter(
+                guid,
+                Long.toString(timestampStartSeconds),
+                Long.toString(System.currentTimeMillis() / 1000L),
+                Arrays.asList(CoronerQueryFields.ERROR_TYPE, CoronerQueryFields.ERROR_MESSAGE),
+                QUERY_LIMIT));
+    }
 
-            List<NativeReport> reports = new ArrayList<>();
-            for (int index = 0; index < response.getResultsNumber(); index++) {
-                reports.add(new NativeReport(
-                        response.getAttribute(index, CoronerQueryFields.GUID, String.class),
-                        response.values.get(index).getGroupIdentifier(),
-                        response.getAttribute(index, CoronerQueryFields.ERROR_TYPE, String.class),
-                        response.getAttribute(index, CoronerQueryFields.ERROR_MESSAGE, String.class),
-                        response.values.get(index).getGroupRowCount()));
-            }
-            return reports;
-        };
+    /** Source filtered on an exact {@code error.message}, immune to collapsed grouping. */
+    static ReportSource coronerMessageSource(final CoronerClient client, final String message) {
+        return (guid, timestampStartSeconds) -> toReports(client.guidMessageTimestampFilter(
+                guid,
+                message,
+                Long.toString(timestampStartSeconds),
+                Long.toString(System.currentTimeMillis() / 1000L),
+                Arrays.asList(CoronerQueryFields.ERROR_TYPE, CoronerQueryFields.ERROR_MESSAGE),
+                QUERY_LIMIT));
+    }
+
+    private static List<NativeReport> toReports(CoronerResponse response) throws Exception {
+        List<NativeReport> reports = new ArrayList<>();
+        for (int index = 0; index < response.getResultsNumber(); index++) {
+            reports.add(new NativeReport(
+                    response.getAttribute(index, CoronerQueryFields.GUID, String.class),
+                    response.values.get(index).getGroupIdentifier(),
+                    response.getAttribute(index, CoronerQueryFields.ERROR_TYPE, String.class),
+                    response.getAttribute(index, CoronerQueryFields.ERROR_MESSAGE, String.class),
+                    response.values.get(index).getGroupRowCount()));
+        }
+        return reports;
     }
 
     static List<NativeReport> awaitExactly(
@@ -84,8 +101,10 @@ final class CoronerNativeReportAssertions {
             String guid,
             long timestampStartSeconds,
             int expectedCount,
-            Set<String> expectedMessages) {
-        return awaitExactly(coronerSource(client), guid, timestampStartSeconds, expectedCount, expectedMessages);
+            Set<String> expectedMessages,
+            String expectedErrorType) {
+        return awaitExactly(
+                coronerSource(client), guid, timestampStartSeconds, expectedCount, expectedMessages, expectedErrorType);
     }
 
     static List<NativeReport> awaitExactly(
@@ -93,13 +112,15 @@ final class CoronerNativeReportAssertions {
             String guid,
             long timestampStartSeconds,
             int expectedCount,
-            Set<String> expectedMessages) {
+            Set<String> expectedMessages,
+            String expectedErrorType) {
         return awaitExactly(
                 source,
                 guid,
                 timestampStartSeconds,
                 expectedCount,
                 expectedMessages,
+                expectedErrorType,
                 POLL_DEADLINE_MS,
                 POLL_INTERVAL_MS,
                 STABILITY_WINDOW_MS);
@@ -112,6 +133,7 @@ final class CoronerNativeReportAssertions {
             long timestampStartSeconds,
             int expectedCount,
             Set<String> expectedMessages,
+            String expectedErrorType,
             long deadlineMs,
             long intervalMs,
             long stabilityMs) {
@@ -124,7 +146,7 @@ final class CoronerNativeReportAssertions {
 
                 if (totalRowCount(reports) == expectedCount) {
                     // Duplicate-stability window: a delayed duplicate arriving right after the
-                    // expected count must fail, and the RXID set must not change.
+                    // expected count must fail, and the group-identifier set must not change.
                     SystemClock.sleep(stabilityMs);
                     List<NativeReport> stableReports = source.fetch(guid, timestampStartSeconds);
                     validate(stableReports, guid, expectedCount);
@@ -133,24 +155,29 @@ final class CoronerNativeReportAssertions {
                                 + totalRowCount(stableReports));
                     }
                     assertEquals(
-                            "RXID set changed during the stability window", rxidSet(reports), rxidSet(stableReports));
+                            "Group-identifier set changed during the stability window",
+                            groupIdSet(reports),
+                            groupIdSet(stableReports));
+                    if (expectedErrorType != null) {
+                        for (NativeReport report : stableReports) {
+                            if (!expectedErrorType.equals(report.errorType)) {
+                                fail("Report must classify as " + expectedErrorType + ", found " + report.errorType);
+                            }
+                        }
+                    }
                     if (expectedMessages != null) {
+                        if (totalRowCount(stableReports) != stableReports.size()) {
+                            // A collapsed group exposes one head message for many rows; it can
+                            // never prove the full expected set, so relaxing here would let a
+                            // duplicate of one message pass for a missing other message.
+                            fail("Collapsed grouping cannot prove the expected message set; "
+                                    + "use per-message queries for guid " + guid);
+                        }
                         Set<String> messages = new HashSet<>();
                         for (NativeReport report : stableReports) {
                             messages.add(report.errorMessage);
                         }
-                        if (totalRowCount(stableReports) == stableReports.size()) {
-                            // Per-report identity available: require the exact message set.
-                            assertEquals("Unexpected report messages", expectedMessages, messages);
-                        } else {
-                            // Collapsed grouping exposes one head value per group; every observed
-                            // message must still be expected (the count assertion stays exact).
-                            for (String message : messages) {
-                                if (!expectedMessages.contains(message)) {
-                                    fail("Unexpected report message: " + message);
-                                }
-                            }
-                        }
+                        assertEquals("Unexpected report messages", expectedMessages, messages);
                     }
                     return stableReports;
                 }
@@ -169,6 +196,45 @@ final class CoronerNativeReportAssertions {
         return null;
     }
 
+    /**
+     * Proves one specific {@code error.message} was ingested exactly once for this GUID, through a
+     * message-filtered query: correct even when GUID-wide grouping collapses. The report must
+     * classify as {@code Crash}.
+     */
+    static NativeReport awaitExactlyOneWithMessage(
+            CoronerClient client, String guid, String message, long timestampStartSeconds) {
+        return awaitExactlyOneWithMessage(
+                coronerMessageSource(client, message),
+                guid,
+                message,
+                timestampStartSeconds,
+                POLL_DEADLINE_MS,
+                POLL_INTERVAL_MS,
+                STABILITY_WINDOW_MS);
+    }
+
+    /** Timing-injectable variant; {@code source} must already filter on the message. */
+    static NativeReport awaitExactlyOneWithMessage(
+            ReportSource source,
+            String guid,
+            String message,
+            long timestampStartSeconds,
+            long deadlineMs,
+            long intervalMs,
+            long stabilityMs) {
+        List<NativeReport> reports = awaitExactly(
+                source,
+                guid,
+                timestampStartSeconds,
+                1,
+                Collections.singleton(message),
+                CRASH_ERROR_TYPE,
+                deadlineMs,
+                intervalMs,
+                stabilityMs);
+        return reports.get(0);
+    }
+
     static NativeReport awaitExactlyOneFatal(ReportSource source, String guid, long timestampStartSeconds) {
         return awaitExactlyOneFatal(
                 source, guid, timestampStartSeconds, POLL_DEADLINE_MS, POLL_INTERVAL_MS, STABILITY_WINDOW_MS);
@@ -182,11 +248,9 @@ final class CoronerNativeReportAssertions {
             long deadlineMs,
             long intervalMs,
             long stabilityMs) {
-        List<NativeReport> reports =
-                awaitExactly(source, guid, timestampStartSeconds, 1, null, deadlineMs, intervalMs, stabilityMs);
-        NativeReport report = reports.get(0);
-        assertEquals("Fatal report must classify as Crash", "Crash", report.errorType);
-        return report;
+        List<NativeReport> reports = awaitExactly(
+                source, guid, timestampStartSeconds, 1, null, CRASH_ERROR_TYPE, deadlineMs, intervalMs, stabilityMs);
+        return reports.get(0);
     }
 
     static NativeReport awaitExactlyOneFatal(CoronerClient client, String guid, long timestampStartSeconds) {
@@ -205,7 +269,7 @@ final class CoronerNativeReportAssertions {
     }
 
     /** Reports are groups; Coroner may fold many rows into one group, so sum the row counts. */
-    private static int totalRowCount(List<NativeReport> reports) {
+    static int totalRowCount(List<NativeReport> reports) {
         int total = 0;
         for (NativeReport report : reports) {
             total += report.rowCount;
@@ -213,12 +277,12 @@ final class CoronerNativeReportAssertions {
         return total;
     }
 
-    private static Set<String> rxidSet(List<NativeReport> reports) {
-        Set<String> rxids = new HashSet<>();
+    private static Set<String> groupIdSet(List<NativeReport> reports) {
+        Set<String> groupIds = new HashSet<>();
         for (NativeReport report : reports) {
-            rxids.add(report.rxid);
+            groupIds.add(report.groupId);
         }
-        return rxids;
+        return groupIds;
     }
 
     private CoronerNativeReportAssertions() {}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertions.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertions.java
@@ -1,0 +1,225 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import android.os.SystemClock;
+import backtraceio.coroner.CoronerClient;
+import backtraceio.coroner.query.CoronerQueryFields;
+import backtraceio.coroner.response.CoronerResponse;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * GUID-correlated ingestion assertions for native qualification. GUID is the primary correlation
+ * key (fatal reports carry no controllable {@code error.message}); the query limit exceeds every
+ * expected count, so duplicate reports are detectable — with the historical limit of one they were
+ * not. The count policy is injectable so a sabotage test can prove the exactly-N assertion rejects
+ * duplicates.
+ */
+final class CoronerNativeReportAssertions {
+
+    static final long POLL_DEADLINE_MS = 90_000;
+    static final long POLL_INTERVAL_MS = 2_000;
+    static final long STABILITY_WINDOW_MS = 10_000;
+    static final int QUERY_LIMIT = 10;
+
+    /**
+     * Immutable test-only view of one result group. Coroner can collapse an {@code _rxid}-grouped
+     * query into a single {@code "*"} group whose row count carries the real match total, so the
+     * count policy sums {@code rowCount} instead of counting groups.
+     */
+    static final class NativeReport {
+        final String guid;
+        final String rxid;
+        final String errorType;
+        final String errorMessage;
+        final int rowCount;
+
+        NativeReport(String guid, String rxid, String errorType, String errorMessage) {
+            this(guid, rxid, errorType, errorMessage, 1);
+        }
+
+        NativeReport(String guid, String rxid, String errorType, String errorMessage, int rowCount) {
+            this.guid = guid;
+            this.rxid = rxid;
+            this.errorType = errorType;
+            this.errorMessage = errorMessage;
+            this.rowCount = rowCount;
+        }
+    }
+
+    /** Injectable report source; production queries Coroner, sabotage tests inject fakes. */
+    interface ReportSource {
+        List<NativeReport> fetch(String guid, long timestampStartSeconds) throws Exception;
+    }
+
+    static ReportSource coronerSource(final CoronerClient client) {
+        return (guid, timestampStartSeconds) -> {
+            CoronerResponse response = client.guidTimestampFilter(
+                    guid,
+                    Long.toString(timestampStartSeconds),
+                    Long.toString(System.currentTimeMillis() / 1000L),
+                    Arrays.asList(CoronerQueryFields.ERROR_TYPE, CoronerQueryFields.ERROR_MESSAGE),
+                    QUERY_LIMIT);
+
+            List<NativeReport> reports = new ArrayList<>();
+            for (int index = 0; index < response.getResultsNumber(); index++) {
+                reports.add(new NativeReport(
+                        response.getAttribute(index, CoronerQueryFields.GUID, String.class),
+                        response.values.get(index).getGroupIdentifier(),
+                        response.getAttribute(index, CoronerQueryFields.ERROR_TYPE, String.class),
+                        response.getAttribute(index, CoronerQueryFields.ERROR_MESSAGE, String.class),
+                        response.values.get(index).getGroupRowCount()));
+            }
+            return reports;
+        };
+    }
+
+    static List<NativeReport> awaitExactly(
+            CoronerClient client,
+            String guid,
+            long timestampStartSeconds,
+            int expectedCount,
+            Set<String> expectedMessages) {
+        return awaitExactly(coronerSource(client), guid, timestampStartSeconds, expectedCount, expectedMessages);
+    }
+
+    static List<NativeReport> awaitExactly(
+            ReportSource source,
+            String guid,
+            long timestampStartSeconds,
+            int expectedCount,
+            Set<String> expectedMessages) {
+        return awaitExactly(
+                source,
+                guid,
+                timestampStartSeconds,
+                expectedCount,
+                expectedMessages,
+                POLL_DEADLINE_MS,
+                POLL_INTERVAL_MS,
+                STABILITY_WINDOW_MS);
+    }
+
+    /** Timing-injectable variant so sabotage tests run in milliseconds, not the CI deadlines. */
+    static List<NativeReport> awaitExactly(
+            ReportSource source,
+            String guid,
+            long timestampStartSeconds,
+            int expectedCount,
+            Set<String> expectedMessages,
+            long deadlineMs,
+            long intervalMs,
+            long stabilityMs) {
+        long deadline = SystemClock.elapsedRealtime() + deadlineMs;
+        Exception lastPollFailure = null;
+        while (SystemClock.elapsedRealtime() < deadline) {
+            try {
+                List<NativeReport> reports = source.fetch(guid, timestampStartSeconds);
+                validate(reports, guid, expectedCount);
+
+                if (totalRowCount(reports) == expectedCount) {
+                    // Duplicate-stability window: a delayed duplicate arriving right after the
+                    // expected count must fail, and the RXID set must not change.
+                    SystemClock.sleep(stabilityMs);
+                    List<NativeReport> stableReports = source.fetch(guid, timestampStartSeconds);
+                    validate(stableReports, guid, expectedCount);
+                    if (totalRowCount(stableReports) != expectedCount) {
+                        fail("Report count changed during the stability window: expected " + expectedCount + ", found "
+                                + totalRowCount(stableReports));
+                    }
+                    assertEquals(
+                            "RXID set changed during the stability window", rxidSet(reports), rxidSet(stableReports));
+                    if (expectedMessages != null) {
+                        Set<String> messages = new HashSet<>();
+                        for (NativeReport report : stableReports) {
+                            messages.add(report.errorMessage);
+                        }
+                        if (totalRowCount(stableReports) == stableReports.size()) {
+                            // Per-report identity available: require the exact message set.
+                            assertEquals("Unexpected report messages", expectedMessages, messages);
+                        } else {
+                            // Collapsed grouping exposes one head value per group; every observed
+                            // message must still be expected (the count assertion stays exact).
+                            for (String message : messages) {
+                                if (!expectedMessages.contains(message)) {
+                                    fail("Unexpected report message: " + message);
+                                }
+                            }
+                        }
+                    }
+                    return stableReports;
+                }
+                lastPollFailure = null;
+            } catch (AssertionError hardFailure) {
+                throw hardFailure;
+            } catch (Exception pollFailure) {
+                lastPollFailure = pollFailure;
+            }
+            SystemClock.sleep(intervalMs);
+        }
+        fail("Expected " + expectedCount + " report(s) for guid " + guid + " before the deadline"
+                + (lastPollFailure == null
+                        ? ""
+                        : "; last poll failure: " + lastPollFailure.getClass().getName()));
+        return null;
+    }
+
+    static NativeReport awaitExactlyOneFatal(ReportSource source, String guid, long timestampStartSeconds) {
+        return awaitExactlyOneFatal(
+                source, guid, timestampStartSeconds, POLL_DEADLINE_MS, POLL_INTERVAL_MS, STABILITY_WINDOW_MS);
+    }
+
+    /** Timing-injectable variant so sabotage tests avoid the production stability window. */
+    static NativeReport awaitExactlyOneFatal(
+            ReportSource source,
+            String guid,
+            long timestampStartSeconds,
+            long deadlineMs,
+            long intervalMs,
+            long stabilityMs) {
+        List<NativeReport> reports =
+                awaitExactly(source, guid, timestampStartSeconds, 1, null, deadlineMs, intervalMs, stabilityMs);
+        NativeReport report = reports.get(0);
+        assertEquals("Fatal report must classify as Crash", "Crash", report.errorType);
+        return report;
+    }
+
+    static NativeReport awaitExactlyOneFatal(CoronerClient client, String guid, long timestampStartSeconds) {
+        return awaitExactlyOneFatal(coronerSource(client), guid, timestampStartSeconds);
+    }
+
+    private static void validate(List<NativeReport> reports, String guid, int expectedCount) {
+        for (NativeReport report : reports) {
+            if (!guid.equals(report.guid)) {
+                fail("Report guid mismatch: expected " + guid + ", found " + report.guid);
+            }
+        }
+        if (totalRowCount(reports) > expectedCount) {
+            fail("Duplicate reports detected: expected " + expectedCount + ", found " + totalRowCount(reports));
+        }
+    }
+
+    /** Reports are groups; Coroner may fold many rows into one group, so sum the row counts. */
+    private static int totalRowCount(List<NativeReport> reports) {
+        int total = 0;
+        for (NativeReport report : reports) {
+            total += report.rowCount;
+        }
+        return total;
+    }
+
+    private static Set<String> rxidSet(List<NativeReport> reports) {
+        Set<String> rxids = new HashSet<>();
+        for (NativeReport report : reports) {
+            rxids.add(report.rxid);
+        }
+        return rxids;
+    }
+
+    private CoronerNativeReportAssertions() {}
+}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertionsTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertionsTest.java
@@ -1,0 +1,126 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import backtraceio.backtraceio.CoronerNativeReportAssertions.NativeReport;
+import backtraceio.backtraceio.CoronerNativeReportAssertions.ReportSource;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Sabotage coverage for the exactly-N ingestion policy: the same count policy the split-install
+ * tests use must reject duplicates and instability. With the historical query limit of one this
+ * class of defect was undetectable, because a response could never contain two reports.
+ */
+@RunWith(AndroidJUnit4.class)
+public class CoronerNativeReportAssertionsTest {
+
+    private static final String GUID = "11111111-2222-3333-4444-555555555555";
+    private static final long FAST = 50;
+
+    private static NativeReport report(String rxid, String message) {
+        return new NativeReport(GUID, rxid, "Crash", message);
+    }
+
+    private static List<NativeReport> awaitFast(ReportSource source, int expected, HashSet<String> messages) {
+        return CoronerNativeReportAssertions.awaitExactly(source, GUID, 0, expected, messages, 2_000, FAST, FAST);
+    }
+
+    @Test
+    public void twoReportsFailAnExpectedOneAssertion() {
+        ReportSource duplicates = (guid, ts) -> Arrays.asList(report("rxid-a", "dump"), report("rxid-b", "dump"));
+
+        assertThrows(AssertionError.class, () -> awaitFast(duplicates, 1, null));
+    }
+
+    @Test
+    public void transientFailureThenSuccessPasses() {
+        AtomicInteger calls = new AtomicInteger();
+        ReportSource flaky = (guid, ts) -> {
+            if (calls.incrementAndGet() == 1) {
+                throw new IOException("transient");
+            }
+            return Arrays.asList(report("rxid-a", "dump"));
+        };
+
+        List<NativeReport> reports = awaitFast(flaky, 1, new HashSet<>(Arrays.asList("dump")));
+        assertEquals(1, reports.size());
+        assertEquals("rxid-a", reports.get(0).rxid);
+    }
+
+    @Test
+    public void duplicateArrivingDuringStabilityWindowFails() {
+        AtomicInteger calls = new AtomicInteger();
+        ReportSource lateDuplicate = (guid, ts) -> calls.incrementAndGet() == 1
+                ? Arrays.asList(report("rxid-a", "dump"))
+                : Arrays.asList(report("rxid-a", "dump"), report("rxid-b", "dump"));
+
+        assertThrows(AssertionError.class, () -> awaitFast(lateDuplicate, 1, null));
+    }
+
+    @Test
+    public void stableSingleReportPasses() {
+        ReportSource stable = (guid, ts) -> Arrays.asList(report("rxid-a", "dump"));
+
+        List<NativeReport> reports = awaitFast(stable, 1, null);
+        assertEquals(1, reports.size());
+    }
+
+    @Test
+    public void twoDistinctLifecycleMessagesPass() {
+        ReportSource lifecycle =
+                (guid, ts) -> Arrays.asList(report("rxid-a", "before-disable"), report("rxid-b", "after-reenable"));
+
+        List<NativeReport> reports =
+                awaitFast(lifecycle, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")));
+        assertEquals(2, reports.size());
+    }
+
+    @Test
+    public void wrongGuidFails() {
+        ReportSource wrongGuid = (guid, ts) ->
+                Arrays.asList(new NativeReport("99999999-0000-0000-0000-000000000000", "rxid-a", "Crash", "dump"));
+
+        assertThrows(AssertionError.class, () -> awaitFast(wrongGuid, 1, null));
+    }
+
+    @Test
+    public void wrongErrorTypeFailsTheFatalAssertion() {
+        ReportSource managedOnly =
+                (guid, ts) -> new ArrayList<>(Arrays.asList(new NativeReport(GUID, "rxid-a", "Managed", "dump")));
+
+        assertThrows(
+                AssertionError.class,
+                () -> CoronerNativeReportAssertions.awaitExactlyOneFatal(
+                        (guid, ts) -> managedOnly.fetch(guid, ts), GUID, 0, 2_000, FAST, FAST));
+    }
+
+    /**
+     * Coroner can fold every matching row into one "*" group whose count carries the real total;
+     * the policy must sum row counts, or duplicates hidden inside a collapsed group pass as one.
+     */
+    @Test
+    public void collapsedGroupWithTwoRowsFailsAnExpectedOneAssertion() {
+        ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "dump", 2));
+
+        assertThrows(AssertionError.class, () -> awaitFast(collapsed, 1, null));
+    }
+
+    @Test
+    public void collapsedGroupWithTwoRowsSatisfiesAnExpectedTwoAssertion() {
+        ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "before-disable", 2));
+
+        List<NativeReport> reports =
+                awaitFast(collapsed, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")));
+        assertEquals(1, reports.size());
+        assertEquals(2, reports.get(0).rowCount);
+    }
+}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertionsTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/CoronerNativeReportAssertionsTest.java
@@ -16,9 +16,11 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
- * Sabotage coverage for the exactly-N ingestion policy: the same count policy the split-install
- * tests use must reject duplicates and instability. With the historical query limit of one this
- * class of defect was undetectable, because a response could never contain two reports.
+ * Sabotage coverage for the exactly-N ingestion policy: the same count, message, and error-type
+ * policies the split-install tests use must reject duplicates, instability, collapsed groups that
+ * cannot prove a message set, and misclassified reports. With the historical query limit of one
+ * this class of defect was undetectable, because a response could never contain two reports. This
+ * suite needs no credentials and runs in the secretless lanes.
  */
 @RunWith(AndroidJUnit4.class)
 public class CoronerNativeReportAssertionsTest {
@@ -26,19 +28,21 @@ public class CoronerNativeReportAssertionsTest {
     private static final String GUID = "11111111-2222-3333-4444-555555555555";
     private static final long FAST = 50;
 
-    private static NativeReport report(String rxid, String message) {
-        return new NativeReport(GUID, rxid, "Crash", message);
+    private static NativeReport report(String groupId, String message) {
+        return new NativeReport(GUID, groupId, "Crash", message);
     }
 
-    private static List<NativeReport> awaitFast(ReportSource source, int expected, HashSet<String> messages) {
-        return CoronerNativeReportAssertions.awaitExactly(source, GUID, 0, expected, messages, 2_000, FAST, FAST);
+    private static List<NativeReport> awaitFast(
+            ReportSource source, int expected, HashSet<String> messages, String errorType) {
+        return CoronerNativeReportAssertions.awaitExactly(
+                source, GUID, 0, expected, messages, errorType, 2_000, FAST, FAST);
     }
 
     @Test
     public void twoReportsFailAnExpectedOneAssertion() {
         ReportSource duplicates = (guid, ts) -> Arrays.asList(report("rxid-a", "dump"), report("rxid-b", "dump"));
 
-        assertThrows(AssertionError.class, () -> awaitFast(duplicates, 1, null));
+        assertThrows(AssertionError.class, () -> awaitFast(duplicates, 1, null, null));
     }
 
     @Test
@@ -51,9 +55,9 @@ public class CoronerNativeReportAssertionsTest {
             return Arrays.asList(report("rxid-a", "dump"));
         };
 
-        List<NativeReport> reports = awaitFast(flaky, 1, new HashSet<>(Arrays.asList("dump")));
+        List<NativeReport> reports = awaitFast(flaky, 1, new HashSet<>(Arrays.asList("dump")), "Crash");
         assertEquals(1, reports.size());
-        assertEquals("rxid-a", reports.get(0).rxid);
+        assertEquals("rxid-a", reports.get(0).groupId);
     }
 
     @Test
@@ -63,14 +67,14 @@ public class CoronerNativeReportAssertionsTest {
                 ? Arrays.asList(report("rxid-a", "dump"))
                 : Arrays.asList(report("rxid-a", "dump"), report("rxid-b", "dump"));
 
-        assertThrows(AssertionError.class, () -> awaitFast(lateDuplicate, 1, null));
+        assertThrows(AssertionError.class, () -> awaitFast(lateDuplicate, 1, null, null));
     }
 
     @Test
     public void stableSingleReportPasses() {
         ReportSource stable = (guid, ts) -> Arrays.asList(report("rxid-a", "dump"));
 
-        List<NativeReport> reports = awaitFast(stable, 1, null);
+        List<NativeReport> reports = awaitFast(stable, 1, null, null);
         assertEquals(1, reports.size());
     }
 
@@ -80,7 +84,7 @@ public class CoronerNativeReportAssertionsTest {
                 (guid, ts) -> Arrays.asList(report("rxid-a", "before-disable"), report("rxid-b", "after-reenable"));
 
         List<NativeReport> reports =
-                awaitFast(lifecycle, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")));
+                awaitFast(lifecycle, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")), "Crash");
         assertEquals(2, reports.size());
     }
 
@@ -89,7 +93,7 @@ public class CoronerNativeReportAssertionsTest {
         ReportSource wrongGuid = (guid, ts) ->
                 Arrays.asList(new NativeReport("99999999-0000-0000-0000-000000000000", "rxid-a", "Crash", "dump"));
 
-        assertThrows(AssertionError.class, () -> awaitFast(wrongGuid, 1, null));
+        assertThrows(AssertionError.class, () -> awaitFast(wrongGuid, 1, null, null));
     }
 
     @Test
@@ -103,6 +107,14 @@ public class CoronerNativeReportAssertionsTest {
                         (guid, ts) -> managedOnly.fetch(guid, ts), GUID, 0, 2_000, FAST, FAST));
     }
 
+    /** Nonfatal and lifecycle reports must classify as Crash too, not only fatal reports. */
+    @Test
+    public void wrongErrorTypeFailsWhenCrashIsRequired() {
+        ReportSource managed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "rxid-a", "Managed", "dump"));
+
+        assertThrows(AssertionError.class, () -> awaitFast(managed, 1, new HashSet<>(Arrays.asList("dump")), "Crash"));
+    }
+
     /**
      * Coroner can fold every matching row into one "*" group whose count carries the real total;
      * the policy must sum row counts, or duplicates hidden inside a collapsed group pass as one.
@@ -111,16 +123,52 @@ public class CoronerNativeReportAssertionsTest {
     public void collapsedGroupWithTwoRowsFailsAnExpectedOneAssertion() {
         ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "dump", 2));
 
-        assertThrows(AssertionError.class, () -> awaitFast(collapsed, 1, null));
+        assertThrows(AssertionError.class, () -> awaitFast(collapsed, 1, null, null));
+    }
+
+    /** Count-only expectations (no message set) remain provable from a collapsed group. */
+    @Test
+    public void collapsedGroupWithTwoRowsSatisfiesACountOnlyExpectedTwoAssertion() {
+        ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "before-disable", 2));
+
+        List<NativeReport> reports = awaitFast(collapsed, 2, null, "Crash");
+        assertEquals(1, reports.size());
+        assertEquals(2, reports.get(0).rowCount);
+    }
+
+    /**
+     * A collapsed group exposes one head message for many rows, so it can never prove a full
+     * expected message set: two rows showing only "before-disable" could be a duplicate hiding a
+     * missing "after-reenable" report. The policy must fail instead of relaxing the check.
+     */
+    @Test
+    public void collapsedGroupCannotProveExpectedMessagesFails() {
+        ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "before-disable", 2));
+
+        assertThrows(
+                AssertionError.class,
+                () -> awaitFast(collapsed, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")), null));
+    }
+
+    /** The per-message policy must reject a duplicated message, collapsed or not. */
+    @Test
+    public void duplicateRowsForOneMessageFailTheMessageAssertion() {
+        ReportSource duplicated =
+                (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "before-disable", 2));
+
+        assertThrows(
+                AssertionError.class,
+                () -> CoronerNativeReportAssertions.awaitExactlyOneWithMessage(
+                        duplicated, GUID, "before-disable", 0, 2_000, FAST, FAST));
     }
 
     @Test
-    public void collapsedGroupWithTwoRowsSatisfiesAnExpectedTwoAssertion() {
-        ReportSource collapsed = (guid, ts) -> Arrays.asList(new NativeReport(GUID, "*", "Crash", "before-disable", 2));
+    public void messageQuerySatisfiedByExactlyOneCrashReportPasses() {
+        ReportSource single = (guid, ts) -> Arrays.asList(report("rxid-a", "before-disable"));
 
-        List<NativeReport> reports =
-                awaitFast(collapsed, 2, new HashSet<>(Arrays.asList("before-disable", "after-reenable")));
-        assertEquals(1, reports.size());
-        assertEquals(2, reports.get(0).rowCount);
+        NativeReport report = CoronerNativeReportAssertions.awaitExactlyOneWithMessage(
+                single, GUID, "before-disable", 0, 2_000, FAST, FAST);
+        assertEquals("rxid-a", report.groupId);
+        assertEquals(1, report.rowCount);
     }
 }

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/LegacyNativeIntegrationCompatibilityTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/LegacyNativeIntegrationCompatibilityTest.java
@@ -1,0 +1,98 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import backtraceio.library.BacktraceClient;
+import backtraceio.library.BacktraceCredentials;
+import backtraceio.library.BacktraceDatabase;
+import backtraceio.library.common.AbiHelper;
+import backtraceio.library.models.nativeHandler.CrashHandlerConfiguration;
+import java.io.File;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * API 21/22 verifier and resolver smoke: proves the API-isolated references
+ * ({@code ApplicationInfo.splitNames} behind an API 26 nested class, {@code Process.is64Bit()}
+ * behind an API 23 nested class) let every native-integration class load and run on the oldest
+ * supported runtimes without {@code VerifyError}, {@code NoSuchMethodError},
+ * {@code NoSuchFieldError}, or {@code UnsatisfiedLinkError}. Requires no backend credentials, so
+ * it runs in secretless lanes. The assertions are meaningful on every API level and the CI matrix
+ * pins this class to API 21 and 22 emulators.
+ */
+@RunWith(AndroidJUnit4.class)
+public class LegacyNativeIntegrationCompatibilityTest {
+
+    @Test
+    public void nativeIntegrationClassesLoadAndVerify() throws Exception {
+        // Explicit class initialization surfaces verifier and linkage errors eagerly.
+        for (String className : new String[] {
+            "backtraceio.library.common.AbiHelper",
+            "backtraceio.library.models.nativeHandler.CrashHandlerConfiguration",
+            "backtraceio.library.base.BacktraceBase",
+            "backtraceio.library.BacktraceClient",
+            "backtraceio.library.BacktraceDatabase",
+            "backtraceio.library.services.BacktraceCrashHandlerRunner"
+        }) {
+            assertNotNull(Class.forName(className, true, getClass().getClassLoader()));
+        }
+    }
+
+    @Test
+    public void abiHelperReportsAnAbiOnEveryApiLevel() {
+        String abi = AbiHelper.getCurrentAbi();
+        assertNotNull(abi);
+        assertFalse(abi.trim().isEmpty());
+    }
+
+    @Test
+    public void environmentConstructionWorksForTheInstalledApp() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        ApplicationInfo applicationInfo = context.getApplicationInfo();
+
+        List<String> environment = new CrashHandlerConfiguration().getCrashHandlerEnvironmentVariables(applicationInfo);
+
+        String handlerPath = null;
+        String prefix = CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER + "=";
+        for (String variable : environment) {
+            if (variable.startsWith(prefix)) {
+                handlerPath = variable.substring(prefix.length());
+            }
+        }
+        assertNotNull("Resolved handler path must exist for a real installed app", handlerPath);
+        assertFalse(handlerPath.trim().isEmpty());
+    }
+
+    @Test
+    public void knownX86RemainsUnsupported() {
+        assertFalse(new CrashHandlerConfiguration().isSupportedAbi("x86"));
+    }
+
+    @Test
+    public void failedSetupThenBothDumpOverloadsSurvive() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        File databaseRoot = new File(context.getFilesDir(), "legacy-safety-" + System.nanoTime());
+        assertTrue(databaseRoot.mkdirs());
+
+        // Malformed credentials: a null endpoint NPEs inside the URL getter and must be contained
+        // by setupNativeIntegration. The client itself is constructed with valid credentials,
+        // since the client constructor eagerly builds the submission URL.
+        BacktraceCredentials validCredentials = new BacktraceCredentials("https://test.sp.backtrace.io", "token");
+        BacktraceCredentials malformedCredentials = new BacktraceCredentials((String) null, "token");
+        BacktraceDatabase database = new BacktraceDatabase(context, databaseRoot.getAbsolutePath());
+        BacktraceClient client = new BacktraceClient(context, validCredentials, database);
+        database.start();
+
+        assertFalse(Boolean.TRUE.equals(database.setupNativeIntegration(client, malformedCredentials)));
+
+        client.dumpWithoutCrash("legacy-dump-after-failure");
+        client.dumpWithoutCrash("legacy-dump-after-failure", true);
+    }
+}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/NativeFreshProcessSafetyTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/NativeFreshProcessSafetyTest.java
@@ -1,0 +1,47 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import android.content.Context;
+import android.os.Bundle;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Clean-process failure safety: the safety service runs in its own process that has never
+ * initialized the native backend, so — unlike in-process instrumentation tests, where another test
+ * may already have initialized Crashpad — a dump call after a failed setup genuinely exercises the
+ * uninitialized native guards. Requires no backend credentials; runs in every lane, including
+ * secretless forks.
+ */
+@RunWith(AndroidJUnit4.class)
+public class NativeFreshProcessSafetyTest {
+
+    private static final long BIND_TIMEOUT_MS = 20_000;
+    private static final long SAFETY_TIMEOUT_MS = 120_000;
+
+    @Test
+    public void freshProcessSurvivesFailedSetupAndDumpCalls() {
+        Context context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        try (RemoteNativeServiceSession session =
+                RemoteNativeServiceSession.bind(context, NativeSafetyTestService.class, BIND_TIMEOUT_MS)) {
+
+            Bundle completed = session.request(
+                    NativeTestProtocol.CMD_RUN_FRESH_PROCESS_SAFETY,
+                    null,
+                    NativeTestProtocol.EVENT_COMPLETED,
+                    SAFETY_TIMEOUT_MS);
+            assertNotNull(completed);
+            assertTrue("Safety process must report a PID", session.getRemotePid() > 0);
+
+            // A post-run PING proves the clean process survived every scenario and both dump
+            // overloads; a native crash would have killed the process and failed the bind.
+            Bundle pong = session.request(
+                    NativeTestProtocol.CMD_PING, null, NativeTestProtocol.EVENT_COMPLETED, BIND_TIMEOUT_MS);
+            assertNotNull(pong);
+        }
+    }
+}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/NativeSplitProcessIntegrationTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/NativeSplitProcessIntegrationTest.java
@@ -65,14 +65,22 @@ public class NativeSplitProcessIntegrationTest {
 
             java.util.List<CoronerNativeReportAssertions.NativeReport> reports =
                     CoronerNativeReportAssertions.awaitExactly(
-                            coroner, guid, timestampStart, 1, new HashSet<>(Arrays.asList(message)));
+                            coroner,
+                            guid,
+                            timestampStart,
+                            1,
+                            new HashSet<>(Arrays.asList(message)),
+                            CoronerNativeReportAssertions.CRASH_ERROR_TYPE);
             logEvidence(
                     "nonfatal",
                     guid,
                     reports,
+                    "\"" + escapeJson(message) + "\":1",
                     "\"process_abi\":\"" + ready.getString(NativeTestProtocol.KEY_PROCESS_ABI)
                             + "\",\"process_is_64_bit\":"
-                            + ready.getBoolean(NativeTestProtocol.KEY_IS_64_BIT));
+                            + ready.getBoolean(NativeTestProtocol.KEY_IS_64_BIT)
+                            + ",\"handler_path\":\"" + escapeJson(ready.getString(NativeTestProtocol.KEY_HANDLER_PATH))
+                            + "\"");
 
             // Cleanup only after ingestion is confirmed; the client must stay alive while
             // uploading.
@@ -112,11 +120,12 @@ public class NativeSplitProcessIntegrationTest {
 
             CoronerNativeReportAssertions.NativeReport fatalReport =
                     CoronerNativeReportAssertions.awaitExactlyOneFatal(coroner, guid, timestampStart);
-            assertNotNull(fatalReport.rxid);
+            assertNotNull(fatalReport.groupId);
             logEvidence(
                     "fatal",
                     guid,
                     java.util.Collections.singletonList(fatalReport),
+                    null,
                     "\"crashed_pid\":" + crashedPid + ",\"binder_died\":true");
 
             recoverySession.request(
@@ -138,8 +147,7 @@ public class NativeSplitProcessIntegrationTest {
             beforeData.putString(NativeTestProtocol.KEY_MESSAGE, beforeMessage);
             session.request(
                     NativeTestProtocol.CMD_DUMP, beforeData, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
-            CoronerNativeReportAssertions.awaitExactly(
-                    coroner, guid, timestampStart, 1, new HashSet<>(Arrays.asList(beforeMessage)));
+            CoronerNativeReportAssertions.awaitExactlyOneWithMessage(coroner, guid, beforeMessage, timestampStart);
 
             session.request(
                     NativeTestProtocol.CMD_DISABLE, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
@@ -152,16 +160,22 @@ public class NativeSplitProcessIntegrationTest {
             session.request(
                     NativeTestProtocol.CMD_DUMP, afterData, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
 
-            // Exactly two total reports with both distinct messages proves the upload thread
-            // actually restarted, not merely that Java state changed.
+            // Proving the upload thread actually restarted requires all three conditions, each
+            // with its own stability window: exactly two reports GUID-wide, and exactly one report
+            // per distinct message. Message-filtered queries stay correct when Coroner collapses
+            // the GUID-wide grouping into a single wildcard group; the GUID-wide query alone
+            // could then not distinguish a duplicate from the missing second message.
             java.util.List<CoronerNativeReportAssertions.NativeReport> lifecycleReports =
                     CoronerNativeReportAssertions.awaitExactly(
-                            coroner,
-                            guid,
-                            timestampStart,
-                            2,
-                            new HashSet<>(Arrays.asList(beforeMessage, afterMessage)));
-            logEvidence("lifecycle", guid, lifecycleReports, null);
+                            coroner, guid, timestampStart, 2, null, CoronerNativeReportAssertions.CRASH_ERROR_TYPE);
+            CoronerNativeReportAssertions.awaitExactlyOneWithMessage(coroner, guid, beforeMessage, timestampStart);
+            CoronerNativeReportAssertions.awaitExactlyOneWithMessage(coroner, guid, afterMessage, timestampStart);
+            logEvidence(
+                    "lifecycle",
+                    guid,
+                    lifecycleReports,
+                    "\"" + escapeJson(beforeMessage) + "\":1,\"" + escapeJson(afterMessage) + "\":1",
+                    null);
 
             session.request(
                     NativeTestProtocol.CMD_CLEANUP, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
@@ -217,25 +231,36 @@ public class NativeSplitProcessIntegrationTest {
 
     /**
      * Machine-readable evidence line collected by scripts/run_split_install_test.sh into
-     * native-report-evidence.json. Carries GUIDs and RXIDs only — never credentials.
+     * native-report-evidence.json. Carries GUIDs and group identifiers only — never credentials.
+     * {@code group_ids} are RXIDs when the backend returns per-report groups and the literal
+     * {@code "*"} when it collapses the grouping; {@code stable_count} is the summed report count,
+     * which is what the assertion actually verified. {@code messagesJson} lists each proven
+     * message with its individually verified count.
      */
     private static void logEvidence(
             String phase,
             String guid,
             java.util.List<CoronerNativeReportAssertions.NativeReport> reports,
+            String messagesJson,
             String extraJson) {
-        StringBuilder rxids = new StringBuilder("[");
+        StringBuilder groupIds = new StringBuilder("[");
         for (int i = 0; i < reports.size(); i++) {
             if (i > 0) {
-                rxids.append(',');
+                groupIds.append(',');
             }
-            rxids.append('"').append(reports.get(i).rxid).append('"');
+            groupIds.append('"').append(escapeJson(reports.get(i).groupId)).append('"');
         }
-        rxids.append(']');
+        groupIds.append(']');
         android.util.Log.i(
                 "NativeQualEvidence",
-                "{\"phase\":\"" + phase + "\",\"guid\":\"" + guid + "\",\"rxids\":" + rxids + ",\"stable_count\":"
-                        + reports.size() + (extraJson == null ? "" : "," + extraJson) + "}");
+                "{\"phase\":\"" + phase + "\",\"guid\":\"" + guid + "\",\"group_ids\":" + groupIds
+                        + ",\"stable_count\":" + CoronerNativeReportAssertions.totalRowCount(reports)
+                        + (messagesJson == null ? "" : ",\"messages\":{" + messagesJson + "}")
+                        + (extraJson == null ? "" : "," + extraJson) + "}");
+    }
+
+    private static String escapeJson(String value) {
+        return value == null ? "" : value.replace("\\", "\\\\").replace("\"", "\\\"");
     }
 
     private static boolean hasText(String value) {

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/NativeSplitProcessIntegrationTest.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/NativeSplitProcessIntegrationTest.java
@@ -1,0 +1,244 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.os.Bundle;
+import android.os.SystemClock;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import backtraceio.coroner.CoronerClient;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Real-handler qualification through dedicated processes: nonfatal ingestion, fatal crash with
+ * restart-assisted recovery upload, and disable/re-enable lifecycle. Every gate correlates by GUID
+ * (applied through Crashpad at initialization) with a bounded multi-result query, so duplicates
+ * are detectable. Skips without backend credentials; the split-path assertion applies on split
+ * installs.
+ */
+@RunWith(AndroidJUnit4.class)
+public class NativeSplitProcessIntegrationTest {
+
+    private static final long BIND_TIMEOUT_MS = 20_000;
+    private static final long COMMAND_TIMEOUT_MS = 60_000;
+    private static final long CRASH_DEATH_TIMEOUT_MS = 20_000;
+
+    private Context context;
+    private CoronerClient coroner;
+
+    @Before
+    public void setUp() {
+        context = InstrumentationRegistry.getInstrumentation().getTargetContext();
+        assumeTrue(
+                "Backtrace test credentials are not configured",
+                hasText(BuildConfig.BACKTRACE_SUBMISSION_URL)
+                        && hasText(BuildConfig.BACKTRACE_CORONER_URL)
+                        && hasText(BuildConfig.BACKTRACE_CORONER_TOKEN));
+        coroner = new CoronerClient(BuildConfig.BACKTRACE_CORONER_URL, BuildConfig.BACKTRACE_CORONER_TOKEN);
+    }
+
+    @Test
+    public void nonfatalDumpFromDedicatedProcessIsIngestedExactlyOnce() {
+        String guid = UUID.randomUUID().toString();
+        long timestampStart = nowSeconds() - 5;
+
+        try (RemoteNativeServiceSession session =
+                RemoteNativeServiceSession.bind(context, NativeNonfatalTestService.class, BIND_TIMEOUT_MS)) {
+            Bundle ready = prepare(session, NativeTestProtocol.CMD_PREPARE_REAL_NATIVE, guid, null);
+            verifySplitBackedHandlerPath(ready);
+
+            String message = "split-nonfatal-" + guid;
+            Bundle dumpData = new Bundle();
+            dumpData.putString(NativeTestProtocol.KEY_MESSAGE, message);
+            session.request(
+                    NativeTestProtocol.CMD_DUMP, dumpData, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+
+            java.util.List<CoronerNativeReportAssertions.NativeReport> reports =
+                    CoronerNativeReportAssertions.awaitExactly(
+                            coroner, guid, timestampStart, 1, new HashSet<>(Arrays.asList(message)));
+            logEvidence(
+                    "nonfatal",
+                    guid,
+                    reports,
+                    "\"process_abi\":\"" + ready.getString(NativeTestProtocol.KEY_PROCESS_ABI)
+                            + "\",\"process_is_64_bit\":"
+                            + ready.getBoolean(NativeTestProtocol.KEY_IS_64_BIT));
+
+            // Cleanup only after ingestion is confirmed; the client must stay alive while
+            // uploading.
+            session.request(
+                    NativeTestProtocol.CMD_CLEANUP, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+        }
+    }
+
+    @Test
+    public void fatalCrashIsRecoveredAndIngestedExactlyOnce() {
+        String guid = UUID.randomUUID().toString();
+        long timestampStart = nowSeconds() - 5;
+        String databasePath;
+        int crashedPid;
+
+        try (RemoteNativeServiceSession fatalSession =
+                RemoteNativeServiceSession.bind(context, NativeFatalTestService.class, BIND_TIMEOUT_MS)) {
+            Bundle ready = prepare(fatalSession, NativeTestProtocol.CMD_PREPARE_REAL_NATIVE, guid, null);
+            verifySplitBackedHandlerPath(ready);
+            databasePath = ready.getString(NativeTestProtocol.KEY_DATABASE_PATH);
+            crashedPid = fatalSession.getRemotePid();
+            assertTrue("Fatal process must report a PID", crashedPid > 0);
+            assertNotNull(databasePath);
+
+            fatalSession.send(NativeTestProtocol.CMD_CRASH, null);
+            fatalSession.awaitEvent(NativeTestProtocol.EVENT_WILL_CRASH, COMMAND_TIMEOUT_MS);
+            // Binder death is the primary process-termination assertion.
+            fatalSession.awaitBinderDeath(CRASH_DEATH_TIMEOUT_MS);
+        }
+        awaitProcDisappeared(crashedPid);
+
+        // Model the next application launch: a recovery process pointed at the same Crashpad
+        // database starts the uploader for the pending fatal report.
+        try (RemoteNativeServiceSession recoverySession =
+                RemoteNativeServiceSession.bind(context, NativeRecoveryTestService.class, BIND_TIMEOUT_MS)) {
+            prepare(recoverySession, NativeTestProtocol.CMD_PREPARE_RECOVERY, guid, databasePath);
+
+            CoronerNativeReportAssertions.NativeReport fatalReport =
+                    CoronerNativeReportAssertions.awaitExactlyOneFatal(coroner, guid, timestampStart);
+            assertNotNull(fatalReport.rxid);
+            logEvidence(
+                    "fatal",
+                    guid,
+                    java.util.Collections.singletonList(fatalReport),
+                    "\"crashed_pid\":" + crashedPid + ",\"binder_died\":true");
+
+            recoverySession.request(
+                    NativeTestProtocol.CMD_CLEANUP, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+        }
+    }
+
+    @Test
+    public void disableAndReEnableRestartsUploads() {
+        String guid = UUID.randomUUID().toString();
+        long timestampStart = nowSeconds() - 5;
+
+        try (RemoteNativeServiceSession session =
+                RemoteNativeServiceSession.bind(context, NativeLifecycleTestService.class, BIND_TIMEOUT_MS)) {
+            prepare(session, NativeTestProtocol.CMD_PREPARE_REAL_NATIVE, guid, null);
+
+            String beforeMessage = "before-disable-" + guid;
+            Bundle beforeData = new Bundle();
+            beforeData.putString(NativeTestProtocol.KEY_MESSAGE, beforeMessage);
+            session.request(
+                    NativeTestProtocol.CMD_DUMP, beforeData, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+            CoronerNativeReportAssertions.awaitExactly(
+                    coroner, guid, timestampStart, 1, new HashSet<>(Arrays.asList(beforeMessage)));
+
+            session.request(
+                    NativeTestProtocol.CMD_DISABLE, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+            session.request(
+                    NativeTestProtocol.CMD_ENABLE, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+
+            String afterMessage = "after-reenable-" + guid;
+            Bundle afterData = new Bundle();
+            afterData.putString(NativeTestProtocol.KEY_MESSAGE, afterMessage);
+            session.request(
+                    NativeTestProtocol.CMD_DUMP, afterData, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+
+            // Exactly two total reports with both distinct messages proves the upload thread
+            // actually restarted, not merely that Java state changed.
+            java.util.List<CoronerNativeReportAssertions.NativeReport> lifecycleReports =
+                    CoronerNativeReportAssertions.awaitExactly(
+                            coroner,
+                            guid,
+                            timestampStart,
+                            2,
+                            new HashSet<>(Arrays.asList(beforeMessage, afterMessage)));
+            logEvidence("lifecycle", guid, lifecycleReports, null);
+
+            session.request(
+                    NativeTestProtocol.CMD_CLEANUP, null, NativeTestProtocol.EVENT_COMPLETED, COMMAND_TIMEOUT_MS);
+        }
+    }
+
+    private Bundle prepare(RemoteNativeServiceSession session, int command, String guid, String databasePath) {
+        Bundle data = new Bundle();
+        data.putString(NativeTestProtocol.KEY_GUID, guid);
+        if (databasePath != null) {
+            data.putString(NativeTestProtocol.KEY_DATABASE_PATH, databasePath);
+        }
+        Bundle ready = session.request(command, data, NativeTestProtocol.EVENT_READY, COMMAND_TIMEOUT_MS);
+        assertNotNull(ready.getString(NativeTestProtocol.KEY_HANDLER_PATH));
+        assertNotNull(ready.getString(NativeTestProtocol.KEY_PROCESS_ABI));
+        return ready;
+    }
+
+    /** On a split install the resolved handler path must point at an installed ABI split. */
+    private void verifySplitBackedHandlerPath(Bundle ready) {
+        ApplicationInfo applicationInfo = context.getApplicationInfo();
+        if (applicationInfo.splitSourceDirs == null || applicationInfo.splitSourceDirs.length == 0) {
+            return;
+        }
+        String handlerPath = ready.getString(NativeTestProtocol.KEY_HANDLER_PATH);
+        int separator = handlerPath.indexOf("!/");
+        if (separator <= 0) {
+            return; // Extracted-library install; nothing split-backed to verify.
+        }
+        String container = handlerPath.substring(0, separator);
+        boolean installed = Arrays.asList(applicationInfo.splitSourceDirs).contains(container)
+                || (applicationInfo.splitPublicSourceDirs != null
+                        && Arrays.asList(applicationInfo.splitPublicSourceDirs).contains(container));
+        assertTrue("Handler path is not an installed split: " + handlerPath, installed);
+    }
+
+    /** Secondary confirmation of process death; binder death is the primary assertion. */
+    private static void awaitProcDisappeared(int pid) {
+        long deadline = SystemClock.elapsedRealtime() + CRASH_DEATH_TIMEOUT_MS;
+        File proc = new File("/proc/" + pid);
+        while (SystemClock.elapsedRealtime() < deadline) {
+            if (!proc.exists()) {
+                return;
+            }
+            SystemClock.sleep(250);
+        }
+        // /proc visibility can be restricted; binder death already proved termination.
+    }
+
+    private static long nowSeconds() {
+        return System.currentTimeMillis() / 1000L;
+    }
+
+    /**
+     * Machine-readable evidence line collected by scripts/run_split_install_test.sh into
+     * native-report-evidence.json. Carries GUIDs and RXIDs only — never credentials.
+     */
+    private static void logEvidence(
+            String phase,
+            String guid,
+            java.util.List<CoronerNativeReportAssertions.NativeReport> reports,
+            String extraJson) {
+        StringBuilder rxids = new StringBuilder("[");
+        for (int i = 0; i < reports.size(); i++) {
+            if (i > 0) {
+                rxids.append(',');
+            }
+            rxids.append('"').append(reports.get(i).rxid).append('"');
+        }
+        rxids.append(']');
+        android.util.Log.i(
+                "NativeQualEvidence",
+                "{\"phase\":\"" + phase + "\",\"guid\":\"" + guid + "\",\"rxids\":" + rxids + ",\"stable_count\":"
+                        + reports.size() + (extraJson == null ? "" : "," + extraJson) + "}");
+    }
+
+    private static boolean hasText(String value) {
+        return value != null && !value.isEmpty();
+    }
+}

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/RemoteNativeServiceSession.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/RemoteNativeServiceSession.java
@@ -135,15 +135,21 @@ final class RemoteNativeServiceSession implements AutoCloseable {
             }
             Event event;
             try {
-                event = events.poll(remaining, TimeUnit.MILLISECONDS);
+                // Short poll slices so a remote-process death surfaces immediately instead of
+                // burning the whole deadline; already-queued events are always drained first, so
+                // the fatal-crash flow still observes EVENT_WILL_CRASH before the death.
+                event = events.poll(Math.min(remaining, 250), TimeUnit.MILLISECONDS);
             } catch (InterruptedException interrupted) {
                 Thread.currentThread().interrupt();
                 fail("Interrupted waiting for event " + expectedEvent);
                 return null;
             }
             if (event == null) {
-                fail("Timed out waiting for event " + expectedEvent);
-                return null;
+                if (binderDeath.getCount() == 0 && events.isEmpty()) {
+                    fail("Remote service process died (pid " + remotePid.get() + ") while waiting for event "
+                            + expectedEvent);
+                }
+                continue;
             }
             if (event.what == NativeTestProtocol.EVENT_FAILED) {
                 fail("Remote service reported failure: "

--- a/example-app/src/androidTest/java/backtraceio/backtraceio/RemoteNativeServiceSession.java
+++ b/example-app/src/androidTest/java/backtraceio/backtraceio/RemoteNativeServiceSession.java
@@ -1,0 +1,184 @@
+package backtraceio.backtraceio;
+
+import static org.junit.Assert.fail;
+
+import android.app.Service;
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.content.ServiceConnection;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.Messenger;
+import android.os.RemoteException;
+import android.os.SystemClock;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Instrumentation-side session around one debug-only native qualification service running in its
+ * own process. Bundles carry only strings, ints, booleans, and longs; a reported
+ * {@code EVENT_FAILED} fails immediately with the service's safe error class and scenario instead
+ * of waiting for a timeout.
+ */
+final class RemoteNativeServiceSession implements AutoCloseable {
+
+    private static final class Event {
+        final int what;
+        final Bundle data;
+
+        Event(int what, Bundle data) {
+            this.what = what;
+            this.data = data;
+        }
+    }
+
+    private final Context context;
+    private final ServiceConnection connection;
+    private final Messenger remote;
+    private final Messenger replyMessenger;
+    private final HandlerThread replyThread;
+    private final BlockingQueue<Event> events = new LinkedBlockingQueue<>();
+    private final CountDownLatch binderDeath = new CountDownLatch(1);
+    private final AtomicInteger remotePid = new AtomicInteger(-1);
+
+    private RemoteNativeServiceSession(
+            Context context, ServiceConnection connection, IBinder binder, HandlerThread replyThread) {
+        this.context = context;
+        this.connection = connection;
+        this.remote = new Messenger(binder);
+        this.replyThread = replyThread;
+        Handler replyHandler = new Handler(replyThread.getLooper()) {
+            @Override
+            public void handleMessage(Message message) {
+                Bundle data = message.getData() == null ? new Bundle() : new Bundle(message.getData());
+                if (data.containsKey(NativeTestProtocol.KEY_PID)) {
+                    remotePid.set(data.getInt(NativeTestProtocol.KEY_PID));
+                }
+                events.add(new Event(message.what, data));
+            }
+        };
+        this.replyMessenger = new Messenger(replyHandler);
+        try {
+            binder.linkToDeath(binderDeath::countDown, 0);
+        } catch (RemoteException alreadyDead) {
+            binderDeath.countDown();
+        }
+    }
+
+    static RemoteNativeServiceSession bind(Context context, Class<? extends Service> serviceClass, long timeoutMs) {
+        final CountDownLatch connected = new CountDownLatch(1);
+        final IBinder[] binderHolder = new IBinder[1];
+
+        ServiceConnection connection = new ServiceConnection() {
+            @Override
+            public void onServiceConnected(ComponentName name, IBinder service) {
+                binderHolder[0] = service;
+                connected.countDown();
+            }
+
+            @Override
+            public void onServiceDisconnected(ComponentName name) {
+                // Binder death is tracked through the DeathRecipient.
+            }
+        };
+
+        Intent intent = new Intent(context, serviceClass);
+        if (!context.bindService(intent, connection, Context.BIND_AUTO_CREATE)) {
+            fail("Unable to bind " + serviceClass.getSimpleName());
+        }
+        try {
+            if (!connected.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                context.unbindService(connection);
+                fail("Timed out binding " + serviceClass.getSimpleName());
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            fail("Interrupted while binding " + serviceClass.getSimpleName());
+        }
+
+        HandlerThread replyThread = new HandlerThread(serviceClass.getSimpleName() + "-replies");
+        replyThread.start();
+        return new RemoteNativeServiceSession(context, connection, binderHolder[0], replyThread);
+    }
+
+    Bundle request(int command, Bundle data, int expectedEvent, long timeoutMs) {
+        send(command, data);
+        return awaitEvent(expectedEvent, timeoutMs);
+    }
+
+    void send(int command, Bundle data) {
+        Message message = Message.obtain(null, command);
+        message.replyTo = replyMessenger;
+        if (data != null) {
+            message.setData(data);
+        }
+        try {
+            remote.send(message);
+        } catch (RemoteException failure) {
+            fail("Remote service is unreachable for command " + command);
+        }
+    }
+
+    Bundle awaitEvent(int expectedEvent, long timeoutMs) {
+        long deadline = SystemClock.elapsedRealtime() + timeoutMs;
+        while (true) {
+            long remaining = deadline - SystemClock.elapsedRealtime();
+            if (remaining <= 0) {
+                fail("Timed out waiting for event " + expectedEvent);
+            }
+            Event event;
+            try {
+                event = events.poll(remaining, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException interrupted) {
+                Thread.currentThread().interrupt();
+                fail("Interrupted waiting for event " + expectedEvent);
+                return null;
+            }
+            if (event == null) {
+                fail("Timed out waiting for event " + expectedEvent);
+                return null;
+            }
+            if (event.what == NativeTestProtocol.EVENT_FAILED) {
+                fail("Remote service reported failure: "
+                        + event.data.getString(NativeTestProtocol.KEY_ERROR_TYPE) + " in scenario "
+                        + event.data.getString(NativeTestProtocol.KEY_SCENARIO));
+            }
+            if (event.what == expectedEvent) {
+                return event.data;
+            }
+            // Unrelated event (for example a stale COMPLETED); keep waiting for the expected one.
+        }
+    }
+
+    void awaitBinderDeath(long timeoutMs) {
+        try {
+            if (!binderDeath.await(timeoutMs, TimeUnit.MILLISECONDS)) {
+                fail("Remote service process did not die within " + timeoutMs + " ms");
+            }
+        } catch (InterruptedException interrupted) {
+            Thread.currentThread().interrupt();
+            fail("Interrupted waiting for remote process death");
+        }
+    }
+
+    int getRemotePid() {
+        return remotePid.get();
+    }
+
+    @Override
+    public void close() {
+        try {
+            context.unbindService(connection);
+        } catch (IllegalArgumentException alreadyUnbound) {
+            // The connection died with the remote process; nothing to unbind.
+        }
+        replyThread.quitSafely();
+    }
+}

--- a/example-app/src/debug/AndroidManifest.xml
+++ b/example-app/src/debug/AndroidManifest.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Debug-only native qualification harness. Each service runs in its own named process so a
+         test observes fresh process-global native state (Crashpad initialization is per-process
+         and once-only). Processes share the app UID and normal private-file access; do NOT use
+         android:isolatedProcess, which would diverge from production behavior. -->
+    <application>
+        <service
+            android:name=".NativeSafetyTestService"
+            android:exported="false"
+            android:process=":native_safety_test"
+            android:stopWithTask="true" />
+
+        <service
+            android:name=".NativeNonfatalTestService"
+            android:exported="false"
+            android:process=":native_nonfatal_test"
+            android:stopWithTask="true" />
+
+        <service
+            android:name=".NativeFatalTestService"
+            android:exported="false"
+            android:process=":native_fatal_test"
+            android:stopWithTask="true" />
+
+        <service
+            android:name=".NativeRecoveryTestService"
+            android:exported="false"
+            android:process=":native_recovery_test"
+            android:stopWithTask="true" />
+
+        <service
+            android:name=".NativeLifecycleTestService"
+            android:exported="false"
+            android:process=":native_lifecycle_test"
+            android:stopWithTask="true" />
+
+        <activity
+            android:name=".NativeStartupQualificationActivity"
+            android:exported="true"
+            android:excludeFromRecents="true"
+            android:finishOnTaskLaunch="true"
+            android:noHistory="true" />
+    </application>
+</manifest>

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeFatalTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeFatalTestService.java
@@ -1,0 +1,4 @@
+package backtraceio.backtraceio;
+
+/** Dedicated process (see the debug manifest) so native process-global state starts fresh. */
+public final class NativeFatalTestService extends NativeIntegrationTestService {}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeIntegrationTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeIntegrationTestService.java
@@ -206,7 +206,7 @@ public abstract class NativeIntegrationTestService extends Service {
      */
     private void runFreshProcessSafety() {
         String sentinels = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL"
-                + " --annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL"
+                + " --annotation=private.application.value=SENSITIVE_ATTRIBUTE_SENTINEL"
                 + " /data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so";
 
         runSafetyScenario("malformed-credentials", null, new BacktraceCredentials((String) null, "token"));

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeIntegrationTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeIntegrationTestService.java
@@ -1,0 +1,375 @@
+package backtraceio.backtraceio;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
+import android.os.IBinder;
+import android.os.Message;
+import android.os.Messenger;
+import android.os.Process;
+import android.os.RemoteException;
+import backtraceio.library.BacktraceClient;
+import backtraceio.library.BacktraceCredentials;
+import backtraceio.library.BacktraceDatabase;
+import backtraceio.library.common.AbiHelper;
+import backtraceio.library.enums.UnwindingMode;
+import backtraceio.library.interfaces.NativeCommunication;
+import backtraceio.library.models.database.BacktraceDatabaseRecord;
+import backtraceio.library.models.database.BacktraceDatabaseSettings;
+import backtraceio.library.models.json.BacktraceReport;
+import backtraceio.library.models.nativeHandler.CrashHandlerConfiguration;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Debug-only base for the native qualification services. Each concrete subclass runs in its own
+ * named process (see the debug manifest), so every service observes fresh process-global native
+ * state. Commands execute on a {@link HandlerThread}; failures are reported through
+ * {@code EVENT_FAILED} carrying only the failure class name and scenario — never exception
+ * messages, which can embed credentials or paths.
+ */
+public abstract class NativeIntegrationTestService extends Service {
+
+    private HandlerThread commandThread;
+    private Messenger messenger;
+
+    // Retained while a report may still be uploading; released only on CMD_CLEANUP.
+    private BacktraceClient client;
+    private BacktraceDatabase database;
+    private String guid;
+    private String databasePath;
+    private String handlerPath;
+
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        commandThread = new HandlerThread(getClass().getSimpleName() + "-commands");
+        commandThread.start();
+        messenger = new Messenger(new CommandHandler(commandThread));
+    }
+
+    @Override
+    public IBinder onBind(Intent intent) {
+        return messenger.getBinder();
+    }
+
+    @Override
+    public void onDestroy() {
+        if (commandThread != null) {
+            commandThread.quitSafely();
+        }
+        super.onDestroy();
+    }
+
+    private final class CommandHandler extends Handler {
+        CommandHandler(HandlerThread thread) {
+            super(thread.getLooper());
+        }
+
+        @Override
+        public void handleMessage(Message message) {
+            final Messenger replyTo = message.replyTo;
+            if (replyTo == null) {
+                return;
+            }
+            final int command = message.what;
+            final Bundle data = message.getData() == null ? new Bundle() : new Bundle(message.getData());
+            try {
+                handleCommand(command, data, replyTo);
+            } catch (RuntimeException | LinkageError failure) {
+                Bundle result = new Bundle();
+                if (failure instanceof SafetyScenarioFailure) {
+                    result.putString(
+                            NativeTestProtocol.KEY_ERROR_TYPE, ((SafetyScenarioFailure) failure).underlyingType);
+                    result.putString(NativeTestProtocol.KEY_SCENARIO, ((SafetyScenarioFailure) failure).scenario);
+                } else {
+                    result.putString(NativeTestProtocol.KEY_ERROR_TYPE, failureType(failure));
+                    result.putString(NativeTestProtocol.KEY_SCENARIO, "command-" + command);
+                }
+                reply(replyTo, NativeTestProtocol.EVENT_FAILED, result);
+            }
+        }
+    }
+
+    private void handleCommand(int command, Bundle data, Messenger replyTo) {
+        switch (command) {
+            case NativeTestProtocol.CMD_PING:
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, processFacts());
+                break;
+            case NativeTestProtocol.CMD_RUN_FRESH_PROCESS_SAFETY:
+                runFreshProcessSafety();
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, processFacts());
+                break;
+            case NativeTestProtocol.CMD_PREPARE_REAL_NATIVE:
+                prepareRealNative(data.getString(NativeTestProtocol.KEY_GUID), null);
+                reply(replyTo, NativeTestProtocol.EVENT_READY, readyFacts());
+                break;
+            case NativeTestProtocol.CMD_PREPARE_RECOVERY:
+                prepareRealNative(
+                        data.getString(NativeTestProtocol.KEY_GUID),
+                        data.getString(NativeTestProtocol.KEY_DATABASE_PATH));
+                reply(replyTo, NativeTestProtocol.EVENT_READY, readyFacts());
+                break;
+            case NativeTestProtocol.CMD_DUMP:
+                requirePrepared();
+                client.dumpWithoutCrash(data.getString(NativeTestProtocol.KEY_MESSAGE));
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, null);
+                break;
+            case NativeTestProtocol.CMD_DISABLE:
+                requirePrepared();
+                client.disableNativeIntegration();
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, null);
+                break;
+            case NativeTestProtocol.CMD_ENABLE:
+                requirePrepared();
+                if (!client.tryEnableNativeIntegration()) {
+                    throw new IllegalStateException("Native integration re-enable returned false");
+                }
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, null);
+                break;
+            case NativeTestProtocol.CMD_CRASH:
+                requirePrepared();
+                reply(replyTo, NativeTestProtocol.EVENT_WILL_CRASH, null);
+                client.nativeCrash();
+                break;
+            case NativeTestProtocol.CMD_CLEANUP:
+                if (client != null) {
+                    client.disableNativeIntegration();
+                }
+                client = null;
+                database = null;
+                reply(replyTo, NativeTestProtocol.EVENT_COMPLETED, null);
+                stopSelf();
+                break;
+            default:
+                throw new IllegalArgumentException("Unknown command: " + command);
+        }
+    }
+
+    /**
+     * Constructs a real client, resolves the handler path <em>after</em> client construction (so
+     * {@code dladdr()} observes the loaded library), and requires native integration to enable.
+     */
+    private void prepareRealNative(String requestedGuid, String existingDatabasePath) {
+        requireText(BuildConfig.BACKTRACE_SUBMISSION_URL, "submission URL");
+
+        guid = requestedGuid == null
+                ? UUID.randomUUID().toString()
+                : UUID.fromString(requestedGuid).toString();
+
+        File databaseRoot = existingDatabasePath == null
+                ? new File(getFilesDir(), "native-qualification/" + getClass().getSimpleName() + "-" + guid)
+                : new File(existingDatabasePath);
+
+        if (!databaseRoot.exists() && !databaseRoot.mkdirs() && !databaseRoot.isDirectory()) {
+            throw new IllegalStateException("Unable to create qualification database");
+        }
+
+        Map<String, Object> attributes = new HashMap<>();
+        // The native backend reads `guid` during initialization and applies it through Crashpad,
+        // so both nonfatal and fatal reports from this process correlate without a custom
+        // project-indexed field.
+        attributes.put("guid", guid);
+        attributes.put("test.native.qualification", getClass().getSimpleName());
+
+        BacktraceCredentials credentials = new BacktraceCredentials(BuildConfig.BACKTRACE_SUBMISSION_URL);
+        BacktraceDatabaseSettings settings = new BacktraceDatabaseSettings(databaseRoot.getAbsolutePath());
+        database = new BacktraceDatabase(this, settings);
+        client = new BacktraceClient(this, credentials, database, attributes, new ArrayList<>());
+
+        handlerPath = findEnvironmentValue(
+                new CrashHandlerConfiguration().getCrashHandlerEnvironmentVariables(getApplicationInfo()),
+                CrashHandlerConfiguration.BACKTRACE_CRASH_HANDLER);
+        if (handlerPath == null || handlerPath.trim().isEmpty()) {
+            throw new IllegalStateException("Resolved handler path is blank");
+        }
+
+        if (!client.tryEnableNativeIntegration()) {
+            throw new IllegalStateException("Native integration returned false");
+        }
+
+        databasePath = databaseRoot.getAbsolutePath();
+    }
+
+    /**
+     * Fresh-process failure safety: every scenario runs before any successful native
+     * initialization in this process, then proves both dump overloads and managed persistence
+     * survive. Sentinel-bearing failures exercise the sanitized diagnostics on a real device.
+     */
+    private void runFreshProcessSafety() {
+        String sentinels = "https://example.invalid/minidump?token=SECRET_URL_TOKEN_SENTINEL"
+                + " --annotation=private.customer.value=PRIVATE_CUSTOMER_SENTINEL"
+                + " /data/app/~~opaque/split_config.arm64_v8a.apk!/lib/arm64-v8a/libbacktrace-native.so";
+
+        runSafetyScenario("malformed-credentials", null, new BacktraceCredentials((String) null, "token"));
+        runSafetyScenario("bridge-false", stubBridge(null), null);
+        runSafetyScenario(
+                "bridge-runtime-exception", stubBridge(new IllegalStateException("bridge failed: " + sentinels)), null);
+        runSafetyScenario(
+                "bridge-linkage-error", stubBridge(new UnsatisfiedLinkError("bridge failed: " + sentinels)), null);
+    }
+
+    private void runSafetyScenario(
+            String scenario, NativeCommunication bridge, BacktraceCredentials malformedCredentials) {
+        try {
+            File databaseRoot = new File(getFilesDir(), "fresh-safety/" + scenario + "-" + System.nanoTime());
+            if (!databaseRoot.mkdirs() && !databaseRoot.isDirectory()) {
+                throw new IllegalStateException("Unable to create safety database");
+            }
+
+            // The client is always constructed with valid credentials: a malformed credential is
+            // exercised through setupNativeIntegration (the contained path), not the client
+            // constructor, which eagerly builds the submission URL.
+            BacktraceCredentials validCredentials =
+                    new BacktraceCredentials("https://test.sp.backtrace.io", "1231231231231");
+            BacktraceCredentials setupCredentials =
+                    malformedCredentials != null ? malformedCredentials : validCredentials;
+            BacktraceDatabase safetyDatabase =
+                    new BacktraceDatabase(this, new BacktraceDatabaseSettings(databaseRoot.getAbsolutePath()));
+            BacktraceClient safetyClient = new BacktraceClient(this, validCredentials, safetyDatabase);
+            if (bridge != null) {
+                safetyDatabase.useNativeCommunication(bridge);
+            }
+            safetyDatabase.start();
+
+            if (Boolean.TRUE.equals(safetyDatabase.setupNativeIntegration(safetyClient, setupCredentials))) {
+                throw new IllegalStateException("Setup unexpectedly succeeded");
+            }
+
+            String message = "fresh-process-safety-" + scenario;
+            safetyClient.dumpWithoutCrash(message);
+            safetyClient.dumpWithoutCrash(message, true);
+
+            BacktraceDatabaseRecord managedRecord =
+                    safetyDatabase.add(new BacktraceReport("managed-" + scenario), Collections.emptyMap());
+            if (managedRecord == null) {
+                throw new IllegalStateException("Managed record was not persisted");
+            }
+        } catch (RuntimeException | LinkageError failure) {
+            throw new SafetyScenarioFailure(scenario, failureType(failure));
+        }
+    }
+
+    /**
+     * Carries the failed scenario name and the underlying failure class (never a message) so the
+     * parent's diagnostics identify the scenario without weakening the sanitization invariant.
+     */
+    private static final class SafetyScenarioFailure extends IllegalStateException {
+        final String scenario;
+        final String underlyingType;
+
+        SafetyScenarioFailure(String scenario, String underlyingType) {
+            super("scenario " + scenario + " failed: " + underlyingType);
+            this.scenario = scenario;
+            this.underlyingType = underlyingType;
+        }
+    }
+
+    /** Bridge stub covering every {@link NativeCommunication} method; only Java-handler init is affected. */
+    private static NativeCommunication stubBridge(final Object initFailure) {
+        return new NativeCommunication() {
+            @Override
+            public boolean handleCrash(String[] args) {
+                return false;
+            }
+
+            @Override
+            public boolean initializeJavaCrashHandler(
+                    String url,
+                    String databasePath,
+                    String classPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    String[] environmentVariables) {
+                if (initFailure instanceof RuntimeException) {
+                    throw (RuntimeException) initFailure;
+                }
+                if (initFailure instanceof LinkageError) {
+                    throw (LinkageError) initFailure;
+                }
+                return false;
+            }
+
+            @Override
+            public boolean initializeCrashHandler(
+                    String url,
+                    String databasePath,
+                    String handlerPath,
+                    String[] attributeKeys,
+                    String[] attributeValues,
+                    String[] attachmentPaths,
+                    boolean enableClientSideUnwinding,
+                    UnwindingMode unwindingMode) {
+                return false;
+            }
+        };
+    }
+
+    private void requirePrepared() {
+        if (client == null) {
+            throw new IllegalStateException("Service is not prepared; send CMD_PREPARE_REAL_NATIVE first");
+        }
+    }
+
+    private Bundle processFacts() {
+        Bundle facts = new Bundle();
+        facts.putInt(NativeTestProtocol.KEY_PID, Process.myPid());
+        facts.putString(NativeTestProtocol.KEY_PROCESS_ABI, AbiHelper.getCurrentAbi());
+        facts.putBoolean(
+                NativeTestProtocol.KEY_IS_64_BIT, Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && Process.is64Bit());
+        return facts;
+    }
+
+    private Bundle readyFacts() {
+        Bundle facts = processFacts();
+        facts.putString(NativeTestProtocol.KEY_GUID, guid);
+        facts.putString(NativeTestProtocol.KEY_DATABASE_PATH, databasePath);
+        facts.putString(NativeTestProtocol.KEY_HANDLER_PATH, handlerPath);
+        return facts;
+    }
+
+    private static void reply(Messenger replyTo, int event, Bundle data) {
+        Message response = Message.obtain(null, event);
+        if (data != null) {
+            response.setData(data);
+        }
+        try {
+            replyTo.send(response);
+        } catch (RemoteException ignored) {
+            // The parent died; nothing meaningful to report to.
+        }
+    }
+
+    private static String findEnvironmentValue(List<String> environment, String key) {
+        String prefix = key + "=";
+        for (String value : environment) {
+            if (value.startsWith(prefix)) {
+                return value.substring(prefix.length());
+            }
+        }
+        return null;
+    }
+
+    private static void requireText(String value, String name) {
+        if (value == null || value.trim().isEmpty()) {
+            throw new IllegalStateException("Missing required " + name);
+        }
+    }
+
+    private static String failureType(Throwable failure) {
+        if (failure == null) {
+            return "unknown";
+        }
+        String type = failure.getClass().getName();
+        return type == null || type.trim().isEmpty() ? "unknown" : type;
+    }
+}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeLifecycleTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeLifecycleTestService.java
@@ -1,0 +1,4 @@
+package backtraceio.backtraceio;
+
+/** Dedicated process (see the debug manifest) so native process-global state starts fresh. */
+public final class NativeLifecycleTestService extends NativeIntegrationTestService {}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeNonfatalTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeNonfatalTestService.java
@@ -1,0 +1,4 @@
+package backtraceio.backtraceio;
+
+/** Dedicated process (see the debug manifest) so native process-global state starts fresh. */
+public final class NativeNonfatalTestService extends NativeIntegrationTestService {}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeRecoveryTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeRecoveryTestService.java
@@ -1,0 +1,4 @@
+package backtraceio.backtraceio;
+
+/** Dedicated process (see the debug manifest) so native process-global state starts fresh. */
+public final class NativeRecoveryTestService extends NativeIntegrationTestService {}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeSafetyTestService.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeSafetyTestService.java
@@ -1,0 +1,4 @@
+package backtraceio.backtraceio;
+
+/** Dedicated process (see the debug manifest) so native process-global state starts fresh. */
+public final class NativeSafetyTestService extends NativeIntegrationTestService {}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeStartupQualificationActivity.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeStartupQualificationActivity.java
@@ -1,0 +1,75 @@
+package backtraceio.backtraceio;
+
+import android.app.Activity;
+import android.os.Bundle;
+import android.os.SystemClock;
+import android.os.Trace;
+import backtraceio.library.BacktraceClient;
+import backtraceio.library.BacktraceCredentials;
+import backtraceio.library.BacktraceDatabase;
+import backtraceio.library.models.database.BacktraceDatabaseSettings;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Debug-only startup-qualification entry point: performs the production main-thread native
+ * initialization inside a named trace section so Perfetto captures its exact cost, writes a small
+ * result JSON to app-private storage for the capture script, then disables and finishes. No
+ * tracing dependency is added to the release SDK; {@link Trace} is a platform API.
+ */
+public final class NativeStartupQualificationActivity extends Activity {
+
+    private static final String TRACE_SECTION = "BacktraceQualification#tryEnableNativeIntegration";
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        File databaseRoot = new File(getFilesDir(), "startup-qualification-" + SystemClock.elapsedRealtimeNanos());
+        databaseRoot.mkdirs();
+
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put("test.native.qualification", "startup");
+
+        String submissionUrl = BuildConfig.BACKTRACE_SUBMISSION_URL;
+        boolean nativeEnabled = false;
+        long startNanos = System.nanoTime();
+        BacktraceClient client = null;
+        try {
+            if (submissionUrl != null && !submissionUrl.trim().isEmpty()) {
+                BacktraceCredentials credentials = new BacktraceCredentials(submissionUrl);
+                BacktraceDatabase database =
+                        new BacktraceDatabase(this, new BacktraceDatabaseSettings(databaseRoot.getAbsolutePath()));
+                client = new BacktraceClient(this, credentials, database, attributes, new java.util.ArrayList<>());
+
+                Trace.beginSection(TRACE_SECTION);
+                try {
+                    nativeEnabled = client.tryEnableNativeIntegration();
+                } finally {
+                    Trace.endSection();
+                }
+            }
+        } finally {
+            long durationNanos = System.nanoTime() - startNanos;
+            writeResult(nativeEnabled, durationNanos);
+            if (client != null) {
+                client.disableNativeIntegration();
+            }
+            finish();
+        }
+    }
+
+    private void writeResult(boolean nativeEnabled, long durationNanos) {
+        String json = "{\"trace_section\":\"" + TRACE_SECTION + "\",\"native_enabled\":" + nativeEnabled
+                + ",\"duration_nanos\":" + durationNanos + "}";
+        File result = new File(getFilesDir(), "native-startup-qualification.json");
+        try (FileOutputStream output = new FileOutputStream(result)) {
+            output.write(json.getBytes(StandardCharsets.UTF_8));
+        } catch (java.io.IOException ignored) {
+            // The capture script treats a missing result file as a failed iteration.
+        }
+    }
+}

--- a/example-app/src/debug/java/backtraceio/backtraceio/NativeTestProtocol.java
+++ b/example-app/src/debug/java/backtraceio/backtraceio/NativeTestProtocol.java
@@ -1,0 +1,35 @@
+package backtraceio.backtraceio;
+
+/**
+ * Messenger protocol between instrumentation and the debug-only native qualification services.
+ * Primitive-only bundles: strings, ints, booleans, and longs. Credentials are never sent in either
+ * direction; database and handler paths travel only in controlled test responses and artifacts.
+ */
+final class NativeTestProtocol {
+    static final int CMD_PING = 1;
+    static final int CMD_RUN_FRESH_PROCESS_SAFETY = 2;
+    static final int CMD_PREPARE_REAL_NATIVE = 3;
+    static final int CMD_PREPARE_RECOVERY = 4;
+    static final int CMD_DUMP = 5;
+    static final int CMD_DISABLE = 6;
+    static final int CMD_ENABLE = 7;
+    static final int CMD_CRASH = 8;
+    static final int CMD_CLEANUP = 9;
+
+    static final int EVENT_READY = 100;
+    static final int EVENT_COMPLETED = 101;
+    static final int EVENT_WILL_CRASH = 102;
+    static final int EVENT_FAILED = 199;
+
+    static final String KEY_GUID = "guid";
+    static final String KEY_MESSAGE = "message";
+    static final String KEY_DATABASE_PATH = "database_path";
+    static final String KEY_HANDLER_PATH = "handler_path";
+    static final String KEY_PROCESS_ABI = "process_abi";
+    static final String KEY_IS_64_BIT = "is_64_bit";
+    static final String KEY_PID = "pid";
+    static final String KEY_ERROR_TYPE = "error_type";
+    static final String KEY_SCENARIO = "scenario";
+
+    private NativeTestProtocol() {}
+}

--- a/scripts/analyze_native_startup_trace.py
+++ b/scripts/analyze_native_startup_trace.py
@@ -97,14 +97,31 @@ def main() -> int:
     parser.add_argument("--trace-processor", required=True)
     parser.add_argument("--traces", required=True, help="directory of .perfetto-trace files")
     parser.add_argument("--output", required=True)
+    parser.add_argument(
+        "--expected-samples",
+        type=int,
+        default=None,
+        help="require exactly this many trace-section samples per captured variant",
+    )
     arguments = parser.parse_args()
 
     variants = {"baseline": [], "fixture": []}
     trace_counts = {"baseline": 0, "fixture": 0}
     callstack_coverage = False
     matches = set()
-    for trace in sorted(glob.glob(arguments.traces + "/*.perfetto-trace")):
-        variant = "fixture" if "/fixture-" in trace or "fixture-" in trace.rsplit("/", 1)[-1] else "baseline"
+    traces = sorted(glob.glob(arguments.traces + "/*.perfetto-trace"))
+    if not traces:
+        print(f"No .perfetto-trace files found in {arguments.traces}; nothing was analyzed", file=sys.stderr)
+        return 1
+    for trace in traces:
+        basename = trace.rsplit("/", 1)[-1]
+        if basename.startswith("fixture-"):
+            variant = "fixture"
+        elif basename.startswith("baseline-"):
+            variant = "baseline"
+        else:
+            print(f"Unrecognized trace name {basename}: expected baseline-*/fixture-*", file=sys.stderr)
+            return 1
         trace_counts[variant] += 1
         variants[variant].extend(section_durations_ms(arguments.trace_processor, trace))
         covered, trace_matches = forbidden_matches(arguments.trace_processor, trace)
@@ -137,6 +154,13 @@ def main() -> int:
             print(
                 f"{variant}: {count} trace(s) captured but zero {TRACE_SECTION} samples;"
                 " app atrace was probably not enabled for the package",
+                file=sys.stderr,
+            )
+            return 1
+        if count > 0 and arguments.expected_samples is not None and len(variants[variant]) != arguments.expected_samples:
+            print(
+                f"{variant}: expected exactly {arguments.expected_samples} {TRACE_SECTION} samples"
+                f" (one per cold-start iteration), found {len(variants[variant])}",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/analyze_native_startup_trace.py
+++ b/scripts/analyze_native_startup_trace.py
@@ -103,10 +103,31 @@ def main() -> int:
         default=None,
         help="require exactly this many trace-section samples per captured variant",
     )
+    parser.add_argument(
+        "--expected-baseline-traces",
+        type=int,
+        default=None,
+        help="require exactly this many baseline trace files",
+    )
+    parser.add_argument(
+        "--expected-fixture-traces",
+        type=int,
+        default=None,
+        help="require exactly this many fixture trace files (use zero when not captured)",
+    )
     arguments = parser.parse_args()
+
+    for flag, count in (
+        ("--expected-samples", arguments.expected_samples),
+        ("--expected-baseline-traces", arguments.expected_baseline_traces),
+        ("--expected-fixture-traces", arguments.expected_fixture_traces),
+    ):
+        if count is not None and count < 0:
+            parser.error(f"{flag} must be zero or greater")
 
     variants = {"baseline": [], "fixture": []}
     trace_counts = {"baseline": 0, "fixture": 0}
+    per_trace_section_counts = {}
     callstack_coverage = False
     matches = set()
     traces = sorted(glob.glob(arguments.traces + "/*.perfetto-trace"))
@@ -123,7 +144,9 @@ def main() -> int:
             print(f"Unrecognized trace name {basename}: expected baseline-*/fixture-*", file=sys.stderr)
             return 1
         trace_counts[variant] += 1
-        variants[variant].extend(section_durations_ms(arguments.trace_processor, trace))
+        trace_durations = section_durations_ms(arguments.trace_processor, trace)
+        per_trace_section_counts[basename] = len(trace_durations)
+        variants[variant].extend(trace_durations)
         covered, trace_matches = forbidden_matches(arguments.trace_processor, trace)
         callstack_coverage = callstack_coverage or covered
         matches.update(trace_matches)
@@ -139,6 +162,8 @@ def main() -> int:
         "baseline": baseline,
         "fixture": fixture,
         "median_delta_ms": delta,
+        "trace_file_counts": trace_counts,
+        "per_trace_section_counts": per_trace_section_counts,
         "forbidden_symbol_matches": sorted(matches),
         "callstack_coverage": callstack_coverage,
     }
@@ -146,25 +171,43 @@ def main() -> int:
         json.dump(summary, output, indent=2)
     print(json.dumps(summary, indent=2))
 
+    failed = False
     if matches:
         print("Forbidden symbols present in runtime callstacks", file=sys.stderr)
-        return 1
-    for variant, count in trace_counts.items():
-        if count > 0 and not variants[variant]:
+        failed = True
+
+    expected_trace_counts = {
+        "baseline": arguments.expected_baseline_traces,
+        "fixture": arguments.expected_fixture_traces,
+    }
+    for variant, expected_count in expected_trace_counts.items():
+        actual_count = trace_counts[variant]
+        if expected_count is not None and actual_count != expected_count:
             print(
-                f"{variant}: {count} trace(s) captured but zero {TRACE_SECTION} samples;"
-                " app atrace was probably not enabled for the package",
+                f"{variant}: expected exactly {expected_count} trace file(s), found {actual_count}",
                 file=sys.stderr,
             )
-            return 1
-        if count > 0 and arguments.expected_samples is not None and len(variants[variant]) != arguments.expected_samples:
+            failed = True
+
+    if arguments.expected_samples is not None:
+        for variant, trace_count in trace_counts.items():
+            if trace_count > 0 and len(variants[variant]) != arguments.expected_samples:
+                print(
+                    f"{variant}: expected exactly {arguments.expected_samples} {TRACE_SECTION} samples"
+                    f", found {len(variants[variant])}",
+                    file=sys.stderr,
+                )
+                failed = True
+
+    for trace, section_count in per_trace_section_counts.items():
+        if section_count != 1:
             print(
-                f"{variant}: expected exactly {arguments.expected_samples} {TRACE_SECTION} samples"
-                f" (one per cold-start iteration), found {len(variants[variant])}",
+                f"{trace}: expected exactly one {TRACE_SECTION} section, found {section_count};"
+                " app atrace may not be enabled, or the activity may have initialized more than once",
                 file=sys.stderr,
             )
-            return 1
-    return 0
+            failed = True
+    return 1 if failed else 0
 
 
 if __name__ == "__main__":

--- a/scripts/analyze_native_startup_trace.py
+++ b/scripts/analyze_native_startup_trace.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Summarizes Backtrace native-startup Perfetto traces.
+
+Emits JSON with the BacktraceQualification#tryEnableNativeIntegration section sample count,
+median/p95 duration, baseline-versus-fixture delta, and forbidden-symbol matches where callstack
+data exists. When traces carry no callstack samples, callstack_coverage is reported as false
+rather than claiming a clean runtime stack: the static source guard remains the hard automated
+proof that no APK archive reader runs during native initialization.
+"""
+
+import argparse
+import glob
+import json
+import statistics
+import subprocess
+import sys
+
+TRACE_SECTION = "BacktraceQualification#tryEnableNativeIntegration"
+FORBIDDEN_SYMBOLS = (
+    "ZipFile$Source.initCEN",
+    "java.util.zip.ZipFile",
+    "java.util.zip.ZipInputStream",
+    "java.util.jar.JarFile",
+    "java.util.jar.JarInputStream",
+    "apkContains",
+)
+
+
+def query(trace_processor: str, trace: str, sql: str) -> list:
+    completed = subprocess.run(
+        [trace_processor, "-q", "/dev/stdin", trace],
+        input=sql.encode(),
+        capture_output=True,
+        check=True,
+    )
+    rows = completed.stdout.decode().strip().splitlines()
+    return rows[1:] if len(rows) > 1 else []
+
+
+def section_durations_ms(trace_processor: str, trace: str) -> list:
+    sql = (
+        'select dur from slice where name = "' + TRACE_SECTION + '"'
+    )
+    durations = []
+    for row in query(trace_processor, trace, sql):
+        try:
+            durations.append(int(row.strip().split(",")[-1]) / 1_000_000.0)
+        except ValueError:
+            continue
+    return durations
+
+
+def forbidden_matches(trace_processor: str, trace: str) -> tuple:
+    coverage_rows = query(
+        trace_processor,
+        trace,
+        "select count(*) from stack_profile_frame",
+    )
+    has_callstacks = False
+    for row in coverage_rows:
+        try:
+            has_callstacks = int(row.strip().split(",")[-1]) > 0
+        except ValueError:
+            pass
+    matches = []
+    if has_callstacks:
+        for symbol in FORBIDDEN_SYMBOLS:
+            rows = query(
+                trace_processor,
+                trace,
+                'select count(*) from stack_profile_frame where name like "%' + symbol + '%"',
+            )
+            for row in rows:
+                try:
+                    if int(row.strip().split(",")[-1]) > 0:
+                        matches.append(symbol)
+                except ValueError:
+                    continue
+    return has_callstacks, matches
+
+
+def summarize(durations: list) -> dict:
+    if not durations:
+        return {"samples": 0}
+    ordered = sorted(durations)
+    p95_index = max(0, int(round(0.95 * len(ordered))) - 1)
+    return {
+        "samples": len(ordered),
+        "median_ms": round(statistics.median(ordered), 3),
+        "p95_ms": round(ordered[p95_index], 3),
+        "max_ms": round(ordered[-1], 3),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--trace-processor", required=True)
+    parser.add_argument("--traces", required=True, help="directory of .perfetto-trace files")
+    parser.add_argument("--output", required=True)
+    arguments = parser.parse_args()
+
+    variants = {"baseline": [], "fixture": []}
+    trace_counts = {"baseline": 0, "fixture": 0}
+    callstack_coverage = False
+    matches = set()
+    for trace in sorted(glob.glob(arguments.traces + "/*.perfetto-trace")):
+        variant = "fixture" if "/fixture-" in trace or "fixture-" in trace.rsplit("/", 1)[-1] else "baseline"
+        trace_counts[variant] += 1
+        variants[variant].extend(section_durations_ms(arguments.trace_processor, trace))
+        covered, trace_matches = forbidden_matches(arguments.trace_processor, trace)
+        callstack_coverage = callstack_coverage or covered
+        matches.update(trace_matches)
+
+    baseline = summarize(variants["baseline"])
+    fixture = summarize(variants["fixture"])
+    delta = None
+    if baseline.get("samples") and fixture.get("samples"):
+        delta = round(fixture["median_ms"] - baseline["median_ms"], 3)
+
+    summary = {
+        "trace_section": TRACE_SECTION,
+        "baseline": baseline,
+        "fixture": fixture,
+        "median_delta_ms": delta,
+        "forbidden_symbol_matches": sorted(matches),
+        "callstack_coverage": callstack_coverage,
+    }
+    with open(arguments.output, "w") as output:
+        json.dump(summary, output, indent=2)
+    print(json.dumps(summary, indent=2))
+
+    if matches:
+        print("Forbidden symbols present in runtime callstacks", file=sys.stderr)
+        return 1
+    for variant, count in trace_counts.items():
+        if count > 0 and not variants[variant]:
+            print(
+                f"{variant}: {count} trace(s) captured but zero {TRACE_SECTION} samples;"
+                " app atrace was probably not enabled for the package",
+                file=sys.stderr,
+            )
+            return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_native_startup_perfetto.sh
+++ b/scripts/capture_native_startup_perfetto.sh
@@ -6,18 +6,28 @@ set -euo pipefail
 # --with-fixture is set, a large-central-directory build of the example app, so the analyzer can
 # prove initialization cost does not scale with APK ZIP entry count.
 #
+# Fail-closed: every iteration must produce (1) an app result JSON proving
+# tryEnableNativeIntegration() ran and returned true, and (2) a fresh, non-empty trace. A failed
+# Perfetto capture fails the run. The analyzer requires exactly one trace-section sample per
+# captured iteration.
+#
 # Usage:
 #   scripts/capture_native_startup_perfetto.sh \
-#     --package <package> --activity <activity> --iterations 10 --output <dir> [--with-fixture]
+#     --package <package> --activity <activity> --iterations 10 --output <dir> \
+#     [--with-fixture] [--capture-only]
 #
-# The raw .perfetto-trace files are retained; the analyzer runs only when a pinned
-# trace_processor_shell is provided through TRACE_PROCESSOR_SHELL (never downloaded as "latest").
+# Qualification requires a pinned trace_processor_shell via TRACE_PROCESSOR_SHELL (never
+# downloaded as "latest"). Without one, the run must be explicitly requested as --capture-only:
+# raw traces are retained but the run is NOT a completed qualification.
 
 package=""
 activity=".NativeStartupQualificationActivity"
 iterations=10
 output=""
 with_fixture=0
+capture_only=0
+result_file="files/native-startup-qualification.json"
+remote_trace="/data/misc/perfetto-traces/qualification.perfetto-trace"
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -26,6 +36,7 @@ while [ $# -gt 0 ]; do
         --iterations) iterations="$2"; shift 2 ;;
         --output) output="$2"; shift 2 ;;
         --with-fixture) with_fixture=1; shift ;;
+        --capture-only) capture_only=1; shift ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
@@ -38,8 +49,38 @@ if [ "$iterations" -lt 10 ]; then
     echo "At least 10 iterations are required for stable percentiles" >&2
     exit 2
 fi
+if [ "$capture_only" = "0" ] && { [ -z "${TRACE_PROCESSOR_SHELL:-}" ] || [ ! -x "${TRACE_PROCESSOR_SHELL:-}" ]; }; then
+    echo "TRACE_PROCESSOR_SHELL is not an executable pinned trace processor." >&2
+    echo "Provide one for qualification, or pass --capture-only to record raw traces only." >&2
+    exit 2
+fi
 
 mkdir -p "$output"
+# Stale traces from a previous run must never pass as this run's evidence: the analyzer globs the
+# whole directory, so a reused directory could satisfy --expected-samples with old captures.
+if ls "$output"/*.perfetto-trace > /dev/null 2>&1; then
+    echo "Output directory $output already contains traces; use a fresh directory per run." >&2
+    exit 2
+fi
+
+# Pin the baseline APK identity: baseline iterations must measure a known, freshly installed
+# build, not whatever happens to be on the device (for example a leftover fixture install).
+baseline_apk="example-app/build/outputs/apk/debug/example-app-debug.apk"
+test -f "$baseline_apk"
+baseline_apk_copy="$output/baseline.apk"
+cp "$baseline_apk" "$baseline_apk_copy"
+python3 - "$baseline_apk_copy" "$output" <<'PY'
+import sys
+import zipfile
+
+apk, output = sys.argv[1], sys.argv[2]
+count = len(zipfile.ZipFile(apk).namelist())
+with open(output + "/baseline-apk-entry-count.txt", "w") as record:
+    record.write(str(count) + "\n")
+print("baseline APK entry count:", count)
+PY
+adb install -r "$baseline_apk_copy" > /dev/null
+
 fixture_dir="example-app/build/native-startup-fixture/assets"
 
 cleanup_fixture() {
@@ -59,17 +100,44 @@ capture_variant() {
     local iteration
     for iteration in $(seq 1 "$iterations"); do
         local trace_file="$output/$variant-$iteration.perfetto-trace"
+
+        # Fresh state per iteration: a stale result or trace must never satisfy this iteration.
         adb shell am force-stop "$package"
+        adb shell run-as "$package" rm -f "$result_file"
+        adb shell rm -f "$remote_trace"
         sleep 1
 
-        adb shell perfetto -o /data/misc/perfetto-traces/qualification.perfetto-trace \
+        adb shell perfetto -o "$remote_trace" \
             -t 20s --app "$package" sched freq idle am wm view binder_driver &
         local perfetto_pid=$!
         sleep 2
 
         adb shell am start -n "$package/$activity" -W > /dev/null
-        wait "$perfetto_pid" || true
-        adb pull /data/misc/perfetto-traces/qualification.perfetto-trace "$trace_file" > /dev/null
+
+        # A failed Perfetto capture is a hard failure, not a skipped iteration.
+        if ! wait "$perfetto_pid"; then
+            echo "$variant iteration $iteration: perfetto capture failed" >&2
+            exit 1
+        fi
+
+        # The activity result must prove the production init path ran and enabled native capture;
+        # a missing submission URL or a false return must fail the iteration.
+        local result_json
+        if ! result_json="$(adb shell run-as "$package" cat "$result_file" 2>/dev/null)" \
+                || [ -z "$result_json" ]; then
+            echo "$variant iteration $iteration: app result JSON is missing" >&2
+            exit 1
+        fi
+        if ! echo "$result_json" | grep -q '"native_enabled":true'; then
+            echo "$variant iteration $iteration: native integration did not enable: $result_json" >&2
+            exit 1
+        fi
+
+        adb pull "$remote_trace" "$trace_file" > /dev/null
+        if [ ! -s "$trace_file" ]; then
+            echo "$variant iteration $iteration: pulled trace is missing or empty" >&2
+            exit 1
+        fi
     done
 }
 
@@ -92,17 +160,37 @@ with open(output + "/fixture-apk-entry-count.txt", "w") as record:
     record.write(str(count) + "\n")
 print("fixture APK entry count:", count)
 PY
+    python3 - "$apk" "$output" <<'PY'
+import sys
+
+apk, output = sys.argv[1], sys.argv[2]
+with open(output + "/baseline-apk-entry-count.txt") as record:
+    baseline_count = int(record.read().strip())
+with open(output + "/fixture-apk-entry-count.txt") as record:
+    fixture_count = int(record.read().strip())
+if fixture_count <= baseline_count:
+    raise SystemExit(
+        f"Fixture APK ({fixture_count} entries) is not larger than baseline ({baseline_count});"
+        " the large-central-directory build did not take effect"
+    )
+PY
     adb install -r "$apk" > /dev/null
     capture_variant fixture
+    # Leave the device in the baseline state so a later run cannot capture its baseline from the
+    # leftover 10k-entry fixture install.
+    adb install -r "$baseline_apk_copy" > /dev/null
 fi
 
-if [ -n "${TRACE_PROCESSOR_SHELL:-}" ] && [ -x "${TRACE_PROCESSOR_SHELL}" ]; then
-    python3 scripts/analyze_native_startup_trace.py \
-        --trace-processor "$TRACE_PROCESSOR_SHELL" \
-        --traces "$output" \
-        --output "$output/native-startup-summary.json"
-else
-    echo "TRACE_PROCESSOR_SHELL not set; raw traces retained in $output, analyzer skipped."
+if [ "$capture_only" = "1" ]; then
+    echo "CAPTURE-ONLY MODE: raw traces retained in $output."
+    echo "This run is NOT a completed startup qualification; analyze with a pinned trace processor."
+    exit 0
 fi
 
-echo "Perfetto capture complete: $output"
+python3 scripts/analyze_native_startup_trace.py \
+    --trace-processor "$TRACE_PROCESSOR_SHELL" \
+    --traces "$output" \
+    --expected-samples "$iterations" \
+    --output "$output/native-startup-summary.json"
+
+echo "Perfetto startup qualification complete: $output"

--- a/scripts/capture_native_startup_perfetto.sh
+++ b/scripts/capture_native_startup_perfetto.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Cold-start Perfetto capture around the Backtrace native-initialization trace section
-# (BacktraceQualification#tryEnableNativeIntegration). Captures a baseline package and, when
+# Example-app-only cold-start Perfetto capture around the Backtrace native-initialization trace
+# section (BacktraceQualification#tryEnableNativeIntegration). Captures a baseline build and, when
 # --with-fixture is set, a large-central-directory build of the example app, so the analyzer can
 # prove initialization cost does not scale with APK ZIP entry count.
 #
@@ -13,15 +13,21 @@ set -euo pipefail
 #
 # Usage:
 #   scripts/capture_native_startup_perfetto.sh \
-#     --package <package> --activity <activity> --iterations 10 --output <dir> \
+#     --iterations 10 --output <dir> \
 #     [--with-fixture] [--capture-only]
+#
+# The optional --package and --activity arguments are retained only for explicitness and must name
+# the repository's example-app qualification activity. This public harness does not operate on
+# arbitrary installed applications.
 #
 # Qualification requires a pinned trace_processor_shell via TRACE_PROCESSOR_SHELL (never
 # downloaded as "latest"). Without one, the run must be explicitly requested as --capture-only:
 # raw traces are retained but the run is NOT a completed qualification.
 
-package=""
-activity=".NativeStartupQualificationActivity"
+example_package="backtraceio.backtraceio"
+example_activity=".NativeStartupQualificationActivity"
+package="$example_package"
+activity="$example_activity"
 iterations=10
 output=""
 with_fixture=0
@@ -41,8 +47,12 @@ while [ $# -gt 0 ]; do
     esac
 done
 
-if [ -z "$package" ] || [ -z "$output" ]; then
-    echo "--package and --output are required" >&2
+if [ -z "$output" ]; then
+    echo "--output is required" >&2
+    exit 2
+fi
+if [ "$package" != "$example_package" ] || [ "$activity" != "$example_activity" ]; then
+    echo "This harness only supports $example_package/$example_activity from example-app." >&2
     exit 2
 fi
 if [ "$iterations" -lt 10 ]; then
@@ -55,21 +65,54 @@ if [ "$capture_only" = "0" ] && { [ -z "${TRACE_PROCESSOR_SHELL:-}" ] || [ ! -x 
     exit 2
 fi
 
+if [ -L "$output" ] || { [ -e "$output" ] && [ ! -d "$output" ]; }; then
+    echo "Output path must be a directory and must not be a symbolic link: $output" >&2
+    exit 2
+fi
+fixture_root="example-app/build/native-startup-fixture"
+fixture_dir="$fixture_root/assets"
+if ! python3 - "$output" "$fixture_root" <<'PY'
+import os
+import sys
+
+output, fixture_root = (os.path.realpath(path) for path in sys.argv[1:])
+if os.path.commonpath((output, fixture_root)) == fixture_root:
+    raise SystemExit("Evidence output must be outside the generated fixture directory")
+PY
+then
+    exit 2
+fi
 mkdir -p "$output"
-# Stale traces from a previous run must never pass as this run's evidence: the analyzer globs the
-# whole directory, so a reused directory could satisfy --expected-samples with old captures.
-if ls "$output"/*.perfetto-trace > /dev/null 2>&1; then
-    echo "Output directory $output already contains traces; use a fresh directory per run." >&2
+# Every evidence item must belong to this run. Reusing even a trace-free directory could retain an
+# old result JSON, summary, or device-facts file and make the artifact internally inconsistent.
+if [ -n "$(find "$output" -mindepth 1 -maxdepth 1 -print -quit)" ]; then
+    echo "Output directory $output is not empty; use a fresh directory per run." >&2
     exit 2
 fi
 
 # Pin the baseline APK identity: baseline iterations must measure a known, freshly installed
 # build, not whatever happens to be on the device (for example a leftover fixture install).
+./gradlew :example-app:assembleDebug
 baseline_apk="example-app/build/outputs/apk/debug/example-app-debug.apk"
 test -f "$baseline_apk"
-baseline_apk_copy="$output/baseline.apk"
+baseline_apk_copy="$(mktemp "${TMPDIR:-/tmp}/backtrace-native-startup-baseline-apk.XXXXXX")"
+baseline_copy_ready=0
+
+cleanup_fixture() {
+    if [ "$baseline_copy_ready" = "1" ]; then
+        # A fixture build overwrites Gradle's normal debug output. Restore the exact baseline APK so
+        # a later baseline-only invocation cannot accidentally measure the large-entry fixture.
+        cp -- "$baseline_apk_copy" "$baseline_apk"
+    fi
+    rm -f -- "$baseline_apk_copy"
+    rm -rf -- "$fixture_root"
+}
+trap cleanup_fixture EXIT
+
 cp "$baseline_apk" "$baseline_apk_copy"
+baseline_copy_ready=1
 python3 - "$baseline_apk_copy" "$output" <<'PY'
+import hashlib
 import sys
 import zipfile
 
@@ -77,16 +120,17 @@ apk, output = sys.argv[1], sys.argv[2]
 count = len(zipfile.ZipFile(apk).namelist())
 with open(output + "/baseline-apk-entry-count.txt", "w") as record:
     record.write(str(count) + "\n")
+sha256 = hashlib.sha256()
+with open(apk, "rb") as apk_file:
+    for chunk in iter(lambda: apk_file.read(1024 * 1024), b""):
+        sha256.update(chunk)
+digest = sha256.hexdigest()
+with open(output + "/baseline-apk-sha256.txt", "w") as record:
+    record.write(digest + "\n")
 print("baseline APK entry count:", count)
+print("baseline APK sha256:", digest)
 PY
 adb install -r "$baseline_apk_copy" > /dev/null
-
-fixture_dir="example-app/build/native-startup-fixture/assets"
-
-cleanup_fixture() {
-    rm -rf "example-app/build/native-startup-fixture"
-}
-trap cleanup_fixture EXIT
 
 {
     echo "model=$(adb shell getprop ro.product.model | tr -d '\r')"
@@ -122,14 +166,40 @@ capture_variant() {
 
         # The activity result must prove the production init path ran and enabled native capture;
         # a missing submission URL or a false return must fail the iteration.
-        local result_json
-        if ! result_json="$(adb shell run-as "$package" cat "$result_file" 2>/dev/null)" \
-                || [ -z "$result_json" ]; then
+        local result_output="$output/$variant-$iteration-result.json"
+        if ! adb shell run-as "$package" cat "$result_file" > "$result_output" 2>/dev/null \
+                || [ ! -s "$result_output" ]; then
             echo "$variant iteration $iteration: app result JSON is missing" >&2
             exit 1
         fi
-        if ! echo "$result_json" | grep -q '"native_enabled":true'; then
-            echo "$variant iteration $iteration: native integration did not enable: $result_json" >&2
+        if ! python3 - "$result_output" "$variant" "$iteration" <<'PY'
+import json
+import sys
+
+path, variant, iteration = sys.argv[1:]
+try:
+    with open(path, encoding="utf-8") as result_file:
+        result = json.load(result_file)
+except (OSError, UnicodeError, json.JSONDecodeError) as error:
+    raise SystemExit(f"{variant} iteration {iteration}: invalid app result JSON: {error}")
+
+if not isinstance(result, dict):
+    raise SystemExit(f"{variant} iteration {iteration}: app result must be a JSON object")
+if result.get("trace_section") != "BacktraceQualification#tryEnableNativeIntegration":
+    raise SystemExit(f"{variant} iteration {iteration}: app result names the wrong trace section")
+if result.get("native_enabled") is not True:
+    raise SystemExit(f"{variant} iteration {iteration}: native integration did not enable")
+duration_nanos = result.get("duration_nanos")
+if not isinstance(duration_nanos, int) or isinstance(duration_nanos, bool) or duration_nanos <= 0:
+    raise SystemExit(f"{variant} iteration {iteration}: invalid duration_nanos")
+
+# Rewrite validated results in a consistent format so every iteration has reviewable evidence.
+with open(path, "w", encoding="utf-8") as result_file:
+    json.dump(result, result_file, indent=2, sort_keys=True)
+    result_file.write("\n")
+PY
+        then
+            echo "$variant iteration $iteration: app result validation failed" >&2
             exit 1
         fi
 
@@ -187,10 +257,17 @@ if [ "$capture_only" = "1" ]; then
     exit 0
 fi
 
+expected_fixture_traces=0
+if [ "$with_fixture" = "1" ]; then
+    expected_fixture_traces="$iterations"
+fi
+
 python3 scripts/analyze_native_startup_trace.py \
     --trace-processor "$TRACE_PROCESSOR_SHELL" \
     --traces "$output" \
     --expected-samples "$iterations" \
+    --expected-baseline-traces "$iterations" \
+    --expected-fixture-traces "$expected_fixture_traces" \
     --output "$output/native-startup-summary.json"
 
 echo "Perfetto startup qualification complete: $output"

--- a/scripts/capture_native_startup_perfetto.sh
+++ b/scripts/capture_native_startup_perfetto.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Cold-start Perfetto capture around the Backtrace native-initialization trace section
+# (BacktraceQualification#tryEnableNativeIntegration). Captures a baseline package and, when
+# --with-fixture is set, a large-central-directory build of the example app, so the analyzer can
+# prove initialization cost does not scale with APK ZIP entry count.
+#
+# Usage:
+#   scripts/capture_native_startup_perfetto.sh \
+#     --package <package> --activity <activity> --iterations 10 --output <dir> [--with-fixture]
+#
+# The raw .perfetto-trace files are retained; the analyzer runs only when a pinned
+# trace_processor_shell is provided through TRACE_PROCESSOR_SHELL (never downloaded as "latest").
+
+package=""
+activity=".NativeStartupQualificationActivity"
+iterations=10
+output=""
+with_fixture=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --package) package="$2"; shift 2 ;;
+        --activity) activity="$2"; shift 2 ;;
+        --iterations) iterations="$2"; shift 2 ;;
+        --output) output="$2"; shift 2 ;;
+        --with-fixture) with_fixture=1; shift ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$package" ] || [ -z "$output" ]; then
+    echo "--package and --output are required" >&2
+    exit 2
+fi
+if [ "$iterations" -lt 10 ]; then
+    echo "At least 10 iterations are required for stable percentiles" >&2
+    exit 2
+fi
+
+mkdir -p "$output"
+fixture_dir="example-app/build/native-startup-fixture/assets"
+
+cleanup_fixture() {
+    rm -rf "example-app/build/native-startup-fixture"
+}
+trap cleanup_fixture EXIT
+
+{
+    echo "model=$(adb shell getprop ro.product.model | tr -d '\r')"
+    echo "sdk=$(adb shell getprop ro.build.version.sdk | tr -d '\r')"
+    echo "abi=$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+    echo "page_size=$(adb shell getconf PAGE_SIZE | tr -d '\r')"
+} | tee "$output/device-facts.txt"
+
+capture_variant() {
+    local variant="$1"
+    local iteration
+    for iteration in $(seq 1 "$iterations"); do
+        local trace_file="$output/$variant-$iteration.perfetto-trace"
+        adb shell am force-stop "$package"
+        sleep 1
+
+        adb shell perfetto -o /data/misc/perfetto-traces/qualification.perfetto-trace \
+            -t 20s --app "$package" sched freq idle am wm view binder_driver &
+        local perfetto_pid=$!
+        sleep 2
+
+        adb shell am start -n "$package/$activity" -W > /dev/null
+        wait "$perfetto_pid" || true
+        adb pull /data/misc/perfetto-traces/qualification.perfetto-trace "$trace_file" > /dev/null
+    done
+}
+
+echo "== baseline capture =="
+capture_variant baseline
+
+if [ "$with_fixture" = "1" ]; then
+    echo "== large-central-directory fixture capture =="
+    python3 scripts/generate_native_startup_fixture.py \
+        --entries 10000 --bytes-per-entry 1 --output "$fixture_dir"
+    ./gradlew :example-app:assembleDebug -PnativeStartupFixtureAssets="$PWD/$fixture_dir"
+    apk="example-app/build/outputs/apk/debug/example-app-debug.apk"
+    python3 - "$apk" "$output" <<'PY'
+import sys
+import zipfile
+
+apk, output = sys.argv[1], sys.argv[2]
+count = len(zipfile.ZipFile(apk).namelist())
+with open(output + "/fixture-apk-entry-count.txt", "w") as record:
+    record.write(str(count) + "\n")
+print("fixture APK entry count:", count)
+PY
+    adb install -r "$apk" > /dev/null
+    capture_variant fixture
+fi
+
+if [ -n "${TRACE_PROCESSOR_SHELL:-}" ] && [ -x "${TRACE_PROCESSOR_SHELL}" ]; then
+    python3 scripts/analyze_native_startup_trace.py \
+        --trace-processor "$TRACE_PROCESSOR_SHELL" \
+        --traces "$output" \
+        --output "$output/native-startup-summary.json"
+else
+    echo "TRACE_PROCESSOR_SHELL not set; raw traces retained in $output, analyzer skipped."
+fi
+
+echo "Perfetto capture complete: $output"

--- a/scripts/check_native_ci_policy.sh
+++ b/scripts/check_native_ci_policy.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# CI trust/supply-chain policy checker for the test workflow. Fails on:
+#   - an unpinned external `uses:` (anything not pinned to a full 40-hex commit SHA)
+#   - `saucectl-version: latest`
+#   - `pull_request_target`
+#   - ACCESS_TOKEN used in checkout
+#   - a repository-secret reference in a job not gated by the trusted policy output
+#     (workflow_dispatch-only jobs count as trusted: forks cannot dispatch them)
+#   - `|| true` on a workflow gate command
+#   - missing `permissions:` with `contents: read`
+#   - missing API 21/22 legacy lane
+#   - missing 16 KB runtime image (google_apis_ps16k)
+#   - missing fatal-process gate (RUN_FATAL=1)
+#
+# Usage: scripts/check_native_ci_policy.sh <workflow-file>
+
+workflow="${1:?usage: $0 <workflow-file>}"
+if [ ! -f "$workflow" ]; then
+    echo "Workflow file not found: $workflow" >&2
+    exit 1
+fi
+
+python3 - "$workflow" <<'PY'
+import re
+import sys
+
+path = sys.argv[1]
+text = open(path, encoding="utf-8").read()
+lines = text.splitlines()
+violations = []
+
+# Rule: pull_request_target is never allowed.
+if re.search(r"^\s*pull_request_target\s*:", text, re.M):
+    violations.append("pull_request_target must not be used")
+
+# Rule: permissions: contents: read at the workflow level.
+if not re.search(r"^permissions:\s*$", text, re.M) or not re.search(r"^\s+contents:\s*read\s*$", text, re.M):
+    violations.append("workflow must declare permissions: contents: read")
+
+# Rule: every external action pinned to a full commit SHA.
+for number, line in enumerate(lines, 1):
+    match = re.search(r"uses:\s*([^\s#]+)", line)
+    if not match:
+        continue
+    ref = match.group(1)
+    if "@" not in ref:
+        violations.append(f"line {number}: action without a ref: {ref}")
+        continue
+    sha = ref.rsplit("@", 1)[1]
+    if not re.fullmatch(r"[0-9a-f]{40}", sha):
+        violations.append(f"line {number}: action not pinned to a full commit SHA: {ref}")
+
+# Rule: no `saucectl-version: latest`.
+if re.search(r"saucectl-version:\s*latest", text):
+    violations.append("saucectl-version must be pinned, not latest")
+
+# Rule: ACCESS_TOKEN must not be used for checkout.
+if "ACCESS_TOKEN" in text:
+    violations.append("ACCESS_TOKEN must not be referenced; submodules are public over HTTPS")
+
+# Rule: no `|| true` in workflow run blocks (gates live in scripts, where only
+# diagnostics may be non-gating).
+for number, line in enumerate(lines, 1):
+    if "|| true" in line:
+        violations.append(f"line {number}: '|| true' is not allowed on a workflow command")
+
+# Rule: repository secrets only in trusted-gated jobs. Split on top-level job keys.
+job_starts = [
+    (index, re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line).group(1))
+    for index, line in enumerate(lines)
+    if re.match(r"^  ([A-Za-z0-9_-]+):\s*$", line)
+]
+jobs_index = next((i for i, line in enumerate(lines) if line.strip() == "jobs:"), None)
+if jobs_index is not None:
+    job_starts = [(i, name) for i, name in job_starts if i > jobs_index]
+    for position, (start, name) in enumerate(job_starts):
+        end = job_starts[position + 1][0] if position + 1 < len(job_starts) else len(lines)
+        body = "\n".join(lines[start:end])
+        secret_refs = [
+            secret
+            for secret in re.findall(r"secrets\.([A-Za-z0-9_]+)", body)
+            if secret not in ("GITHUB_TOKEN",)
+        ]
+        if not secret_refs:
+            continue
+        trusted_gated = "needs.policy.outputs.trusted == 'true'" in body
+        dispatch_gated = "github.event_name == 'workflow_dispatch'" in body
+        if not trusted_gated and not dispatch_gated:
+            violations.append(
+                f"job '{name}' references secrets ({', '.join(sorted(set(secret_refs)))})"
+                " without a trusted-policy gate"
+            )
+
+# Rule: required lanes present.
+if not re.search(r"api-level:\s*\[\s*21\s*,\s*22\s*\]", text):
+    violations.append("missing API 21/22 legacy lane")
+if "google_apis_ps16k" not in text:
+    violations.append("missing 16 KB runtime lane (google_apis_ps16k)")
+if "RUN_FATAL=1" not in text and "run_16kb_native_qualification.sh" not in text:
+    violations.append("missing fatal-process gate (RUN_FATAL=1)")
+
+if violations:
+    for violation in violations:
+        print("CI policy violation: " + violation, file=sys.stderr)
+    sys.exit(1)
+
+print(f"CI policy check passed for {path}.")
+PY

--- a/scripts/check_native_ci_policy_selftest.sh
+++ b/scripts/check_native_ci_policy_selftest.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Self-test for check_native_ci_policy.sh: the real workflow must pass, and a sabotaged copy per
+# rule must fail. Run from the repository root.
+
+checker="scripts/check_native_ci_policy.sh"
+workflow=".github/workflows/test.yml"
+if [ ! -f "$checker" ] || [ ! -f "$workflow" ]; then
+    echo "Self-test must run from the repository root" >&2
+    exit 1
+fi
+
+sandbox="$(mktemp -d)"
+trap 'rm -rf "$sandbox"' EXIT
+
+failures=0
+
+expect_pass() {
+    if ! "$checker" "$1" > /dev/null 2>&1; then
+        echo "FAIL: checker rejected $2" >&2
+        failures=1
+    fi
+}
+
+expect_fail() {
+    if "$checker" "$1" > /dev/null 2>&1; then
+        echo "FAIL: checker accepted a workflow with $2" >&2
+        failures=1
+    fi
+}
+
+expect_pass "$workflow" "the real workflow"
+
+sabotage() {
+    local name="$1"
+    local python_expr="$2"
+    local copy="$sandbox/$name.yml"
+    python3 - "$workflow" "$copy" "$python_expr" <<'PY'
+import sys
+
+source, destination, expression = sys.argv[1], sys.argv[2], sys.argv[3]
+text = open(source, encoding="utf-8").read()
+text = eval(expression, {"text": text})
+open(destination, "w", encoding="utf-8").write(text)
+PY
+    echo "$copy"
+}
+
+expect_fail "$(sabotage unpinned \
+    "text.replace('reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d', 'reactivecircus/android-emulator-runner@v2', 1)")" \
+    "an unpinned action"
+
+expect_fail "$(sabotage saucectl-latest \
+    "text.replace('saucectl-version: 0.213.0', 'saucectl-version: latest')")" \
+    "saucectl-version: latest"
+
+expect_fail "$(sabotage prt \
+    "text.replace('  pull_request:', '  pull_request_target:', 1)")" \
+    "pull_request_target"
+
+expect_fail "$(sabotage access-token \
+    "text.replace('persist-credentials: false', 'token: \${{ secrets.ACCESS_TOKEN }}', 1)")" \
+    "ACCESS_TOKEN in checkout"
+
+expect_fail "$(sabotage ungated-secret \
+    "text.replace(\"if: needs.policy.outputs.trusted == 'true'\", 'timeout-minutes: 59')")" \
+    "secrets outside a trusted-gated job"
+
+expect_fail "$(sabotage or-true \
+    "text.replace('run: scripts/check_no_native_init_apk_zip_scan.sh', 'run: scripts/check_no_native_init_apk_zip_scan.sh || true', 1)")" \
+    "|| true on a gate"
+
+expect_fail "$(sabotage no-permissions \
+    "text.replace('permissions:\\n  contents: read\\n', '')")" \
+    "missing permissions: contents: read"
+
+expect_fail "$(sabotage no-legacy \
+    "text.replace('api-level: [21, 22]', 'api-level: [30]')")" \
+    "missing API 21/22 lane"
+
+expect_fail "$(sabotage no-16kb \
+    "text.replace('google_apis_ps16k', 'google_apis')")" \
+    "missing 16 KB runtime lane"
+
+expect_fail "$(sabotage no-fatal \
+    "text.replace('RUN_FATAL=1', 'RUN_FATAL=0').replace('run_16kb_native_qualification.sh', 'run_split_install_test.sh')")" \
+    "missing fatal-process gate"
+
+if [ "$failures" -ne 0 ]; then
+    echo "CI policy self-test FAILED." >&2
+    exit 1
+fi
+
+echo "CI policy self-test passed: real workflow accepted, 10 sabotaged variants rejected."

--- a/scripts/generate_native_startup_fixture.py
+++ b/scripts/generate_native_startup_fixture.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+"""Generates a disposable large-central-directory asset fixture for startup qualification.
+
+The generated files go into a build/work directory, never into Git: they exist only to inflate the
+APK ZIP central-directory entry count so a startup trace can prove Backtrace initialization cost
+does not scale with it.
+
+Usage:
+    scripts/generate_native_startup_fixture.py --entries 10000 --bytes-per-entry 1 --output <dir>
+"""
+
+import argparse
+import os
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--entries", type=int, default=10000)
+    parser.add_argument("--bytes-per-entry", type=int, default=1)
+    parser.add_argument("--output", required=True)
+    arguments = parser.parse_args()
+
+    if arguments.entries < 1 or arguments.bytes_per_entry < 0:
+        print("entries must be >= 1 and bytes-per-entry >= 0", file=sys.stderr)
+        return 2
+
+    output = os.path.abspath(arguments.output)
+    if not any(marker in output for marker in ("build", "tmp", "work")):
+        print(
+            "Refusing to generate fixture assets outside a build/tmp/work directory: " + output,
+            file=sys.stderr,
+        )
+        return 2
+
+    os.makedirs(output, exist_ok=True)
+    payload = b"x" * arguments.bytes_per_entry
+    for index in range(arguments.entries):
+        bucket = os.path.join(output, f"bucket{index // 1000:03d}")
+        os.makedirs(bucket, exist_ok=True)
+        with open(os.path.join(bucket, f"fixture{index:05d}.txt"), "wb") as entry:
+            entry.write(payload)
+
+    print(f"Generated {arguments.entries} fixture entries under {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_16kb_native_qualification.sh
+++ b/scripts/run_16kb_native_qualification.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# 16 KB runtime qualification. ELF alignment is a static property; this proves the complete native
+# integration on a device actually running 16 KB pages: the first command asserts the runtime page
+# size, then the full split-install gate (resolver, fresh-process safety, nonfatal, fatal+recovery,
+# lifecycle) runs with the page-size assertion re-checked inside the gate, plus 16 KB zip alignment
+# of the debug APK.
+
+page_size="$(adb shell getconf PAGE_SIZE | tr -d '\r')"
+test "$page_size" = "16384"
+
+# The zip-alignment check is a hard gate: a missing APK means the caller forgot to build it, not
+# that the check may be skipped.
+apk="example-app/build/outputs/apk/debug/example-app-debug.apk"
+test -f "$apk"
+build_tools_version="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -1)"
+zipalign="$ANDROID_HOME/build-tools/$build_tools_version/zipalign"
+"$zipalign" -c -P 16 -v 4 "$apk" > /dev/null
+echo "zipalign -P 16 check passed for $apk"
+
+EXPECTED_PAGE_SIZE=16384 \
+REQUIRE_INGESTION="${REQUIRE_INGESTION:-1}" \
+RUN_FATAL="${RUN_FATAL:-1}" \
+./scripts/run_split_install_test.sh

--- a/scripts/run_legacy_native_compatibility_test.sh
+++ b/scripts/run_legacy_native_compatibility_test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# API 21/22 verifier, resolver, and clean-process safety lane. Secretless: none of these tests
+# require backend credentials. Run from the repository root with one connected device/emulator.
+
+./gradlew \
+    :example-app:assembleDebug \
+    :example-app:assembleDebugAndroidTest
+
+./gradlew :example-app:connectedDebugAndroidTest \
+    -Pandroid.testInstrumentationRunnerArguments.class=backtraceio.backtraceio.LegacyNativeIntegrationCompatibilityTest,backtraceio.backtraceio.NativeFreshProcessSafetyTest

--- a/scripts/run_native_release_device_gate.sh
+++ b/scripts/run_native_release_device_gate.sh
@@ -19,6 +19,8 @@ set -euo pipefail
 # cannot pass this gate — use REQUIRE_INGESTION=0 scripts/run_split_install_test.sh for that.
 # BUNDLETOOL_JAR must point at the pinned bundletool (default: ./bundletool.jar).
 
+readonly BUNDLETOOL_1_17_2_SHA256="2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae"
+
 abi=""
 require_device_64=""
 require_page_size=""
@@ -60,6 +62,8 @@ require_tool java
 require_tool adb
 require_tool git
 require_tool python3
+require_tool keytool
+require_tool sha256sum
 if [ -z "${ANDROID_HOME:-}" ] || [ ! -d "$ANDROID_HOME" ]; then
     echo "ANDROID_HOME must point at an Android SDK" >&2
     missing=1
@@ -86,6 +90,13 @@ if [ ! -f "$bundletool_jar" ]; then
     missing=1
 fi
 if [ "$missing" -ne 0 ]; then
+    exit 2
+fi
+actual_bundletool_sha256="$(sha256sum -- "$bundletool_jar")"
+actual_bundletool_sha256="${actual_bundletool_sha256%% *}"
+if [ "$actual_bundletool_sha256" != "$BUNDLETOOL_1_17_2_SHA256" ]; then
+    echo "bundletool checksum mismatch: the hardware gate requires bundletool 1.17.2" >&2
+    echo "Expected $BUNDLETOOL_1_17_2_SHA256, found $actual_bundletool_sha256" >&2
     exit 2
 fi
 
@@ -116,10 +127,13 @@ if [ "$require_device_64" = "true" ] && [ -z "$abilist64" ]; then
     echo "Device does not advertise a 64-bit ABI list" >&2
     exit 1
 fi
-if [ "$abi" = "armeabi-v7a" ] && ! echo ",$abilist," | grep -q ",armeabi-v7a,"; then
-    echo "Device does not support armeabi-v7a; cannot run the 32-bit qualification" >&2
-    exit 1
-fi
+case ",$abilist," in
+    *",$abi,"*) ;;
+    *)
+        echo "Device does not advertise requested ABI $abi in ro.product.cpu.abilist" >&2
+        exit 1
+        ;;
+esac
 if [ -n "$require_page_size" ] && [ "$page_size" != "$require_page_size" ]; then
     echo "PAGE_SIZE mismatch: expected $require_page_size, found $page_size" >&2
     exit 1

--- a/scripts/run_native_release_device_gate.sh
+++ b/scripts/run_native_release_device_gate.sh
@@ -2,20 +2,25 @@
 set -euo pipefail
 
 # Hardware release gate for allocated devices (modern arm64 split installs, real 32-bit processes
-# on 64-bit hardware, physical 16 KB devices). Fails clearly when no device is attached; never
-# silently passes. Run from the repository root.
+# on 64-bit hardware, physical 16 KB devices). Fails clearly when no device is attached or a
+# prerequisite is missing; never silently passes. Run from the repository root.
 #
-# Usage:
-#   scripts/run_native_release_device_gate.sh \
-#     --abi arm64-v8a|armeabi-v7a \
-#     --require-device-64-bit true|false \
-#     --require-process-64-bit true|false \
-#     --require-page-size 4096|16384 \
-#     --require-ingestion true
+# Process bitness is derived from the requested ABI — arm64-v8a is a 64-bit process and
+# armeabi-v7a is a 32-bit process — so the two advertised scenarios cannot be misconfigured:
+#
+#   # 64-bit qualification on modern arm64 hardware
+#   scripts/run_native_release_device_gate.sh --abi arm64-v8a --require-device-64-bit true
+#
+#   # 32-bit process on 64-bit-capable hardware (mixed-bitness qualification)
+#   scripts/run_native_release_device_gate.sh --abi armeabi-v7a --require-device-64-bit true
+#
+# Optional: --require-page-size 4096|16384 (empty skips). Ingestion is mandatory: the process-ABI
+# verification reads service-reported facts out of the ingestion evidence, so a secretless run
+# cannot pass this gate — use REQUIRE_INGESTION=0 scripts/run_split_install_test.sh for that.
+# BUNDLETOOL_JAR must point at the pinned bundletool (default: ./bundletool.jar).
 
 abi=""
 require_device_64=""
-require_process_64=""
 require_page_size=""
 require_ingestion="true"
 
@@ -23,15 +28,64 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --abi) abi="$2"; shift 2 ;;
         --require-device-64-bit) require_device_64="$2"; shift 2 ;;
-        --require-process-64-bit) require_process_64="$2"; shift 2 ;;
         --require-page-size) require_page_size="$2"; shift 2 ;;
         --require-ingestion) require_ingestion="$2"; shift 2 ;;
         *) echo "Unknown argument: $1" >&2; exit 2 ;;
     esac
 done
 
-if [ -z "$abi" ]; then
-    echo "--abi is required" >&2
+if [ "$require_ingestion" != "true" ]; then
+    echo "The hardware release gate requires ingestion (--require-ingestion true):" >&2
+    echo "process-ABI verification reads service-reported facts from the ingestion evidence." >&2
+    echo "For secretless checks use REQUIRE_INGESTION=0 scripts/run_split_install_test.sh." >&2
+    exit 2
+fi
+
+case "$abi" in
+    arm64-v8a) expect_64_bit_process=true ;;
+    armeabi-v7a) expect_64_bit_process=false ;;
+    "") echo "--abi is required (arm64-v8a or armeabi-v7a)" >&2; exit 2 ;;
+    *) echo "Unsupported --abi '$abi' (arm64-v8a or armeabi-v7a)" >&2; exit 2 ;;
+esac
+
+# --- prerequisites: self-hosted runners carry no guarantees --------------------------------------
+missing=0
+require_tool() {
+    if ! command -v "$1" > /dev/null 2>&1; then
+        echo "Missing required tool: $1" >&2
+        missing=1
+    fi
+}
+require_tool java
+require_tool adb
+require_tool git
+require_tool python3
+if [ -z "${ANDROID_HOME:-}" ] || [ ! -d "$ANDROID_HOME" ]; then
+    echo "ANDROID_HOME must point at an Android SDK" >&2
+    missing=1
+else
+    build_tools_version=""
+    if [ -d "$ANDROID_HOME/build-tools" ]; then
+        build_tools_version="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -1)"
+    fi
+    if [ -z "$build_tools_version" ]; then
+        echo "No build-tools installed under $ANDROID_HOME/build-tools" >&2
+        missing=1
+    else
+        for tool in apksigner zipalign; do
+            if [ ! -x "$ANDROID_HOME/build-tools/$build_tools_version/$tool" ]; then
+                echo "Missing $tool in build-tools $build_tools_version" >&2
+                missing=1
+            fi
+        done
+    fi
+fi
+bundletool_jar="${BUNDLETOOL_JAR:-bundletool.jar}"
+if [ ! -f "$bundletool_jar" ]; then
+    echo "Missing bundletool jar: $bundletool_jar (set BUNDLETOOL_JAR or download the pinned release)" >&2
+    missing=1
+fi
+if [ "$missing" -ne 0 ]; then
     exit 2
 fi
 
@@ -62,6 +116,10 @@ if [ "$require_device_64" = "true" ] && [ -z "$abilist64" ]; then
     echo "Device does not advertise a 64-bit ABI list" >&2
     exit 1
 fi
+if [ "$abi" = "armeabi-v7a" ] && ! echo ",$abilist," | grep -q ",armeabi-v7a,"; then
+    echo "Device does not support armeabi-v7a; cannot run the 32-bit qualification" >&2
+    exit 1
+fi
 if [ -n "$require_page_size" ] && [ "$page_size" != "$require_page_size" ]; then
     echo "PAGE_SIZE mismatch: expected $require_page_size, found $page_size" >&2
     exit 1
@@ -74,8 +132,8 @@ fi
     :example-app:assembleDebugAndroidTest
 
 # The split gate performs install, resolver, safety, and (when required) the ingestion phases.
-# Process ABI and bitness are read from the service READY facts inside the instrumentation tests;
-# the expected process ABI is additionally asserted here from the qualification build restriction.
+# Process ABI and bitness are read from the service READY facts inside the instrumentation tests
+# and land in the evidence, where they are asserted against the requested ABI below.
 expected_ingestion=0
 run_fatal=0
 if [ "$require_ingestion" = "true" ]; then
@@ -83,17 +141,18 @@ if [ "$require_ingestion" = "true" ]; then
     run_fatal=1
 fi
 
+BUNDLETOOL_JAR="$bundletool_jar" \
 REQUIRE_INGESTION="$expected_ingestion" \
 RUN_FATAL="$run_fatal" \
 EXPECTED_PAGE_SIZE="${require_page_size:-}" \
 ./scripts/run_split_install_test.sh
 
-# --- process bitness verification from the evidence ---------------------------------------------
-python3 - "$abi" "$require_process_64" <<'PY'
+# --- process ABI/bitness verification from the evidence -----------------------------------------
+python3 - "$abi" "$expect_64_bit_process" <<'PY'
 import json
 import sys
 
-abi, require_64 = sys.argv[1], sys.argv[2]
+abi, expect_64 = sys.argv[1], sys.argv[2] == "true"
 with open("native-report-evidence.json") as evidence_file:
     evidence = json.load(evidence_file)
 
@@ -103,13 +162,14 @@ if process_abi is None:
     raise SystemExit(
         "Evidence carries no service-reported process ABI; run with --require-ingestion true"
     )
-if abi == "armeabi-v7a" and process_abi not in (None, "armeabi-v7a"):
-    raise SystemExit(f"Expected an armeabi-v7a process, found {process_abi}")
-if require_64 == "true" and process_abi and "64" not in process_abi:
-    raise SystemExit(f"Expected a 64-bit process ABI, found {process_abi}")
-if require_64 == "false" and process_abi and "64" in process_abi:
-    raise SystemExit(f"Expected a 32-bit process ABI, found {process_abi}")
-print("Process ABI/bitness verified:", process_abi)
+if process_abi != abi:
+    raise SystemExit(f"Expected a {abi} process, found {process_abi}")
+is_64 = device.get("is_64_bit")
+if is_64 is not expect_64:
+    raise SystemExit(
+        f"Expected process 64-bit={expect_64} for ABI {abi}, evidence says {is_64}"
+    )
+print(f"Process ABI/bitness verified: {process_abi} (64-bit={is_64})")
 PY
 
 echo "Hardware release gate passed for --abi $abi."

--- a/scripts/run_native_release_device_gate.sh
+++ b/scripts/run_native_release_device_gate.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Hardware release gate for allocated devices (modern arm64 split installs, real 32-bit processes
+# on 64-bit hardware, physical 16 KB devices). Fails clearly when no device is attached; never
+# silently passes. Run from the repository root.
+#
+# Usage:
+#   scripts/run_native_release_device_gate.sh \
+#     --abi arm64-v8a|armeabi-v7a \
+#     --require-device-64-bit true|false \
+#     --require-process-64-bit true|false \
+#     --require-page-size 4096|16384 \
+#     --require-ingestion true
+
+abi=""
+require_device_64=""
+require_process_64=""
+require_page_size=""
+require_ingestion="true"
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --abi) abi="$2"; shift 2 ;;
+        --require-device-64-bit) require_device_64="$2"; shift 2 ;;
+        --require-process-64-bit) require_process_64="$2"; shift 2 ;;
+        --require-page-size) require_page_size="$2"; shift 2 ;;
+        --require-ingestion) require_ingestion="$2"; shift 2 ;;
+        *) echo "Unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$abi" ]; then
+    echo "--abi is required" >&2
+    exit 2
+fi
+
+# A missing device must be a loud failure, not a silent pass.
+device_count="$(adb devices | awk 'NR>1 && $2=="device"' | wc -l | tr -d ' ')"
+if [ "$device_count" -lt 1 ]; then
+    echo "Hardware release gate requires an attached device; none found." >&2
+    exit 1
+fi
+
+# --- device facts -------------------------------------------------------------------------------
+abilist="$(adb shell getprop ro.product.cpu.abilist | tr -d '\r')"
+abilist32="$(adb shell getprop ro.product.cpu.abilist32 | tr -d '\r')"
+abilist64="$(adb shell getprop ro.product.cpu.abilist64 | tr -d '\r')"
+page_size="$(adb shell getconf PAGE_SIZE | tr -d '\r')"
+sdk="$(adb shell getprop ro.build.version.sdk | tr -d '\r')"
+model="$(adb shell getprop ro.product.model | tr -d '\r')"
+{
+    echo "sdk=$sdk"
+    echo "model=$model"
+    echo "abilist=$abilist"
+    echo "abilist32=$abilist32"
+    echo "abilist64=$abilist64"
+    echo "page_size=$page_size"
+} | tee device-facts.txt
+
+if [ "$require_device_64" = "true" ] && [ -z "$abilist64" ]; then
+    echo "Device does not advertise a 64-bit ABI list" >&2
+    exit 1
+fi
+if [ -n "$require_page_size" ] && [ "$page_size" != "$require_page_size" ]; then
+    echo "PAGE_SIZE mismatch: expected $require_page_size, found $page_size" >&2
+    exit 1
+fi
+
+# --- ABI-restricted qualification build ---------------------------------------------------------
+./gradlew -PqualificationAbi="$abi" \
+    :example-app:bundleDebug \
+    :example-app:assembleDebug \
+    :example-app:assembleDebugAndroidTest
+
+# The split gate performs install, resolver, safety, and (when required) the ingestion phases.
+# Process ABI and bitness are read from the service READY facts inside the instrumentation tests;
+# the expected process ABI is additionally asserted here from the qualification build restriction.
+expected_ingestion=0
+run_fatal=0
+if [ "$require_ingestion" = "true" ]; then
+    expected_ingestion=1
+    run_fatal=1
+fi
+
+REQUIRE_INGESTION="$expected_ingestion" \
+RUN_FATAL="$run_fatal" \
+EXPECTED_PAGE_SIZE="${require_page_size:-}" \
+./scripts/run_split_install_test.sh
+
+# --- process bitness verification from the evidence ---------------------------------------------
+python3 - "$abi" "$require_process_64" <<'PY'
+import json
+import sys
+
+abi, require_64 = sys.argv[1], sys.argv[2]
+with open("native-report-evidence.json") as evidence_file:
+    evidence = json.load(evidence_file)
+
+device = evidence.get("device", {})
+process_abi = device.get("process_abi")
+if process_abi is None:
+    raise SystemExit(
+        "Evidence carries no service-reported process ABI; run with --require-ingestion true"
+    )
+if abi == "armeabi-v7a" and process_abi not in (None, "armeabi-v7a"):
+    raise SystemExit(f"Expected an armeabi-v7a process, found {process_abi}")
+if require_64 == "true" and process_abi and "64" not in process_abi:
+    raise SystemExit(f"Expected a 64-bit process ABI, found {process_abi}")
+if require_64 == "false" and process_abi and "64" in process_abi:
+    raise SystemExit(f"Expected a 32-bit process ABI, found {process_abi}")
+print("Process ABI/bitness verified:", process_abi)
+PY
+
+echo "Hardware release gate passed for --abi $abi."

--- a/scripts/run_split_install_test.sh
+++ b/scripts/run_split_install_test.sh
@@ -29,6 +29,15 @@ debug_keystore="${DEBUG_KEYSTORE:-$HOME/.android/debug.keystore}"
 require_ingestion="${REQUIRE_INGESTION:-1}"
 run_fatal="${RUN_FATAL:-1}"
 
+case "$require_ingestion" in
+    0|1) ;;
+    *) echo "REQUIRE_INGESTION must be 0 or 1" >&2; exit 2 ;;
+esac
+case "$run_fatal" in
+    0|1) ;;
+    *) echo "RUN_FATAL must be 0 or 1" >&2; exit 2 ;;
+esac
+
 runner="backtraceio.backtraceio.test/androidx.test.runner.AndroidJUnitRunner"
 
 for artifact in "$bundletool_jar" "$bundle" "$test_apk"; do
@@ -119,7 +128,12 @@ fi
 
 # A persistent device may carry NativeQualEvidence lines from a previous run; stale evidence
 # must never satisfy this run's gates or contaminate its provenance.
-adb logcat -c 2>/dev/null || true
+adb logcat -c
+native_evidence_after_clear="$(adb logcat -d -s NativeQualEvidence:I)"
+if printf '%s\n' "$native_evidence_after_clear" | grep -q "NativeQualEvidence"; then
+    echo "NativeQualEvidence log entries remain after clearing Logcat; refusing stale evidence." >&2
+    exit 1
+fi
 
 # --- instrumentation APK, certificate-aligned ---------------------------------------------------
 build_tools_version="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -1)"
@@ -175,7 +189,9 @@ run_instrumentation_test \
 
 # Sanitization gate: the safety scenarios deliberately throw sentinel-bearing failures in a real
 # process; a raw sentinel in UNfiltered logcat means the sanitized-diagnostics contract regressed.
-if adb logcat -d 2>/dev/null | grep -qE "SECRET_URL_TOKEN_SENTINEL|PRIVATE_CUSTOMER_SENTINEL"; then
+raw_logcat="$(adb logcat -d)"
+if printf '%s\n' "$raw_logcat" \
+        | grep -qE "SECRET_URL_TOKEN_SENTINEL|SENSITIVE_ATTRIBUTE_SENTINEL"; then
     echo "Sanitized-diagnostics regression: a sensitive sentinel reached Logcat" >&2
     exit 1
 fi
@@ -203,63 +219,188 @@ else
 fi
 
 # --- evidence -----------------------------------------------------------------------------------
-# Provenance: a pull_request checkout is a synthetic merge commit, so HEAD is NOT the PR head.
-# Record both SHAs; PR_HEAD_SHA is provided by CI, and HEAD^2 of a merge checkout is the PR head.
-tested_merge_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+# Provenance: a pull_request checkout can be a synthetic merge commit, so HEAD is not necessarily
+# the source head. Record the source and exact tested checkout separately, and include the merge
+# SHA only when the tested checkout is a merge whose second parent is the source head.
+tested_checkout_sha="$(git rev-parse HEAD)"
+pull_request_merge_sha=""
 if [ -n "${PR_HEAD_SHA:-}" ]; then
-    pr_head_sha="$PR_HEAD_SHA"
-elif [ "${GITHUB_ACTIONS:-}" = "true" ] && git rev-parse -q --verify HEAD^2 > /dev/null 2>&1; then
-    pr_head_sha="$(git rev-parse HEAD^2)"
+    source_head_sha="$PR_HEAD_SHA"
+    if ! printf '%s\n' "$source_head_sha" | grep -Eq '^([0-9a-f]{40}|[0-9a-f]{64})$'; then
+        echo "PR_HEAD_SHA is not a full lowercase object ID: $PR_HEAD_SHA" >&2
+        exit 1
+    fi
+    if [ "$source_head_sha" != "$tested_checkout_sha" ]; then
+        # Read the merge object's raw parent hashes instead of resolving HEAD^2. GitHub's default
+        # depth-one PR checkout has the merge object but not its parent objects.
+        merge_parent_count="$(git cat-file -p HEAD | awk '$1 == "parent" { count++ } END { print count + 0 }')"
+        merge_source_sha="$(git cat-file -p HEAD | awk '$1 == "parent" { count++; if (count == 2) print $2 }')"
+        if [ "$merge_parent_count" != "2" ] || [ -z "$merge_source_sha" ]; then
+            echo "Tested checkout differs from PR_HEAD_SHA but is not a two-parent merge commit." >&2
+            exit 1
+        fi
+        if [ "$merge_source_sha" != "$source_head_sha" ]; then
+            echo "Tested merge second parent does not match PR_HEAD_SHA." >&2
+            exit 1
+        fi
+        pull_request_merge_sha="$tested_checkout_sha"
+    fi
+elif [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+    merge_parent_count="$(git cat-file -p HEAD | awk '$1 == "parent" { count++ } END { print count + 0 }')"
+    if [ "$merge_parent_count" = "2" ]; then
+        source_head_sha="$(git cat-file -p HEAD | awk '$1 == "parent" { count++; if (count == 2) print $2 }')"
+        pull_request_merge_sha="$tested_checkout_sha"
+    else
+        source_head_sha="$tested_checkout_sha"
+    fi
 else
-    pr_head_sha="$tested_merge_sha"
+    source_head_sha="$tested_checkout_sha"
 fi
-adb logcat -d -s NativeQualEvidence:I 2>/dev/null > native-qual-evidence-lines.txt || true
-python3 - "$pr_head_sha" "$tested_merge_sha" <<'PY'
+adb logcat -d -s NativeQualEvidence:I > native-qual-evidence-lines.txt
+python3 - \
+    "$source_head_sha" \
+    "$tested_checkout_sha" \
+    "$pull_request_merge_sha" \
+    "$require_ingestion" \
+    "$run_fatal" <<'PY'
 import json
 import re
 import sys
 
+source_head_sha, tested_checkout_sha, pull_request_merge_sha = sys.argv[1:4]
+require_ingestion = sys.argv[4] == "1"
+run_fatal = sys.argv[5] == "1"
+
 evidence = {
-    "pr_head_sha": sys.argv[1],
-    "tested_merge_sha": sys.argv[2],
+    "source_head_sha": source_head_sha,
+    "tested_checkout_sha": tested_checkout_sha,
     "device": {},
     "install": {"package_paths": []},
 }
-try:
-    with open("device-facts.txt") as facts:
-        for line in facts:
-            key, _, value = line.strip().partition("=")
-            if key == "sdk":
-                evidence["device"]["sdk"] = int(value)
-            elif key == "page_size":
-                evidence["device"]["page_size"] = int(value)
-            elif key == "abilist":
-                evidence["device"]["supported_abis"] = [a for a in value.split(",") if a]
-            elif key == "abi":
-                evidence["device"]["primary_abi"] = value
-            elif key == "abilist64":
-                evidence["device"]["is_64_bit"] = bool(value)
-except OSError:
-    pass
-try:
-    with open("installed-package-paths.txt") as paths:
-        evidence["install"]["package_paths"] = [
-            line.strip().replace("package:", "") for line in paths if line.strip()
-        ]
-except OSError:
-    pass
-try:
-    with open("native-qual-evidence-lines.txt") as lines:
-        for line in lines:
-            match = re.search(r"\{.*\}", line)
-            if not match:
-                continue
+if pull_request_merge_sha:
+    evidence["pull_request_merge_sha"] = pull_request_merge_sha
+
+with open("device-facts.txt") as facts:
+    for line in facts:
+        key, _, value = line.strip().partition("=")
+        if key == "sdk":
+            evidence["device"]["sdk"] = int(value)
+        elif key == "page_size":
+            evidence["device"]["page_size"] = int(value)
+        elif key == "abilist":
+            evidence["device"]["supported_abis"] = [a for a in value.split(",") if a]
+        elif key == "abi":
+            evidence["device"]["primary_abi"] = value
+        elif key == "abilist64":
+            evidence["device"]["is_64_bit"] = bool(value)
+with open("installed-package-paths.txt") as paths:
+    evidence["install"]["package_paths"] = [
+        line.strip().replace("package:", "") for line in paths if line.strip()
+    ]
+
+device = evidence["device"]
+if not (
+    isinstance(device.get("sdk"), int)
+    and device["sdk"] > 0
+    and isinstance(device.get("page_size"), int)
+    and device["page_size"] > 0
+    and isinstance(device.get("supported_abis"), list)
+    and device["supported_abis"]
+    and all(isinstance(abi, str) and abi for abi in device["supported_abis"])
+    and isinstance(device.get("primary_abi"), str)
+    and device["primary_abi"]
+    and isinstance(device.get("is_64_bit"), bool)
+):
+    raise SystemExit("Device facts are incomplete or malformed")
+package_paths = evidence["install"]["package_paths"]
+if not package_paths or not all(isinstance(path, str) and path for path in package_paths):
+    raise SystemExit("Installed package paths are missing or malformed")
+
+expected_phases = set()
+if require_ingestion:
+    expected_phases.update(("nonfatal", "lifecycle"))
+    if run_fatal:
+        expected_phases.add("fatal")
+
+phases = {}
+with open("native-qual-evidence-lines.txt", encoding="utf-8") as lines:
+    for line in lines:
+        if "NativeQualEvidence" not in line:
+            continue
+        match = re.search(r"\{.*\}", line)
+        if not match:
+            raise SystemExit("Malformed NativeQualEvidence line without a JSON object")
+        try:
             entry = json.loads(match.group(0))
-            phase = entry.pop("phase", None)
-            if phase:
-                evidence[phase] = entry
-except OSError:
-    pass
+        except json.JSONDecodeError as error:
+            raise SystemExit(f"Malformed NativeQualEvidence JSON: {error}") from error
+        if not isinstance(entry, dict):
+            raise SystemExit("NativeQualEvidence entry must be a JSON object")
+        phase = entry.pop("phase", None)
+        if phase not in expected_phases:
+            raise SystemExit(f"Unexpected NativeQualEvidence phase: {phase!r}")
+        if phase in phases:
+            raise SystemExit(f"Duplicate NativeQualEvidence phase: {phase}")
+        phases[phase] = entry
+
+missing_phases = expected_phases.difference(phases)
+if missing_phases:
+    raise SystemExit("Missing NativeQualEvidence phase(s): " + ", ".join(sorted(missing_phases)))
+
+def require(condition, message):
+    if not condition:
+        raise SystemExit(message)
+
+for phase, entry in phases.items():
+    require(isinstance(entry.get("guid"), str) and entry["guid"], f"{phase}: missing GUID")
+    group_ids = entry.get("group_ids")
+    require(
+        isinstance(group_ids, list)
+        and group_ids
+        and all(isinstance(group_id, str) and group_id for group_id in group_ids),
+        f"{phase}: invalid group_ids",
+    )
+    stable_count = entry.get("stable_count")
+    require(
+        isinstance(stable_count, int) and not isinstance(stable_count, bool),
+        f"{phase}: invalid stable_count",
+    )
+    expected_count = 2 if phase == "lifecycle" else 1
+    require(stable_count == expected_count, f"{phase}: expected stable_count={expected_count}")
+
+    if phase in ("nonfatal", "lifecycle"):
+        messages = entry.get("messages")
+        expected_messages = 2 if phase == "lifecycle" else 1
+        require(
+            isinstance(messages, dict)
+            and len(messages) == expected_messages
+            and all(isinstance(message, str) and message for message in messages)
+            and all(count == 1 and not isinstance(count, bool) for count in messages.values()),
+            f"{phase}: invalid exact-message evidence",
+        )
+
+if "nonfatal" in phases:
+    nonfatal = phases["nonfatal"]
+    require(
+        isinstance(nonfatal.get("process_abi"), str) and nonfatal["process_abi"],
+        "nonfatal: missing process ABI",
+    )
+    require(isinstance(nonfatal.get("process_is_64_bit"), bool), "nonfatal: missing process bitness")
+    require(
+        isinstance(nonfatal.get("handler_path"), str) and nonfatal["handler_path"],
+        "nonfatal: missing handler path",
+    )
+if "fatal" in phases:
+    fatal = phases["fatal"]
+    require(
+        isinstance(fatal.get("crashed_pid"), int)
+        and not isinstance(fatal["crashed_pid"], bool)
+        and fatal["crashed_pid"] > 0,
+        "fatal: invalid crashed PID",
+    )
+    require(fatal.get("binder_died") is True, "fatal: binder death was not proven")
+
+evidence.update(phases)
 
 # The service READY facts carry the real process ABI/bitness and the resolved handler path;
 # prefer them over device props and surface the handler path at the top level.

--- a/scripts/run_split_install_test.sh
+++ b/scripts/run_split_install_test.sh
@@ -117,6 +117,10 @@ if [ "${EXPECTED_DEVICE_SUPPORTS_64_BIT:-}" = "0" ] && [ -n "$device_abilist64" 
     exit 1
 fi
 
+# A persistent device may carry NativeQualEvidence lines from a previous run; stale evidence
+# must never satisfy this run's gates or contaminate its provenance.
+adb logcat -c 2>/dev/null || true
+
 # --- instrumentation APK, certificate-aligned ---------------------------------------------------
 build_tools_version="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -1)"
 apksigner="$ANDROID_HOME/build-tools/$build_tools_version/apksigner"
@@ -160,6 +164,15 @@ run_instrumentation_test \
     "fresh-process-safety-output.txt" \
     1
 
+# --- phase 4b: assertion-policy sabotage suite (secretless) -------------------------------------
+# The duplicate/collapsed-group/message/error-type policies guard every ingestion gate; they must
+# execute on fork and Dependabot changes too, so they run here rather than only in trusted lanes.
+# The expected count is hard-gated: silently dropped sabotage tests must fail this phase.
+run_instrumentation_test \
+    "backtraceio.backtraceio.CoronerNativeReportAssertionsTest" \
+    "assertion-sabotage-output.txt" \
+    13
+
 # Sanitization gate: the safety scenarios deliberately throw sentinel-bearing failures in a real
 # process; a raw sentinel in UNfiltered logcat means the sanitized-diagnostics contract regressed.
 if adb logcat -d 2>/dev/null | grep -qE "SECRET_URL_TOKEN_SENTINEL|PRIVATE_CUSTOMER_SENTINEL"; then
@@ -190,15 +203,25 @@ else
 fi
 
 # --- evidence -----------------------------------------------------------------------------------
-head_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+# Provenance: a pull_request checkout is a synthetic merge commit, so HEAD is NOT the PR head.
+# Record both SHAs; PR_HEAD_SHA is provided by CI, and HEAD^2 of a merge checkout is the PR head.
+tested_merge_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+if [ -n "${PR_HEAD_SHA:-}" ]; then
+    pr_head_sha="$PR_HEAD_SHA"
+elif [ "${GITHUB_ACTIONS:-}" = "true" ] && git rev-parse -q --verify HEAD^2 > /dev/null 2>&1; then
+    pr_head_sha="$(git rev-parse HEAD^2)"
+else
+    pr_head_sha="$tested_merge_sha"
+fi
 adb logcat -d -s NativeQualEvidence:I 2>/dev/null > native-qual-evidence-lines.txt || true
-python3 - "$head_sha" <<'PY'
+python3 - "$pr_head_sha" "$tested_merge_sha" <<'PY'
 import json
 import re
 import sys
 
 evidence = {
-    "head_sha": sys.argv[1],
+    "pr_head_sha": sys.argv[1],
+    "tested_merge_sha": sys.argv[2],
     "device": {},
     "install": {"package_paths": []},
 }
@@ -238,12 +261,15 @@ try:
 except OSError:
     pass
 
-# The service READY facts carry the real process ABI/bitness; prefer them over device props.
+# The service READY facts carry the real process ABI/bitness and the resolved handler path;
+# prefer them over device props and surface the handler path at the top level.
 nonfatal = evidence.get("nonfatal", {})
 if isinstance(nonfatal, dict) and nonfatal.get("process_abi"):
     evidence["device"]["process_abi"] = nonfatal.pop("process_abi")
     if "process_is_64_bit" in nonfatal:
         evidence["device"]["is_64_bit"] = nonfatal.pop("process_is_64_bit")
+if isinstance(nonfatal, dict) and nonfatal.get("handler_path"):
+    evidence["handler_path"] = nonfatal.pop("handler_path")
 
 with open("native-report-evidence.json", "w") as output:
     json.dump(evidence, output, indent=2)

--- a/scripts/run_split_install_test.sh
+++ b/scripts/run_split_install_test.sh
@@ -1,17 +1,35 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Play-style split-install qualification against the connected device/emulator. Installs a
-# device-specific APK set generated from the debug AAB, proves an ABI configuration split is
-# installed, and runs the resolver qualification test. Requires: repository root as cwd,
-# bundletool.jar present (BUNDLETOOL_JAR overrides the path), adb on PATH, one connected device,
-# and previously built :example-app:bundleDebug and :example-app:assembleDebugAndroidTest outputs.
+# Play-style split-install qualification against the connected device/emulator, in explicit
+# hard-gated phases:
+#   1. build/install a device-specific APK set from the debug AAB (signed; certificates aligned)
+#   2. assert an ABI configuration split is installed
+#   3. resolver test (production dladdr()/metadata path resolution)
+#   4. fresh-process failure-safety test (secretless)
+#   5. REQUIRE_INGESTION=1: nonfatal, fatal+recovery (RUN_FATAL=1), and lifecycle ingestion gates
+#   6. no selected instrumentation test may be skipped
+#   7. optional device-fact assertions (EXPECTED_PAGE_SIZE, EXPECTED_PROCESS_ABI,
+#      EXPECTED_DEVICE_SUPPORTS_64_BIT)
+# Only diagnostic collection may use `|| true`; no test or ingestion gate does.
+#
+# Environment:
+#   REQUIRE_INGESTION=0|1                 (default 1) gate backend ingestion phases
+#   RUN_FATAL=0|1                         (default 1) include the fatal+recovery gate
+#   EXPECTED_PAGE_SIZE=<int>              optional getconf PAGE_SIZE assertion
+#   EXPECTED_PROCESS_ABI=<abi>            optional primary-ABI assertion
+#   EXPECTED_DEVICE_SUPPORTS_64_BIT=0|1   optional 64-bit ABI list assertion
+#   BUNDLETOOL_JAR, APKS_OUTPUT, DEBUG_KEYSTORE overrides as before
 
 bundletool_jar="${BUNDLETOOL_JAR:-bundletool.jar}"
 bundle="example-app/build/outputs/bundle/debug/example-app-debug.aab"
 test_apk="example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk"
 apks_output="${APKS_OUTPUT:-example-app-debug.apks}"
 debug_keystore="${DEBUG_KEYSTORE:-$HOME/.android/debug.keystore}"
+require_ingestion="${REQUIRE_INGESTION:-1}"
+run_fatal="${RUN_FATAL:-1}"
+
+runner="backtraceio.backtraceio.test/androidx.test.runner.AndroidJUnitRunner"
 
 for artifact in "$bundletool_jar" "$bundle" "$test_apk"; do
     if [ ! -f "$artifact" ]; then
@@ -20,26 +38,24 @@ for artifact in "$bundletool_jar" "$bundle" "$test_apk"; do
     fi
 done
 
-# The emulator dies with the CI step, so capture logcat here while it is still reachable; a child
-# crash-handler System.load failure is only diagnosable from this log. Capture only the relevant
-# tags and redact URL/token-shaped values: handler diagnostics can otherwise carry the submission
-# token and customer attributes into an uploaded artifact.
+# --- diagnostics (the only || true zone) --------------------------------------------------------
 collect_logcat() {
     adb logcat -d -s \
         BacktraceCrashHandlerRunner:V \
         Backtrace-Android:V \
+        NativeQualEvidence:I \
         TestRunner:I \
         AndroidRuntime:E 2>/dev/null \
         | sed -E \
             -e 's#(token=)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
             -e 's#https?://[^[:space:]"]+#[REDACTED_URL]#g' \
+            -e 's#--annotation=[^[:space:]"]+#--annotation=[REDACTED]#g' \
+            -e 's#--attachment=[^[:space:]"]+#--attachment=[REDACTED]#g' \
         > split-install-logcat.txt || true
 }
 trap collect_logcat EXIT
 
-# Device-specific APKs must be signed or the install fails with INSTALL_PARSE_FAILED_NO_CERTIFICATES,
-# and the certificate must match the instrumentation APK's, so sign with the same Android debug
-# keystore Gradle uses, creating it first on fresh CI runners where it does not exist yet.
+# --- signing ------------------------------------------------------------------------------------
 if [ ! -f "$debug_keystore" ]; then
     mkdir -p "$(dirname "$debug_keystore")"
     keytool -genkeypair -keystore "$debug_keystore" -storepass android -alias androiddebugkey \
@@ -47,6 +63,7 @@ if [ ! -f "$debug_keystore" ]; then
         -dname "CN=Android Debug,O=Android,C=US"
 fi
 
+# --- phase 1: install ---------------------------------------------------------------------------
 java -jar "$bundletool_jar" build-apks \
     --bundle="$bundle" \
     --output="$apks_output" \
@@ -59,13 +76,43 @@ java -jar "$bundletool_jar" build-apks \
 
 java -jar "$bundletool_jar" install-apks --apks="$apks_output"
 
+# --- phase 2: split present + device facts ------------------------------------------------------
 adb shell pm path backtraceio.backtraceio | tee installed-package-paths.txt
 grep -E 'split_config\.(x86_64|arm64_v8a|armeabi_v7a)\.apk' installed-package-paths.txt
 
-# Instrumentation requires the test package's certificate to match the target's. Which keystore
-# Gradle resolved for the debug signing config is environment-dependent, so make the certificates
-# identical by construction: re-sign a copy of the instrumentation APK with the exact keystore the
-# split APKs were signed with.
+device_sdk="$(adb shell getprop ro.build.version.sdk | tr -d '\r')"
+device_abi="$(adb shell getprop ro.product.cpu.abi | tr -d '\r')"
+device_abilist="$(adb shell getprop ro.product.cpu.abilist | tr -d '\r')"
+device_abilist64="$(adb shell getprop ro.product.cpu.abilist64 | tr -d '\r')"
+device_page_size="$(adb shell getconf PAGE_SIZE | tr -d '\r')"
+{
+    echo "sdk=$device_sdk"
+    echo "abi=$device_abi"
+    echo "abilist=$device_abilist"
+    echo "abilist64=$device_abilist64"
+    echo "page_size=$device_page_size"
+    echo "model=$(adb shell getprop ro.product.model | tr -d '\r')"
+} | tee device-facts.txt
+
+# --- phase 7/8 style device assertions (early, they are cheap) ----------------------------------
+if [ -n "${EXPECTED_PAGE_SIZE:-}" ] && [ "$device_page_size" != "$EXPECTED_PAGE_SIZE" ]; then
+    echo "PAGE_SIZE mismatch: expected $EXPECTED_PAGE_SIZE, found $device_page_size" >&2
+    exit 1
+fi
+if [ -n "${EXPECTED_PROCESS_ABI:-}" ] && [ "$device_abi" != "$EXPECTED_PROCESS_ABI" ]; then
+    echo "Primary ABI mismatch: expected $EXPECTED_PROCESS_ABI, found $device_abi" >&2
+    exit 1
+fi
+if [ "${EXPECTED_DEVICE_SUPPORTS_64_BIT:-}" = "1" ] && [ -z "$device_abilist64" ]; then
+    echo "Device does not advertise a 64-bit ABI list" >&2
+    exit 1
+fi
+if [ "${EXPECTED_DEVICE_SUPPORTS_64_BIT:-}" = "0" ] && [ -n "$device_abilist64" ]; then
+    echo "Device unexpectedly advertises a 64-bit ABI list" >&2
+    exit 1
+fi
+
+# --- instrumentation APK, certificate-aligned ---------------------------------------------------
 build_tools_version="$(ls "$ANDROID_HOME/build-tools" | sort -V | tail -1)"
 apksigner="$ANDROID_HOME/build-tools/$build_tools_version/apksigner"
 signed_test_apk="${TMPDIR:-/tmp}/example-app-debug-androidTest-resigned.apk"
@@ -75,16 +122,18 @@ cp "$test_apk" "$signed_test_apk"
 
 adb install -r "$signed_test_apk"
 
-# Each test must PASS (status code 0), not be skipped by its assumptions (-4) or fail (-1/-2);
-# am instrument itself always exits 0, so gate on the raw status stream and the test count.
+# Each selected test must PASS (status code 0), not be skipped by its assumptions (-4) or fail
+# (-1/-2); am instrument itself always exits 0, so gate on the raw status stream and test count.
 run_instrumentation_test() {
     local selector="$1"
     local output="$2"
     local expected_tests="$3"
+    local timeout_arg="${4:-}"
 
     adb shell am instrument -w -r \
         -e class "$selector" \
-        backtraceio.backtraceio.test/androidx.test.runner.AndroidJUnitRunner | tee "$output"
+        $timeout_arg \
+        "$runner" | tee "$output"
 
     grep -q "INSTRUMENTATION_STATUS_CODE: 0" "$output"
     if grep -qE "INSTRUMENTATION_STATUS_CODE: -[0-9]" "$output"; then
@@ -94,24 +143,107 @@ run_instrumentation_test() {
     grep -q "OK (${expected_tests} test" "$output"
 }
 
+# --- phase 3: resolver --------------------------------------------------------------------------
 run_instrumentation_test \
     "backtraceio.backtraceio.SplitInstallNativeResolutionTest" \
     "split-resolver-output.txt" \
     1
 
-# The handler-ingestion test needs working Backtrace test credentials in BuildConfig. CI provides
-# them and must gate on the result. Local runs may carry stale or absent credentials, so with
-# REQUIRE_INGESTION=0 the handler test runs informationally only and the resolver test remains the
-# hard gate.
-if [ "${REQUIRE_INGESTION:-1}" = "1" ]; then
-    run_instrumentation_test \
-        "backtraceio.backtraceio.SplitInstallNativeIntegrationTest" \
-        "split-native-output.txt" \
-        1
-    echo "Split-install qualification passed: resolver, handler load, and report ingestion verified."
-else
-    adb shell am instrument -w -r \
-        -e class backtraceio.backtraceio.SplitInstallNativeIntegrationTest \
-        backtraceio.backtraceio.test/androidx.test.runner.AndroidJUnitRunner | tee split-native-output.txt || true
-    echo "Split-install resolver qualification passed (handler ingestion not gated in this run)."
+# --- phase 4: fresh-process failure safety (secretless) -----------------------------------------
+run_instrumentation_test \
+    "backtraceio.backtraceio.NativeFreshProcessSafetyTest" \
+    "fresh-process-safety-output.txt" \
+    1
+
+# Sanitization gate: the safety scenarios deliberately throw sentinel-bearing failures in a real
+# process; a raw sentinel in UNfiltered logcat means the sanitized-diagnostics contract regressed.
+if adb logcat -d 2>/dev/null | grep -qE "SECRET_URL_TOKEN_SENTINEL|PRIVATE_CUSTOMER_SENTINEL"; then
+    echo "Sanitized-diagnostics regression: a sensitive sentinel reached Logcat" >&2
+    exit 1
 fi
+
+# --- phase 5: ingestion gates -------------------------------------------------------------------
+if [ "$require_ingestion" = "1" ]; then
+    run_instrumentation_test \
+        "backtraceio.backtraceio.NativeSplitProcessIntegrationTest#nonfatalDumpFromDedicatedProcessIsIngestedExactlyOnce" \
+        "split-nonfatal-output.txt" \
+        1
+
+    if [ "$run_fatal" = "1" ]; then
+        run_instrumentation_test \
+            "backtraceio.backtraceio.NativeSplitProcessIntegrationTest#fatalCrashIsRecoveredAndIngestedExactlyOnce" \
+            "split-fatal-output.txt" \
+            1
+    fi
+
+    run_instrumentation_test \
+        "backtraceio.backtraceio.NativeSplitProcessIntegrationTest#disableAndReEnableRestartsUploads" \
+        "split-lifecycle-output.txt" \
+        1
+else
+    echo "Ingestion gates skipped by policy (REQUIRE_INGESTION=0); resolver and safety gates were mandatory."
+fi
+
+# --- evidence -----------------------------------------------------------------------------------
+head_sha="$(git rev-parse HEAD 2>/dev/null || echo unknown)"
+adb logcat -d -s NativeQualEvidence:I 2>/dev/null > native-qual-evidence-lines.txt || true
+python3 - "$head_sha" <<'PY'
+import json
+import re
+import sys
+
+evidence = {
+    "head_sha": sys.argv[1],
+    "device": {},
+    "install": {"package_paths": []},
+}
+try:
+    with open("device-facts.txt") as facts:
+        for line in facts:
+            key, _, value = line.strip().partition("=")
+            if key == "sdk":
+                evidence["device"]["sdk"] = int(value)
+            elif key == "page_size":
+                evidence["device"]["page_size"] = int(value)
+            elif key == "abilist":
+                evidence["device"]["supported_abis"] = [a for a in value.split(",") if a]
+            elif key == "abi":
+                evidence["device"]["primary_abi"] = value
+            elif key == "abilist64":
+                evidence["device"]["is_64_bit"] = bool(value)
+except OSError:
+    pass
+try:
+    with open("installed-package-paths.txt") as paths:
+        evidence["install"]["package_paths"] = [
+            line.strip().replace("package:", "") for line in paths if line.strip()
+        ]
+except OSError:
+    pass
+try:
+    with open("native-qual-evidence-lines.txt") as lines:
+        for line in lines:
+            match = re.search(r"\{.*\}", line)
+            if not match:
+                continue
+            entry = json.loads(match.group(0))
+            phase = entry.pop("phase", None)
+            if phase:
+                evidence[phase] = entry
+except OSError:
+    pass
+
+# The service READY facts carry the real process ABI/bitness; prefer them over device props.
+nonfatal = evidence.get("nonfatal", {})
+if isinstance(nonfatal, dict) and nonfatal.get("process_abi"):
+    evidence["device"]["process_abi"] = nonfatal.pop("process_abi")
+    if "process_is_64_bit" in nonfatal:
+        evidence["device"]["is_64_bit"] = nonfatal.pop("process_is_64_bit")
+
+with open("native-report-evidence.json", "w") as output:
+    json.dump(evidence, output, indent=2)
+print("wrote native-report-evidence.json")
+PY
+rm -f native-qual-evidence-lines.txt
+
+echo "Split-install qualification passed for the selected phases."

--- a/scripts/run_split_install_test.sh
+++ b/scripts/run_split_install_test.sh
@@ -40,12 +40,17 @@ done
 
 # --- diagnostics (the only || true zone) --------------------------------------------------------
 collect_logcat() {
+    # DEBUG (native tombstones), libc (fatal signals), and ActivityManager (process deaths) are
+    # required to tell a native crash from a system kill in a remote test process.
     adb logcat -d -s \
         BacktraceCrashHandlerRunner:V \
         Backtrace-Android:V \
         NativeQualEvidence:I \
         TestRunner:I \
-        AndroidRuntime:E 2>/dev/null \
+        AndroidRuntime:E \
+        DEBUG:V \
+        libc:F \
+        ActivityManager:I 2>/dev/null \
         | sed -E \
             -e 's#(token=)[A-Za-z0-9._-]+#\1[REDACTED]#g' \
             -e 's#https?://[^[:space:]"]+#[REDACTED_URL]#g' \


### PR DESCRIPTION
## Expand native crash-handler test coverage.

Adds regression coverage and operational improvements for the native integration changes in #218. 
The crash-handler path-resolution algorithm remains unchanged.

## Changes

- Added result-returning `tryEnableNativeIntegration(...)` overloads while preserving the existing `void` APIs.
- Added clean-process tests for failed setup and guarded dump calls.
- Added dedicated-process nonfatal, fatal/recovery, and disable/re-enable lifecycle tests.
- Added bounded GUID and exact-message report queries with duplicate detection.
- Added API 21/22 and 16 KB runtime compatibility lanes.
- Added Play-style split-install resolution and child-handler loading coverage.
- Added stable native diagnostic codes that omit exception messages, arguments, and resolved paths.
- Added an example-app-only startup trace harness with a generated high-entry-count fixture.
- Added safe checks and tests.

## Compatibility

- No public API removals. Existing `void enableNativeIntegration(...)` methods retain their signatures. 
- Result-returning methods are additive.

ref: BT-7460