### PR TITLE
chore: upgrade GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,20 +53,20 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           cache-read-only: true
 
@@ -122,7 +122,7 @@ jobs:
 
       - name: Upload build and test reports
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: source-quality-reports
           retention-days: 7
@@ -143,19 +143,19 @@ jobs:
         api-level: [21, 22]
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -179,7 +179,7 @@ jobs:
 
       - name: Upload legacy lane results
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: legacy-api-${{ matrix.api-level }}-results
           retention-days: 7
@@ -197,19 +197,19 @@ jobs:
     timeout-minutes: 45
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Accept Android SDK licences
         run: yes | "${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager" --licenses
@@ -248,7 +248,7 @@ jobs:
 
       - name: Upload resolver and safety diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aab-resolver-safety-diagnostics
           retention-days: 7
@@ -270,19 +270,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Validate and write trusted credentials
         env:
@@ -317,32 +317,32 @@ jobs:
         run: ./gradlew assembleDebugAndroidTest assembleDebug
 
       - name: Upload symbols.zip
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: native-debug-symbols.zip
           path: example-app/build/outputs/native-debug-symbols/release/native-debug-symbols.zip
           if-no-files-found: ignore
 
       - name: Upload example-app APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: example-app-debug.apk
           path: example-app/build/outputs/apk/debug/example-app-debug.apk
 
       - name: Upload example-app Test APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: example-app-debug-androidTest.apk
           path: example-app/build/outputs/apk/androidTest/debug/example-app-debug-androidTest.apk
 
       - name: Upload backtrace-library AAR
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backtrace-library-debug.aar
           path: backtrace-library/build/outputs/aar/backtrace-library-debug.aar
 
       - name: Upload backtrace-library Test APK
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: backtrace-library-debug-androidTest.apk
           path: backtrace-library/build/outputs/apk/androidTest/debug/backtrace-library-debug-androidTest.apk
@@ -362,22 +362,22 @@ jobs:
           ]
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Download APK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: example-app-debug.apk
 
       - name: Download Test APK
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v5
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.test-apk }}
 
       - name: Install saucectl
-        uses: saucelabs/saucectl-run-action@bc81720eb01738d9c664b07fe42621bd0014283f # v4
+        uses: saucelabs/saucectl-run-action@283660aa934c02723c497efa151d582a3acc5801 # v4.5.0
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
@@ -408,19 +408,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Validate and write trusted credentials
         env:
@@ -485,7 +485,7 @@ jobs:
 
       - name: Upload full qualification diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aab-native-full-diagnostics
           retention-days: 7
@@ -513,19 +513,19 @@ jobs:
     if: needs.policy.outputs.trusted == 'true'
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           submodules: recursive
           persist-credentials: false
 
       - name: set up JDK 21
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5
+        uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: "21"
           distribution: "temurin"
 
       - name: Set up Gradle (caching)
-        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
 
       - name: Validate and write trusted credentials
         env:
@@ -595,7 +595,7 @@ jobs:
 
       - name: Upload 16 KB qualification diagnostics
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: aab-native-16kb-diagnostics
           retention-days: 7
@@ -624,7 +624,7 @@ jobs:
       PR_HEAD_SHA: ${{ github.sha }}
     steps:
       - name: Checkout submodules
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v5
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           submodules: recursive
           persist-credentials: false
@@ -680,7 +680,7 @@ jobs:
 
       - name: Upload hardware gate evidence
         if: always()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: hardware-release-gate-evidence
           retention-days: 30

--- a/.github/workflows/uploadArchives.yml
+++ b/.github/workflows/uploadArchives.yml
@@ -18,7 +18,7 @@ jobs:
 
    steps:
    - name: Checkout submodules
-     uses: actions/checkout@v4
+     uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
      with:
        fetch-depth: 2
        submodules: recursive
@@ -26,7 +26,7 @@ jobs:
        persist-credentials: false
 
    - name: set up JDK 21
-     uses: actions/setup-java@v4
+     uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
      with:
        java-version: 21
        distribution: "temurin"
@@ -54,7 +54,7 @@ jobs:
    - name: Build and upload
      run: ./gradlew build publishAllPublicationsToMavenCentralRepository
 
-   - uses: xresloader/upload-to-github-release@v1
+   - uses: xresloader/upload-to-github-release@7c5757a90c0bcf0c0e1741da8f2abd7b85e675d0 # v1.6.2
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
      with:


### PR DESCRIPTION
Upgrade all actions in `test.yml` and `uploadArchives.yml` to their latest
majors, SHA-pinned with accurate version comments. Clears the Node 20
deprecation and setup-java v4 warnings on GitHub-hosted lanes.

- checkout v4.4.0 -> v7.0.1
- setup-java v4.9.1 -> v6.0.0
- upload-artifact v4.6.2 -> v7.0.1
- download-artifact v4.3.0 -> v8.0.1
- setup-gradle v4.4.3 -> v5.0.2
- saucectl-run-action v4.4.0 -> v4.5.0
- upload-to-github-release `@v1` -> v1.6.2 (now SHA-pinned)