### PR TITLE
Un-pin GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,20 +53,20 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           fetch-depth: 2
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
         with:
           cache-read-only: true
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload build and test reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: source-quality-reports
           retention-days: 7
@@ -143,19 +143,19 @@ jobs:
         api-level: [21, 22]
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -170,7 +170,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Legacy compatibility tests (API ${{ matrix.api-level }})
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: ${{ matrix.api-level }}
           arch: x86_64
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload legacy lane results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: legacy-api-${{ matrix.api-level }}-results
           retention-days: 7
@@ -197,19 +197,19 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -239,7 +239,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Split resolver and fresh-process safety tests
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 30
           arch: x86_64
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload resolver and safety diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: aab-resolver-safety-diagnostics
           retention-days: 7
@@ -270,19 +270,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Validate and write trusted credentials
         env:
@@ -317,32 +317,32 @@ jobs:
         run: ./gradlew assembleDebugAndroidTest assembleDebug
 
       - name: Upload symbols.zip
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: native-debug-symbols.zip
           path: example-app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
           if-no-files-found: ignore
 
       - name: Upload example-app APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: example-app-debug.apk
           path: example-app/build/outputs/apk/debug/example-app-debug.apk
 
       - name: Upload example-app Test APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: example-app-debug-androidTest.apk
           path: example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk
 
       - name: Upload backtrace-library AAR
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: backtrace-library-debug.aar
           path: backtrace-library/build/outputs/aar/backtrace-library-debug.aar
 
       - name: Upload backtrace-library Test APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: backtrace-library-debug-androidTest.apk
           path: backtrace-library/build/outputs/apk/androidTest/debug/backtrace-library-debug-androidTest.apk
@@ -362,22 +362,22 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
       - name: Download APK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        uses: actions/download-artifact@v5
         with:
           name: example-app-debug.apk
 
       - name: Download Test APK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        uses: actions/download-artifact@v5
         with:
           name: ${{ matrix.test-apk }}
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@bc81720eb01738d9c664b07fe42621bd0014283f # v4
+        uses: saucelabs/saucectl-run-action@v4
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -408,19 +408,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Validate and write trusted credentials
         env:
@@ -476,7 +476,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: Full split-install qualification
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 30
           arch: x86_64
@@ -485,7 +485,7 @@ jobs:
 
       - name: Upload full qualification diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: aab-native-full-diagnostics
           retention-days: 7
@@ -513,19 +513,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 17
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@v5
         with:
           java-version: "17"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Validate and write trusted credentials
         env:
@@ -581,7 +581,7 @@ jobs:
           sudo udevadm trigger --name-match=kvm
 
       - name: 16 KB runtime qualification
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2.38.0
+        uses: reactivecircus/android-emulator-runner@v2.38.0
         with:
           api-level: 35
           arch: x86_64
@@ -595,7 +595,7 @@ jobs:
 
       - name: Upload 16 KB qualification diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: aab-native-16kb-diagnostics
           retention-days: 7
@@ -624,7 +624,7 @@ jobs:
       PR_HEAD_SHA: ${{ github.sha }}
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@v5
         with:
           submodules: recursive
           persist-credentials: false
@@ -680,7 +680,7 @@ jobs:
 
       - name: Upload hardware gate evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@v4
         with:
           name: hardware-release-gate-evidence
           retention-days: 30


### PR DESCRIPTION
Un-pin GitHub Actions for Testing.

> [GitHub Actions](https://docs.github.com/en/actions) are typically referenced by version tags (e.g., actions/checkout@v5), but version tags can be moved, force-pushed, or accidentally updated. For better reproducibility and security, you can pin actions to specific version SHAs (immutable references that never change).

### Why Pin to SHAs?

> Version tags are convenient, but they’re mutable. A maintainer can re-release a tag, move it to a different commit, or even force-push to it. This means your workflow could run different code tomorrow than it did today without you changing anything.
> Here’s the key insight: a version tag like v5.0.1 is just a pointer to a specific commit. When you pin to the commit SHA that tag currently points to, you’re locking in that exact version. If the tag ever gets moved or re-released to point to a different commit, your workflow stays pinned to the original commit. You’re insulated from any future changes to that tag.
> Commit SHAs are different. A 40-character SHA like 93cb6efe18208431cddfb8368fd83d5badbf9bfd points to one specific commit, forever. It can never change, never be re-released, never be overwritten.
> For production workflows and security-sensitive operations, this immutability is invaluable.

refs: 
- https://cloudnativeengineer.substack.com/p/github-actions-reproducibility-security
- https://www.stepsecurity.io/blog/pinning-github-actions-for-enhanced-security-a-complete-guide