### PR TITLE
ci: fix flaky 16 KB qualification and bundletool download tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -216,7 +216,8 @@ jobs:
 
       - name: Download bundletool (pinned)
         run: |
-          curl -sL -o bundletool.jar \
+          curl -fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o bundletool.jar \
             "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
           echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
 
@@ -453,7 +454,8 @@ jobs:
 
       - name: Download bundletool (pinned)
         run: |
-          curl -sL -o bundletool.jar \
+          curl -fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o bundletool.jar \
             "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
           echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
 
@@ -558,7 +560,8 @@ jobs:
 
       - name: Download bundletool (pinned)
         run: |
-          curl -sL -o bundletool.jar \
+          curl -fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o bundletool.jar \
             "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
           echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
 
@@ -631,7 +634,8 @@ jobs:
 
       - name: Download bundletool (pinned)
         run: |
-          curl -sL -o bundletool.jar \
+          curl -fSL --retry 5 --retry-all-errors --retry-delay 5 --connect-timeout 30 \
+            -o bundletool.jar \
             "https://github.com/google/bundletool/releases/download/1.17.2/bundletool-all-1.17.2.jar"
           echo "2d4ad908faea64047c1cc9cb747e6aa667c6ab192e09607bd16b67246a8cd6ae  bundletool.jar" | sha256sum -c -
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -577,6 +577,11 @@ jobs:
       - name: Build AAB, debug APK, and instrumentation APK
         run: ./gradlew :example-app:bundleDebug :example-app:assembleDebug :example-app:assembleDebugAndroidTest
 
+      # setup-gradle only stops the daemon in post-job cleanup, so without this an idle -Xmx4g JVM
+      # competes with the memory-sensitive ps16k emulator for host memory.
+      - name: Release build memory before the emulator boots
+        run: ./gradlew --stop
+
       - name: Enable KVM group permissions
         run: |
           echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules

--- a/scripts/run_16kb_native_qualification.sh
+++ b/scripts/run_16kb_native_qualification.sh
@@ -7,6 +7,30 @@ set -euo pipefail
 # lifecycle) runs with the page-size assertion re-checked inside the gate, plus 16 KB zip alignment
 # of the debug APK.
 
+# The emulator runner returns once sys.boot_completed is set, but system services register
+# after that flag. On the slow-booting ps16k image PackageManager can still be unpublished when
+# bundletool queries the device ("cmd: Can't find service: package"), which fails the run at
+# install time. Wait for the services this gate actually depends on before touching the device.
+wait_for_device_ready() {
+    local deadline=$((SECONDS + 300))
+    adb wait-for-device
+    while [ "$SECONDS" -lt "$deadline" ]; do
+        if [ "$(adb shell getprop sys.boot_completed | tr -d '\r')" = "1" ] \
+            && adb shell service check package 2>/dev/null | grep -q "Service package: found" \
+            && adb shell service check activity 2>/dev/null | grep -q "Service activity: found" \
+            && adb shell pm path android 2>&1 | grep -q "^package:" \
+            && adb shell pm list features 2>&1 | grep -q "^feature:"; then
+            echo "Device ready: boot completed, PackageManager and ActivityManager registered."
+            return 0
+        fi
+        sleep 5
+    done
+    echo "Device did not become ready within 300s" >&2
+    adb shell service list >&2 || true
+    return 1
+}
+wait_for_device_ready
+
 page_size="$(adb shell getconf PAGE_SIZE | tr -d '\r')"
 test "$page_size" = "16384"
 


### PR DESCRIPTION
Waits for PackageManager before the 16 KB qualification, retries the bundletool download on transient network errors, and stops the idle Gradle daemon before the memory-sensitive ps16k emulator boots. A hung emulator boot and a mid-test system-server crash remain open.